### PR TITLE
[OA] Fix unsupported markdown in endpoint docs

### DIFF
--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -13,7 +13,7 @@
     "2. Chunk the raw input text using Ray Data and LangChain.\n",
     "3. Compute embeddings using a pre-trained HuggingFace model, and write the results to cloud storage.\n",
     "\n",
-    "![Overview of Text Embeddings Pipeline](assets/diagram.jpg \"Overview of Text Embeddings Pipeline\")\n",
+    "![Overview of Text Embeddings Pipeline](assets/diagram.jpg)\n",
     "\n",
     "For a Python script version of the `.ipynb` notebook used for the workspace template, refer to `main.py`.\n",
     "\n",


### PR DESCRIPTION
- This syntax was causing failures here https://github.com/anyscale/endpoint-docs/actions/runs/8545480588/job/23413876496?pr=133