### PR TITLE
Switch head node of stable diffusion template to CPU only

### DIFF
--- a/configs/serve-stable-diffusion/aws.yaml
+++ b/configs/serve-stable-diffusion/aws.yaml
@@ -1,10 +1,10 @@
 head_node_type:
   name: head_node_type
-  instance_type: g5.xlarge
+  instance_type: m5.2xlarge
 worker_node_types:
 - name: gpu_worker
   instance_type: g5.xlarge
-  min_workers: 0
-  max_workers: 100
+  min_workers: 1
+  max_workers: 1
   use_spot: false
 auto_select_worker_config: true

--- a/configs/serve-stable-diffusion/gce.yaml
+++ b/configs/serve-stable-diffusion/gce.yaml
@@ -1,11 +1,10 @@
-# n1-standard-8-nvidia-t4-16gb-1  --> 8 CPUs, 1 GPU
 head_node_type:
   name: head_node_type
-  instance_type: n1-standard-8-nvidia-t4-16gb-1
+  instance_type: n1-standard-8
 worker_node_types:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1
-  min_workers: 0
-  max_workers: 100
+  min_workers: 1
+  max_workers: 1
   use_spot: false
 auto_select_worker_config: true


### PR DESCRIPTION
I tested this out manually (including service deploy) and it seems to work well. I specified the worker as min=max=1 so that startup is still fast.