### PR TITLE
Update stable diffusion template in preparation for serverless

### DIFF
--- a/configs/serve-stable-diffusion/aws.yaml
+++ b/configs/serve-stable-diffusion/aws.yaml
@@ -1,6 +1,6 @@
 head_node_type:
   name: head_node_type
-  instance_type: g5.xlarge
+  instance_type: m5.xlarge
 worker_node_types:
 - name: gpu_worker
   instance_type: g5.xlarge

--- a/configs/serve-stable-diffusion/gce.yaml
+++ b/configs/serve-stable-diffusion/gce.yaml
@@ -1,7 +1,7 @@
 # n1-standard-8-nvidia-tesla-t4-1  --> 8 CPUs, 1 GPU
 head_node_type:
   name: head_node_type
-  instance_type: n1-standard-8-nvidia-tesla-t4-1
+  instance_type: n1-standard-8
 worker_node_types:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-tesla-t4-1

--- a/templates/serve-stable-diffusion/README.ipynb
+++ b/templates/serve-stable-diffusion/README.ipynb
@@ -5,18 +5,18 @@
    "metadata": {},
    "source": [
     "## Serving a Stable Diffusion Model with Ray Serve\n",
-    "This template shows you how to:\n",
-    "1. Develop and run a Ray Serve application running a stable diffusion model.\n",
+    "In this notebook, we will:\n",
+    "1. Develop and run a Ray Serve application serving a stable diffusion model.\n",
     "2. Send test requests to the application running locally.\n",
     "3. Deploy the application to production as a service.\n",
-    "4. Send requests to the application running in production as a service."
+    "4. Send requests to the deployed service."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 1: Install python dependencies\n",
+    "### Step 1: Install Python dependencies\n",
     "\n",
     "The application requires a few extra Python dependencies. Install them using `pip` and they'll be saved in the workspace and picked up when deploying to production."
    ]
@@ -117,21 +117,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 5: Send a test request to the model running in the service\n",
+    "### Step 5: Send a request to the service\n",
     "\n",
-    "Query the service using the same logic as when testing it locally, with two changes:\n",
-    "1. Update the `HOST` to the service endpoint.\n",
-    "2. Add the authorization token as a header in the HTTP request.\n",
-    "\n",
-    "Both of these values are printed when you run `serve publish`. You can also find them on the service page. For example, if the output looks like:\n",
-    "```bash\n",
-    "(anyscale +4.0s) You can query the service endpoint using the curl request below:\n",
-    "(anyscale +4.0s) curl -H 'Authorization: Bearer 26hTWi2kZwEz0Tdi1_CKRep4NLXbuuaSTDb3WMXK9DM' https://stable_diffusion_app-4rq8m.cld-ltw6mi8dxaebc3yf.s.anyscaleuserdata-staging.com\n",
-    "```\n",
-    "\n",
-    "Then:\n",
-    "- The authorization token is `26hTWi2kZwEz0Tdi1_CKRep4NLXbuuaSTDb3WMXK9DM`.\n",
-    "- The service endpoint is `https://stable_diffusion_app-4rq8m.cld-ltw6mi8dxaebc3yf.s.anyscaleuserdata-staging.com`."
+    "Retrieve the `HOST` and `TOKEN` corresponding to your deployed service from the output of `serve publish`, and then update the values in the following cell. Then, send a request to the model."
    ]
   },
   {
@@ -179,7 +167,8 @@
    "source": [
     "## Summary\n",
     "\n",
-    "This notebook:\n",
+    "In this notebook, we:\n",
+    "\n",
     "- Developed and ran a model serving application locally.\n",
     "- Sent a test request to the application locally.\n",
     "- Deployed the application to production as a service.\n",

--- a/templates/serve-stable-diffusion/README.ipynb
+++ b/templates/serve-stable-diffusion/README.ipynb
@@ -6,10 +6,10 @@
    "source": [
     "## Serving a Stable Diffusion Model with Ray Serve\n",
     "In this notebook, we will:\n",
-    "1. Develop and run a Ray Serve application serving a stable diffusion model.\n",
+    "1. Develop and run a Ray Serve application running a stable diffusion model.\n",
     "2. Send test requests to the application running locally.\n",
     "3. Deploy the application to production as a service.\n",
-    "4. Send requests to the deployed service."
+    "4. Send requests to the application running in production as a service."
    ]
   },
   {
@@ -117,9 +117,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 5: Send a request to the service\n",
+    "### Step 5: Send a test request to the model running in the service\n",
     "\n",
-    "Retrieve the `HOST` and `TOKEN` corresponding to your deployed service from the output of `serve publish`, and then update the values in the following cell. Then, send a request to the model."
+    "Query the service using the same logic as when testing it locally, with two changes:\n",
+    "1. Update the `HOST` to the service endpoint.\n",
+    "2. Update the `TOKEN` to the service's authorization token.\n",
+    "\n",
+    "Both of these values are printed when you run `serve publish`."
    ]
   },
   {
@@ -130,8 +134,8 @@
    "source": [
     "import requests\n",
     "\n",
-    "HOST = \"TODO_INSERT_YOUR_SERVICE_HOST\"\n",
-    "TOKEN = \"TODO_INSERT_YOUR_SERVICE_TOKEN\"\n",
+    "HOST = \"TODO_INSERT_HOST_HERE\"\n",
+    "TOKEN = \"TODO_INSERT_TOKEN_HERE\"\n",
     "\n",
     "def generate_image(prompt: str, image_size: int) -> bytes:\n",
     "    response: requests.Response = requests.get(\n",


### PR DESCRIPTION
* Change head node type to m5.xlarge so it starts up immediately (we can buffer it)
* Fix a few nits from bug bash
* Removed the example showing how to extract host/token from the stdout because it was a lot of unnecessary text IMO and cluttered the screen (I was looking at three tokens on the screen during the bug bash -- two of which were the example & one was my real token from the stdout).