### PR TITLE
Fix all prompt formats

### DIFF
--- a/templates/endpoints/CustomModels.md
+++ b/templates/endpoints/CustomModels.md
@@ -118,8 +118,8 @@ stopping_sequences: []
 ```
 prompt_format:
   system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-  assistant: " {instruction} </s><s> "
-  trailing_assistant: " "
+  assistant: " {instruction} </s><s>"
+  trailing_assistant: ""
   user: "[INST] {system}{instruction} [/INST]"
   system_in_user: true
   default_system_message: "Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity."

--- a/templates/endpoints/models/llama/codellama--CodeLlama-34b-Instruct-hf_a100-40g_tp4.yaml
+++ b/templates/endpoints/models/llama/codellama--CodeLlama-34b-Instruct-hf_a100-40g_tp4.yaml
@@ -29,8 +29,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints/models/llama/meta-llama--Llama-2-13b-chat-hf_a100-40g_tp2.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Llama-2-13b-chat-hf_a100-40g_tp2.yaml
@@ -28,8 +28,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-40g_tp8.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-40g_tp8.yaml
@@ -28,8 +28,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-80g_tp8.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-80g_tp8.yaml
@@ -28,8 +28,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints/models/llama/meta-llama--Llama-2-7b-chat-hf_a10g_tp1.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Llama-2-7b-chat-hf_a10g_tp1.yaml
@@ -29,8 +29,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints/models/llama/meta-llama--Llama-2-7b-chat-hf_l4-lora.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Llama-2-7b-chat-hf_l4-lora.yaml
@@ -31,8 +31,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints/models/llama/meta-llama--Llama-2-7b-chat-hf_l4_tp1.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Llama-2-7b-chat-hf_l4_tp1.yaml
@@ -29,8 +29,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/codellama--CodeLlama-34b-Instruct-hf_a100-40g_tp4.yaml
+++ b/templates/endpoints_v2/models/llama/codellama--CodeLlama-34b-Instruct-hf_a100-40g_tp4.yaml
@@ -29,8 +29,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/meta-llama--Llama-2-13b-chat-hf_a100-40g_tp2.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Llama-2-13b-chat-hf_a100-40g_tp2.yaml
@@ -28,8 +28,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-40g_tp8.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-40g_tp8.yaml
@@ -28,8 +28,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-80g_tp8.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Llama-2-70b-chat-hf_a100-80g_tp8.yaml
@@ -28,8 +28,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/meta-llama--Llama-2-7b-chat-hf_a10g_tp1.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Llama-2-7b-chat-hf_a10g_tp1.yaml
@@ -29,8 +29,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/meta-llama--Llama-2-7b-chat-hf_l4-lora.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Llama-2-7b-chat-hf_l4-lora.yaml
@@ -31,8 +31,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""

--- a/templates/endpoints_v2/models/llama/meta-llama--Llama-2-7b-chat-hf_l4_tp1.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Llama-2-7b-chat-hf_l4_tp1.yaml
@@ -29,8 +29,8 @@ engine_config:
   generation:
     prompt_format:
       system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s> "
-      trailing_assistant: " "
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
       user: "[INST] {system}{instruction} [/INST]"
       system_in_user: true
       default_system_message: ""


### PR DESCRIPTION
As discussed [here](https://anyscaleteam.slack.com/archives/C05N9KFPUR3/p1710374812717179), all llama 2 endpoints templates prompt formats are off. The ground truth can be found in RayLLM. In RayLLM, we test for "prompt format consistency with the following format:
```
llama2_prompt_format = PromptFormat(
    system="<<SYS>>\n{instruction}\n<</SYS>>\n\n",
    assistant=" {instruction} </s><s>",
    trailing_assistant="",
    user="[INST] {system}{instruction} [/INST]",
    default_system_message="",
    system_in_user=True,
)
```
https://github.com/anyscale/ray-llm/blob/9fb9f710dd717429c54968d1c23d2f7b60e7d8f9/tests/test_aviary/common/test_prompt_format_consistency.py#L4
This format is also aligned with llm-forge.

Only the endpoints templates are different.

CC @mjconnor @akshay-anyscale 