### PR TITLE
Update `text-embeddings` template

### DIFF
--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!"
+    "!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!'"
    ]
   },
   {

--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -25,7 +25,42 @@
    "metadata": {},
    "source": [
     "## Step 1: Setup model defaults\n",
-    "First, let's import the dependencies we will use in this template."
+    "\n",
+    "First, install additional required dependencies using `pip`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import utilities used during embeddings computation later (Step 4). This cell copies\n",
+    "# the implementation into a local file located at `util/embedding_util.py`, which\n",
+    "# you can choose to customize for your own use case.\n",
+    "import inspect\n",
+    "import shutil\n",
+    "import ray.anyscale.data.embedding_util\n",
+    "\n",
+    "module_file_path = inspect.getfile(ray.anyscale.data.embedding_util)\n",
+    "out_path = shutil.copy(module_file_path, 'util/embedding_util.py')\n",
+    "print(f\"File copied to {out_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's import the dependencies we will use in this template."
    ]
   },
   {
@@ -206,7 +241,7 @@
     "## Step 4: Compute Embeddings\n",
     "\n",
     "We define the `ComputeEmbeddings` class to compute embeddings using a pre-trained Hugging Face model. The full implementation\n",
-    "is in `util/utils.py`.\n",
+    "is in `util/embedding_util.py`, which you can choose to customize for your use case.\n",
     "\n",
     "Next, apply batch inference for all input data with the Ray Data [`map_batches`](https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html) method. Here, you can easily configure Ray Data to scale the number of model instances."
    ]
@@ -217,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from util.utils import ComputeEmbeddings\n",
+    "from util.embedding_util import ComputeEmbeddings\n",
     "\n",
     "embedded_ds = chunked_ds.map_batches(\n",
     "    ComputeEmbeddings,\n",
