### PR TITLE
Switch to using `flags` for specifying multi-zone

### DIFF
--- a/configs/endpoints_v2/aws.yaml
+++ b/configs/endpoints_v2/aws.yaml
@@ -15,12 +15,5 @@ worker_node_types:
   min_workers: 0
   max_workers: 1
 
-# TODO(shomil): Remove once set by default in OA.
-aws:
-  TagSpecifications:
-    - ResourceType: instance
-      Tags:
-        - Key: as-feature-enable-multi-az-serve
-          Value: "true"
-        - Key: as-feature-multi-zone
-          Value: "true"
+flags:
+  allow-cross-zone-autoscaling: true

--- a/configs/endpoints_v2/gcp.yaml
+++ b/configs/endpoints_v2/gcp.yaml
@@ -16,9 +16,5 @@ worker_node_types:
   max_workers: 1
   use_spot: false
 
-# TODO(shomil): Remove once set by default in OA.
-gcp_advanced_configurations_json:
-  instance_properties:
-    labels:
-      as-feature-multi-zone: 'true'
-      as-feature-enable-multi-az-serve: 'true'
+flags:
+  allow-cross-zone-autoscaling: true


### PR DESCRIPTION
* This is the only API that is compatible across existing backend + existing/new SDK.
* When new backend supports using `enable-cross-zone-scaling`, we will switch to that.