### PR TITLE
Update `text-embeddings` template

### DIFF
--- a/templates/intro-jobs/README.md
+++ b/templates/intro-jobs/README.md
@@ -48,7 +48,7 @@ The following cell should also run to completion within a few minutes and print 
 ```python
 # Second, submit the Ray app for execution on a new Ray cluster.
 # The execution will be managed by Anyscale Jobs.
-!ray job submit --wait -- python main.py
+!ray job submit --name my-job --wait -- python main.py
 
 # Tip: You can run any Ray app as a job by prefixing its entrypoint with "ray job submit --".
 ```

--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -102,11 +102,19 @@
    "outputs": [],
    "source": [
     "HF_MODEL_NAME = \"thenlper/gte-large\"\n",
-    "# Optional: The models listed above do not require a Hugging Face token. \n",
+    "# Optional: The models listed above do not require a Hugging Face token, \n",
+    "# so there is no need to set this variable in that case.\n",
     "# If your model requires a token for access, replace the following with your user token.\n",
     "OPTIONAL_HF_TOKEN_FOR_MODEL = \"<OPTIONAL_HUGGING_FACE_USER_TOKEN>\"\n",
     "NUM_MODEL_INSTANCES = 4\n",
     "OUTPUT_PATH = generate_output_path(os.environ.get(\"ANYSCALE_ARTIFACT_STORAGE\"), HF_MODEL_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Start up Ray, using the Hugging Face token as an environment variable so that it's made available to all nodes in the cluster."
    ]
   },
   {

--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q langchain && echo 'Install complete!'"
+    "!pip install -q langchain==0.1.16 && echo 'Install complete!'"
    ]
   },
   {
@@ -52,8 +52,11 @@
     "import ray.anyscale.data.embedding_util\n",
     "\n",
     "module_file_path = inspect.getfile(ray.anyscale.data.embedding_util)\n",
-    "out_path = shutil.copy(module_file_path, 'util/embedding_util.py')\n",
-    "print(f\"File copied to {out_path}\")"
+    "copy_dest_path = 'util/embedding_util.py'\n",
+    "if not os.path.isfile(copy_dest_path):\n",
+    "    # Only copy the file if it doesn't exist, so we don't overwrite any existing changes.\n",
+    "    out_path = shutil.copy(module_file_path, copy_dest_path)\n",
+    "    print(f\"File copied to {out_path}\")"
    ]
   },
   {
@@ -99,8 +102,9 @@
    "outputs": [],
    "source": [
     "HF_MODEL_NAME = \"thenlper/gte-large\"\n",
-    "# Some Hugging Face models require a token for access; if you choose one of these models, replace the following with your token.\n",
-    "HF_TOKEN = \"<REPLACE_WITH_YOUR_HUGGING_FACE_USER_TOKEN>\"\n",
+    "# Optional: The models listed above do not require a Hugging Face token. \n",
+    "# If your model requires a token for access, replace the following with your user token.\n",
+    "OPTIONAL_HF_TOKEN_FOR_MODEL = \"<OPTIONAL_HUGGING_FACE_USER_TOKEN>\"\n",
     "NUM_MODEL_INSTANCES = 4\n",
     "OUTPUT_PATH = generate_output_path(os.environ.get(\"ANYSCALE_ARTIFACT_STORAGE\"), HF_MODEL_NAME)"
    ]
@@ -116,7 +120,8 @@
     "ray.init(\n",
     "    runtime_env={\n",
     "        \"env_vars\": {\n",
-    "            \"HF_TOKEN\": HF_TOKEN,\n",
+    "            # Set the user token on all nodes.\n",
+    "            \"HF_TOKEN\": OPTIONAL_HF_TOKEN_FOR_MODEL,\n",
     "\n",
     "            # Suppress noisy logging from external libraries\n",
     "            \"TOKENIZERS_PARALLELISM\": \"false\",\n",
@@ -218,7 +223,7 @@
    "source": [
     "We use Ray Data's `flat_map()` method to apply the chunking function we defined above to each row of the input dataset. We use `flat_map()` as opposed to `map()` because the `chunk_row()` function may return more than one output row for each input row.\n",
     "\n",
-    "*Note*: Because Ray Datasets are executed in a streaming fashion, running the cell below will not trigger execution because the dataset is not being consumed yet."
+    "*Note*: Because Ray Datasets are executed in a lazy and streaming fashion, running the cell below will not trigger execution because the dataset is not being consumed yet. See the [Ray Data docs](https://docs.ray.io/en/latest/data/data-internals.html#streaming-execution]) for more details."
    ]
   },
   {
@@ -368,7 +373,7 @@
    "metadata": {},
    "source": [
     "### Handling GPU out-of-memory failures\n",
-    "If you run into CUDA out of memory, your batch size is likely too large. Decrease the batch size as described above.\n",
+    "If you run into a `CUDA out of memory` error, your batch size is likely too large. Decrease the batch size as described above.\n",
     "\n",
     "If your batch size is already set to 1, then use either a smaller model or GPU devices with more memory.\n",
     "\n",

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -64,12 +64,15 @@ Set up default values that will be used in the embeddings computation workflow:
 
 ```python
 HF_MODEL_NAME = "thenlper/gte-large"
-# Optional: The models listed above do not require a Hugging Face token. 
+# Optional: The models listed above do not require a Hugging Face token, 
+# so there is no need to set this variable in that case.
 # If your model requires a token for access, replace the following with your user token.
 OPTIONAL_HF_TOKEN_FOR_MODEL = "<OPTIONAL_HUGGING_FACE_USER_TOKEN>"
 NUM_MODEL_INSTANCES = 4
 OUTPUT_PATH = generate_output_path(os.environ.get("ANYSCALE_ARTIFACT_STORAGE"), HF_MODEL_NAME)
 ```
+
+Start up Ray, using the Hugging Face token as an environment variable so that it's made available to all nodes in the cluster.
 
 
 ```python

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -19,7 +19,7 @@ First, install additional required dependencies using `pip`.
 
 
 ```python
-!pip install -q langchain && echo 'Install complete!'
+!pip install -q langchain==0.1.16 && echo 'Install complete!'
 ```
 
 
@@ -32,8 +32,11 @@ import shutil
 import ray.anyscale.data.embedding_util
 
 module_file_path = inspect.getfile(ray.anyscale.data.embedding_util)
-out_path = shutil.copy(module_file_path, 'util/embedding_util.py')
-print(f"File copied to {out_path}")
+copy_dest_path = 'util/embedding_util.py'
+if not os.path.isfile(copy_dest_path):
+    # Only copy the file if it doesn't exist, so we don't overwrite any existing changes.
+    out_path = shutil.copy(module_file_path, copy_dest_path)
+    print(f"File copied to {out_path}")
 ```
 
 Let's import the dependencies we will use in this template.
@@ -61,8 +64,9 @@ Set up default values that will be used in the embeddings computation workflow:
 
 ```python
 HF_MODEL_NAME = "thenlper/gte-large"
-# Some Hugging Face models require a token for access; if you choose one of these models, replace the following with your token.
-HF_TOKEN = "<REPLACE_WITH_YOUR_HUGGING_FACE_USER_TOKEN>"
+# Optional: The models listed above do not require a Hugging Face token. 
+# If your model requires a token for access, replace the following with your user token.
+OPTIONAL_HF_TOKEN_FOR_MODEL = "<OPTIONAL_HUGGING_FACE_USER_TOKEN>"
 NUM_MODEL_INSTANCES = 4
 OUTPUT_PATH = generate_output_path(os.environ.get("ANYSCALE_ARTIFACT_STORAGE"), HF_MODEL_NAME)
 ```
@@ -74,7 +78,8 @@ if ray.is_initialized():
 ray.init(
     runtime_env={
         "env_vars": {
-            "HF_TOKEN": HF_TOKEN,
+            # Set the user token on all nodes.
+            "HF_TOKEN": OPTIONAL_HF_TOKEN_FOR_MODEL,
 
             # Suppress noisy logging from external libraries
             "TOKENIZERS_PARALLELISM": "false",
@@ -150,7 +155,7 @@ def chunk_row(row, text_column_name):
 
 We use Ray Data's `flat_map()` method to apply the chunking function we defined above to each row of the input dataset. We use `flat_map()` as opposed to `map()` because the `chunk_row()` function may return more than one output row for each input row.
 
-*Note*: Because Ray Datasets are executed in a streaming fashion, running the cell below will not trigger execution because the dataset is not being consumed yet.
+*Note*: Because Ray Datasets are executed in a lazy and streaming fashion, running the cell below will not trigger execution because the dataset is not being consumed yet. See the [Ray Data docs](https://docs.ray.io/en/latest/data/data-internals.html#streaming-execution]) for more details.
 
 
 ```python
@@ -246,7 +251,7 @@ embedded_ds = chunked_ds.map_batches(
 ```
 
 ### Handling GPU out-of-memory failures
-If you run into CUDA out of memory, your batch size is likely too large. Decrease the batch size as described above.
+If you run into a `CUDA out of memory` error, your batch size is likely too large. Decrease the batch size as described above.
 
 If your batch size is already set to 1, then use either a smaller model or GPU devices with more memory.
 


### PR DESCRIPTION
Address comments/fixes from dogfooding the template, including:
- Pinning `langchain` version
- Clarifying optional HuggingFace token
- Only copying the `embedding_util.py` file if it doesn't already exist
- Various formatting

Tested on [workspace](https://console.anyscale-staging.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/workspaces/expwrk_tj3wmwz3jeve26rkn3vn45x2q7/ses_7q5npr7aaxpiez9m52gtwj2huk?workspace-tab=vscode)