### PR TITLE
finetune llm - automatically read cloud id and region

### DIFF
--- a/templates/fine-tune-llm/README.md
+++ b/templates/fine-tune-llm/README.md
@@ -21,9 +21,6 @@ We have provided different example configurations under the `training_configs`
 directory for different base models and instance types. You can use these as a
 starting point for your own fine-tuning jobs.
 
-First, please go to `job_compute_configs/aws.yaml` or `job_compute_configs/gcp.yaml`
-and specify your cloud_id and region under the `cloud_id` and `region` fields.
-
 [Optional] you can get a WandB API key from [WandB](https://wandb.ai/authorize) to track the finetuning process.
 
 Next, you can launch a fine-tuning job where the WandB API key is passed as an environment variable.

--- a/templates/fine-tune-llm/job_compute_configs/aws.yaml
+++ b/templates/fine-tune-llm/job_compute_configs/aws.yaml
@@ -1,8 +1,6 @@
 compute_config:
   allowed_azs:
     - any
-  cloud_id: cld_id # You should specify your `cloud_id` from the `clouds` page
-  region: us-west-2  # You should specify your `region`
   head_node_type:
     instance_type: m5.4xlarge
     name: head_node

--- a/templates/fine-tune-llm/job_compute_configs/gcp.yaml
+++ b/templates/fine-tune-llm/job_compute_configs/gcp.yaml
@@ -1,8 +1,6 @@
 compute_config:
   allowed_azs:
     - any
-  cloud_id: cld_id # You may specify `cloud_id` instead
-  region: us-west1
   head_node_type:
     instance_type: n2-standard-4
     name: head_node

--- a/templates/fine-tune-llm/train.py
+++ b/templates/fine-tune-llm/train.py
@@ -28,7 +28,6 @@ def generate_model_tag(model_id: str) -> str:
     Constructs a finetuned model ID based on the Anyscale endpoints convention.
     """
     username = os.environ.get("ANYSCALE_USERNAME")
-    model_id = model_id.split("/")[-1]
     if username:
         username = username[:5]
     else:

--- a/templates/fine-tune-llm/train.py
+++ b/templates/fine-tune-llm/train.py
@@ -17,7 +17,7 @@ def get_cld_id() -> str:
 
 def get_region() -> str:
     return os.environ.get("ANYSCALE_CLOUD_STORAGE_BUCKET_REGION") or ""
-    
+
 def _get_lora_storage_uri() -> str:
     artifact_storage = os.environ.get("ANYSCALE_ARTIFACT_STORAGE")
     artifact_storage = artifact_storage.rstrip("/")

--- a/templates/fine-tune-llm/train.py
+++ b/templates/fine-tune-llm/train.py
@@ -12,6 +12,12 @@ def _read_yaml_file(file_path):
     with open(file_path, "r") as stream:
         return yaml.safe_load(stream)
 
+def get_cld_id() -> str:
+    return os.environ.get("ANYSCALE_CLOUD_ID") or ""
+
+def get_region() -> str:
+    return os.environ.get("ANYSCALE_CLOUD_STORAGE_BUCKET_REGION") or ""
+    
 
 def _get_lora_storage_uri() -> str:
     artifact_storage = os.environ.get("ANYSCALE_ARTIFACT_STORAGE")
@@ -54,6 +60,11 @@ def main():
 
     job_config = _read_yaml_file(job_config_path)
     training_config = _read_yaml_file(finetune_config_path)
+
+    cld_id = get_cld_id()
+    region = get_region()
+    job_config["compute_config"]["cloud_id"] = cld_id
+    job_config["compute_config"]["region"] = region
 
     is_lora = "lora_config" in training_config
     entrypoint = f"llmforge dev finetune {finetune_config_path}"

--- a/templates/fine-tune-llm/train.py
+++ b/templates/fine-tune-llm/train.py
@@ -18,7 +18,6 @@ def get_cld_id() -> str:
 def get_region() -> str:
     return os.environ.get("ANYSCALE_CLOUD_STORAGE_BUCKET_REGION") or ""
     
-
 def _get_lora_storage_uri() -> str:
     artifact_storage = os.environ.get("ANYSCALE_ARTIFACT_STORAGE")
     artifact_storage = artifact_storage.rstrip("/")


### PR DESCRIPTION
Currently  we ask user to figure out cloud id (not even name). It is not obvious how to get it for most people. Since this is run from a workspace, we can automatically infer these.