### PR TITLE
Adding in name to prevent Job job-job-... name

### DIFF
--- a/templates/intro-jobs/README.ipynb
+++ b/templates/intro-jobs/README.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "# Second, submit the Ray app for execution on a new Ray cluster.\n",
     "# The execution will be managed by Anyscale Jobs.\n",
-    "!ray job submit --wait -- python main.py\n",
+    "!ray job submit --name my-job --wait -- python main.py\n",
     "\n",
     "# Tip: You can run any Ray app as a job by prefixing its entrypoint with \"ray job submit --\"."
    ]


### PR DESCRIPTION
When we submit jobs without an explicit name the prefix `job-` is prepended to the name of the workspace. In this case, the name of the Intro to Jobs workspace already starts with the `job-` prefix, so we submit a job with the name `job-job-...`. This PR changes the template to submit a job with the name `my-job` preventing the email from saying "Anyscale Job job-job-...".

Before:
![image](https://github.com/anyscale/templates/assets/22609193/18a4026e-bf62-4c71-975c-0ff87190ebdd)

After:
<img width="919" alt="image" src="https://github.com/anyscale/templates/assets/22609193/bbf0d4ba-3c61-4a5a-a0de-4f04f2289706">
