### PR TITLE
make small improvement to stable diffusion template

### DIFF
--- a/templates/serve-stable-diffusion/README.ipynb
+++ b/templates/serve-stable-diffusion/README.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "source": [
     "### Step 2: Run the model locally\n",
-    "- Run the command below in a VSCode terminal (Ctrl-`).\n",
+    "- Run the command below in a VSCode terminal (Ctrl+`).\n",
     "- The model will be available at http://localhost:8000.\n",
     "- The command will block and print logs for the application.\n",
     "\n",
@@ -43,6 +43,20 @@
     "# Run the following in a VSCode terminal because it's a blocking command.\n",
     "$ serve run main:stable_diffusion_app\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "bat"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Alternatively you can run the following command for non-blocking serve run in the notebook, but you won't be able to see the logs inline\n",
+    "!serve run main:stable_diffusion_app --non-blocking"
    ]
   },
   {
@@ -185,11 +199,6 @@
     "- Deployed the application to production as a service.\n",
     "- Sent another test request to the application running as a service."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Small fix to the stable diffusion template
- keyboard shortcut to bring up VSCode terminal
- introduce the non-blocking `serve run` command (so user can also highlight and copy)
- drop empty cell in the end