### PR TITLE
Add MistralAI TL=1 LoRA config to APE template

### DIFF
--- a/templates/endpoints/models/mistral/mistralai--Mistral-7B-Instruct-v0.1_a10g_tp1-lora.yaml
+++ b/templates/endpoints/models/mistral/mistralai--Mistral-7B-Instruct-v0.1_a10g_tp1-lora.yaml
@@ -1,0 +1,50 @@
+deployment_config:
+  autoscaling_config:
+    min_replicas: 1
+    initial_replicas: 1
+    max_replicas: 100
+    target_num_ongoing_requests_per_replica: 20
+    metrics_interval_s: 10.0
+    look_back_period_s: 30.0
+    smoothing_factor: 0.6
+    downscale_delay_s: 300.0
+    upscale_delay_s: 15.0
+  max_concurrent_queries: 64
+  ray_actor_options:
+    resources:
+      "accelerator_type:A10G": 0.001
+engine_config:
+  model_id: mistralai/Mistral-7B-Instruct-v0.1
+  hf_model_id: mistralai/Mistral-7B-Instruct-v0.1
+  type: VLLMEngine
+  engine_kwargs:
+    trust_remote_code: true
+    max_num_batched_tokens: 16384
+    max_num_seqs: 64
+    gpu_memory_utilization: 0.95
+    num_tokenizer_actors: 2
+    enable_cuda_graph: true
+    enable_json_logits_processors: true
+    enable_lora: true  # <-- This is required to be used with the LoRA adapter
+    max_lora_rank: 32  # Max rank for the LoRA
+    max_loras: 4
+  max_total_tokens: 16384
+  generation:
+    prompt_format:
+      system: "{instruction} + "
+      assistant: "{instruction}</s> "
+      trailing_assistant: ""
+      user: "[INST] {system}{instruction} [/INST]"
+      system_in_user: true
+      default_system_message: "Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity."
+    stopping_sequences: ["<unk>"]
+scaling_config:
+  num_workers: 1
+  num_gpus_per_worker: 1
+  num_cpus_per_worker: 8
+  placement_strategy: "STRICT_PACK"
+  resources_per_worker:
+    "accelerator_type:A10G": 0.001
+standalone_function_calling_model: true
+multiplex_config:  # <-- This is required to be able to serve multiple LoRA adapters in the same replica
+  max_num_models_per_replica: 24


### PR DESCRIPTION
Forward fixes that https://github.com/anyscale/templates/pull/124 was missing the yaml.
I manually verified the fix by running the template with the yaml included in this PR and querying the model