### PR TITLE
[FT-Template] Fixed wandb api key insertion

### DIFF
--- a/templates/fine-tune-llm/README.md
+++ b/templates/fine-tune-llm/README.md
@@ -27,10 +27,10 @@ Next, you can launch a fine-tuning job where the WandB API key is passed as an e
 
 ```shell
 # Launch a full-param fine-tuning job for Llama 7b with 16 g5.4xlarge instances
-WANDB_API_KEY={YOUR_WANDB_API_KEY} python train.py job_compute_configs/aws.yaml training_configs/full_param/llama-2-7b-512-16xg5_4xlarge.yaml
+WANDB_API_KEY={YOUR_WANDB_API_KEY} python main.py job_compute_configs/aws.yaml training_configs/full_param/llama-2-7b-512-16xg5_4xlarge.yaml
 
 # Launch a LoRA fine-tuning job for Llama 7b with 16 g5.4xlarge instances
-WANDB_API_KEY={YOUR_WANDB_API_KEY} python train.py job_compute_configs/aws.yaml training_configs/lora/llama-2-7b-512-16xg5_4xlarge.yaml
+WANDB_API_KEY={YOUR_WANDB_API_KEY} python main.py job_compute_configs/aws.yaml training_configs/lora/llama-2-7b-512-16xg5_4xlarge.yaml
 ```
 
 Once you submit the command, in the terminal you will see the link to your finetuning job. Ex:

--- a/templates/fine-tune-llm/main.py
+++ b/templates/fine-tune-llm/main.py
@@ -90,6 +90,7 @@ def main():
         job_config.setdefault("runtime_env", {}).setdefault("env_vars", {})[
             "WANDB_API_KEY"
         ] = api_key
+        job_config["runtime_env"]["env_vars"]["RAY_OVERRIDE_JOB_RUNTIME_ENV"] = "1"
 
     with tempfile.NamedTemporaryFile(
         mode="w+", delete=False, dir=".", suffix=".yaml"


### PR DESCRIPTION
- Fixed wandb api key insertion
- Basically llmforge auto adds the runtime env `WANDB_API_KEY` but if it's specified in `runtime_env`, it would be a conflict. So adding `RAY_OVERRIDE_JOB_RUNTIME_ENV ` as an override to make this workflow both work as a ray job (OA) and anyscale job (Platform)
- Customer issue: https://anyscaleteam.slack.com/archives/C0683S5GBJ7/p1710517651515999
- repro'ed example job: https://console.anyscale-staging.com/o/anyscale-internal/jobs/prodjob_d8wyn4f25fe5blrmpft27xlsnr