@@ -373,6 +408,27 @@
    "source": [
     "ds_output = ray.data.read_parquet(OUTPUT_PATH)\n",
     "ds_output.take(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Submitting to Anyscale Jobs\n",
+    "\n",
+    "The script in `main.py` has the same code as this notebook; you can use `ray job submit` to submit the app in that file to Anyscale Jobs. Refer to [Introduction to Jobs](https://docs.endpoints.anyscale.com/preview/examples/intro-jobs/) for more details.\n",
+    "\n",
+    "\n",
+    "Run the following cell to submit a job:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ray job submit -- python main.py"
    ]
   },
   {

--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!'"
+    "!pip install -q langchain && echo 'Install complete!'"
    ]
   },
   {

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -14,7 +14,29 @@ For a Python script version of the `.ipynb` notebook used for the workspace temp
 **Note:** This tutorial is run within a workspace. Please overview the `Introduction to Workspaces` template first before this tutorial.
 
 ## Step 1: Setup model defaults
-First, let's import the dependencies we will use in this template.
+
+First, install additional required dependencies using `pip`.
+
+
+```python
+!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!
+```
+
+
+```python
+# Import utilities used during embeddings computation later (Step 4). This cell copies
+# the implementation into a local file located at `util/embedding_util.py`, which
+# you can choose to customize for your own use case.
+import inspect
+import shutil
+import ray.anyscale.data.embedding_util
+
+module_file_path = inspect.getfile(ray.anyscale.data.embedding_util)
+out_path = shutil.copy(module_file_path, 'util/embedding_util.py')
+print(f"File copied to {out_path}")
+```
+
+Let's import the dependencies we will use in this template.
 
 
 ```python
@@ -142,13 +164,13 @@ chunked_ds = ds.flat_map(
 ## Step 4: Compute Embeddings
 
 We define the `ComputeEmbeddings` class to compute embeddings using a pre-trained Hugging Face model. The full implementation
-is in `util/utils.py`.
+is in `util/embedding_util.py`, which you can choose to customize for your use case.
 
 Next, apply batch inference for all input data with the Ray Data [`map_batches`](https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html) method. Here, you can easily configure Ray Data to scale the number of model instances.
 
 
 ```python
-from util.utils import ComputeEmbeddings
+from util.embedding_util import ComputeEmbeddings
 
 embedded_ds = chunked_ds.map_batches(
     ComputeEmbeddings,
@@ -245,6 +267,18 @@ We can also use Ray Data to read back the output files to ensure the results are
 ```python
 ds_output = ray.data.read_parquet(OUTPUT_PATH)
 ds_output.take(5)
+```
+
+### Submitting to Anyscale Jobs
+
+The script in `main.py` has the same code as this notebook; you can use `ray job submit` to submit the app in that file to Anyscale Jobs. Refer to [Introduction to Jobs](https://docs.endpoints.anyscale.com/preview/examples/intro-jobs/) for more details.
+
+
+Run the following cell to submit a job:
+
+
+```python
+!ray job submit -- python main.py
 ```
 
 ## Summary

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -19,7 +19,7 @@ First, install additional required dependencies using `pip`.
 
 
 ```python
-!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!'
+!pip install -q langchain && echo 'Install complete!'
 ```
 
 

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -19,7 +19,7 @@ First, install additional required dependencies using `pip`.
 
 
 ```python
-!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!
+!pip install -q optimum[onnxruntime-gpu] langchain && echo 'Install complete!'
 ```
 
 

--- a/templates/text-embeddings/main.py
+++ b/templates/text-embeddings/main.py
@@ -1,0 +1,106 @@
+import os
+import ray
+import uuid
+import numpy as np
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+import torch
+from transformers import AutoTokenizer, AutoModel
+import torch.nn.functional as F
+from optimum.bettertransformer import BetterTransformer
+
+from util.utils import generate_output_path
+from util.embedding_util import ComputeEmbeddings
+
+# Step 1: Setup model defaults
+HF_MODEL_NAME = "thenlper/gte-large"
+# Some Hugging Face models require a token for access; if you choose one of these models, replace the following with your token.
+HF_TOKEN = "<REPLACE_WITH_YOUR_HUGGING_FACE_USER_TOKEN>"
+
+NUM_MODEL_INSTANCES = 4
+# The name of Dataset column with the input text.
+TEXT_COLUMN_NAME = "text"
+OUTPUT_PATH = generate_output_path(os.environ.get("ANYSCALE_ARTIFACT_STORAGE"), HF_MODEL_NAME)
+
+if ray.is_initialized():
+    ray.shutdown()
+ray.init(
+    runtime_env={
+        "env_vars": {
+            "HF_TOKEN": HF_TOKEN,
+
+            # Suppress noisy logging from external libraries
+            "TOKENIZERS_PARALLELISM": "false",
+            "COMET_API_KEY": "",
+        },
+    }
+)
+
+# Step 2: Read data files
+ds = ray.data.read_text("s3://anonymous@air-example-data/wikipedia-text-embeddings-100.txt")
+
+# Step 3: Preprocess (Chunk) Input Text
+CHUNK_SIZE = 512
+words_to_tokens = 1.2
+num_tokens = int(CHUNK_SIZE // words_to_tokens)
+num_words = lambda x: len(x.split())
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=num_tokens,
+    keep_separator=True,
+    length_function=num_words,
+    chunk_overlap=0,
+)
+
+
+def chunk_row(row):
+    """Main chunking logic."""
+    if not isinstance(row[TEXT_COLUMN_NAME], str):
+        print(
+            "Found row with missing input text, "
+            f"skipping embeddings computation for this row: {row}"
+        )
+        return []
+
+    length = num_words(row[TEXT_COLUMN_NAME]) * 1.2
+    if length < 20 or length > 4000:
+        return []
+    chunks = splitter.split_text(row[TEXT_COLUMN_NAME])
+
+    new_rows = [
+        {
+            "id": str(uuid.uuid4()),
+            **row,
+            TEXT_COLUMN_NAME: chunk,
+        } for chunk in chunks
+        # Only keep rows with valid input text
+        if isinstance(chunk, str)
+    ]
+    return new_rows
+
+
+chunked_ds = ds.flat_map(chunk_row)
+
+embedded_ds = chunked_ds.map_batches(
+    ComputeEmbeddings,
+    # Total number of GPUs to use.
+    concurrency=NUM_MODEL_INSTANCES,
+    # Size of batches passed to embeddings actor. Set the batch size to as large possible
+    # without running out of memory. If you encounter CUDA out-of-memory errors, decreasing
+    # batch_size may help.
+    batch_size=25,
+    fn_constructor_kwargs={
+        "text_column_name": TEXT_COLUMN_NAME,
+        "model_name": HF_MODEL_NAME,
+        "device": "cuda",
+        "chunk_size": CHUNK_SIZE,
+    },
+    # 1 GPU for each actor.
+    num_gpus=1,
+    # Reduce GPU idle time.
+    max_concurrency=2,
+)
+
+# Write results to cloud storage
+embedded_ds.write_parquet(OUTPUT_PATH)
+
+print(f"Computed embeddings are written into {OUTPUT_PATH}.")

--- a/templates/text-embeddings/util/utils.py
+++ b/templates/text-embeddings/util/utils.py
@@ -1,0 +1,16 @@
+import os
+import random
+import string
+
+
+def generate_output_path(output_path_prefix: str, model_id: str) -> str:
+    """
+    Constructs unique output path to write data out.
+    """
+    username = os.environ.get("ANYSCALE_USERNAME")
+    if username:
+        username = username[:5]
+    else:
+        username = "".join(random.choice(string.ascii_lowercase) for _ in range(5))
+    suffix = "".join(random.choice(string.ascii_lowercase) for _ in range(5))
+    return f"{output_path_prefix}/{model_id}:{username}:{suffix}"


### PR DESCRIPTION
- Instead of including the embeddings computation logic in the docker image, we instead copy the logic from `runtime` (https://github.com/anyscale/runtime/pull/507) into a local file used in the workspace. This way, the user can easily customize the logic for their own use case.
- Add section for Jobs, linking to the Intro to Jobs page.

Tested on [OA workspace](https://console.anyscale-staging.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/workspaces/expwrk_uw29mztdz8z5az79vmqitcraft/ses_9v1fkddrtlauygzndkreuues31?workspace-tab=vscode)