### PR TITLE
Revert `batch-llm` template default model back to Mistral

### DIFF
--- a/templates/batch-llm/README.ipynb
+++ b/templates/batch-llm/README.ipynb
@@ -85,7 +85,7 @@
    "source": [
     "# Set to the name of the Hugging Face model that you wish to use from the preceding list.\n",
     "# Note that using the Llama models will prompt you to set your Hugging Face user token.\n",
-    "HF_MODEL = \"meta-llama/Llama-2-7b-chat-hf\"\n",
+    "HF_MODEL = \"mistralai/Mistral-7B-Instruct-v0.1\"\n",
     "\n",
     "# Create a sampling params object.\n",
     "sampling_params = SamplingParams(temperature=0, max_tokens=2048)\n",

--- a/templates/batch-llm/README.md
+++ b/templates/batch-llm/README.md
@@ -58,7 +58,7 @@ Set up values that will be used in the batch inference workflow:
 ```python
 # Set to the name of the Hugging Face model that you wish to use from the preceding list.
 # Note that using the Llama models will prompt you to set your Hugging Face user token.
-HF_MODEL = "meta-llama/Llama-2-7b-chat-hf"
+HF_MODEL = "mistralai/Mistral-7B-Instruct-v0.1"
 
 # Create a sampling params object.
 sampling_params = SamplingParams(temperature=0, max_tokens=2048)


### PR DESCRIPTION
Made an error merging before commiting the model revert, this PR changes the default model back to Mistral.