### PR TITLE
Update Hugging Face token fetching in `batch-llm` template

### DIFF
--- a/templates/batch-llm/README.ipynb
+++ b/templates/batch-llm/README.ipynb
@@ -50,7 +50,11 @@
     "import ray\n",
     "from vllm import LLM, SamplingParams\n",
     "\n",
-    "from util.utils import generate_output_path, get_a10g_or_equivalent_accelerator_type"
+    "from util.utils import (\n",
+    "    generate_output_path,\n",
+    "    get_a10g_or_equivalent_accelerator_type,\n",
+    "    prompt_for_hugging_face_token,\n",
+    ")"
    ]
   },
   {
@@ -101,28 +105,8 @@
     "    HF_MODEL,\n",
     ")\n",
     "\n",
-    "# If your chosen model requires a user token for authentication, set the following\n",
-    "# variable to `True` to trigger authentication.\n",
-    "REQUIRE_HF_TOKEN = False\n",
-    "\n",
-    "hf_token_cache_path = \"/home/ray/.cache/huggingface/token\"\n",
-    "try:\n",
-    "    # Try loading model config to check if Hugging Face token is required.\n",
-    "    from transformers import AutoConfig\n",
-    "    model = AutoConfig.from_pretrained(HF_MODEL)\n",
-    "except OSError:\n",
-    "    # Model requires HF token to access. Get the token, either from\n",
-    "    # cached token or from user input.\n",
-    "    if not os.path.isfile(hf_token_cache_path):\n",
-    "        print(\"No cached Hugging Face token found. Starting authentication\")\n",
-    "        import huggingface_hub\n",
-    "        # Starts authentication through VSCode overlay. \n",
-    "        # Token saved to `hf_token_cache_path`\n",
-    "        huggingface_hub.interpreter_login()\n",
-    "    \n",
-    "    with open(hf_token_cache_path, \"r\") as file:\n",
-    "        os.environ[\"HF_TOKEN\"] = file.read()\n",
-    "        print(\"Successfully read Hugging Face token from file.\")"
+    "# Prompts the user for Hugging Face token if required by the model.\n",
+    "HF_TOKEN = prompt_for_hugging_face_token(HF_MODEL)"
    ]
   },
   {
@@ -142,7 +126,7 @@
     "    ray.shutdown()\n",
     "ray.init(\n",
     "    runtime_env={\n",
-    "        \"env_vars\": {\"HF_TOKEN\": os.environ.get(\"HF_TOKEN\", \"\")},\n",
+    "        \"env_vars\": {\"HF_TOKEN\": HF_TOKEN},\n",
     "    }\n",
     ")"
    ]

--- a/templates/batch-llm/main.py
+++ b/templates/batch-llm/main.py
@@ -4,17 +4,11 @@ import numpy as np
 import ray
 import os
 
-from util.utils import generate_output_path, get_a10g_or_equivalent_accelerator_type
+from util.utils import generate_output_path, get_a10g_or_equivalent_accelerator_type, read_hugging_face_token_from_cache
 
-# Replace the following string with your Hugging Face token if it is
-# not already set as an environment variable from the README.ipynb notebook.
-HF_TOKEN = os.environ.get("HF_TOKEN", "<REPLACE_WITH_YOUR_HF_TOKEN>")
 
 # Set to the model that you wish to use. Note that using the llama models will require a hugging face token to be set.
 HF_MODEL = "mistralai/Mistral-7B-Instruct-v0.1"
-
-if not HF_TOKEN and "llama" in HF_MODEL.lower():
-    raise ValueError("Please specify environment variable `HF_TOKEN` as Hugging Face token to access Llama models in Hugging Face.")
 
 # Input path to read input data.
 # Read one text file from S3. Ray Data supports reading multiple files
@@ -26,6 +20,9 @@ INPUT_TEXT_COLUMN = "text"
 
 # Output path to write output result.
 output_path = generate_output_path(os.environ.get("ANYSCALE_ARTIFACT_STORAGE"), HF_MODEL)
+
+# Read the Hugging Face token from cached file.
+HF_TOKEN = read_hugging_face_token_from_cache()
 
 # Initialize Ray with a Runtime Environment.
 ray.init(

--- a/templates/batch-llm/util/utils.py
+++ b/templates/batch-llm/util/utils.py
@@ -3,6 +3,11 @@ import random
 import requests
 import string
 
+import huggingface_hub
+from transformers import AutoConfig
+
+HF_TOKEN_CACHE_PATH = "/home/ray/.cache/huggingface/token"
+
 
 def generate_output_path(output_path_prefix: str, model_id: str) -> str:
     """
@@ -36,3 +41,35 @@ def get_a10g_or_equivalent_accelerator_type() -> str:
     instead.
     """
     return "L4" if _on_gcp_cloud() else "A10G"
+
+
+def prompt_for_hugging_face_token(hf_model: str) -> str:
+    """Prompts the user for Hugging Face token if required by the model.
+    Returns the token as a string. If a token is not required by the model,
+    returns an empty string."""
+
+    try:
+        # Try loading model config to check if Hugging Face token is required.
+        AutoConfig.from_pretrained(hf_model)
+        # If config is loaded successfully, no need for token.
+        return ""
+    except OSError:
+        # Model requires HF token to access. Get the token, either from
+        # cached token or from user input.
+        if not os.path.isfile(HF_TOKEN_CACHE_PATH):
+            print("No cached Hugging Face token found. Starting authentication")
+            # Starts authentication through VSCode overlay.
+            # Token saved to `HF_TOKEN_CACHE_PATH`
+            huggingface_hub.interpreter_login()
+
+        return read_hugging_face_token_from_cache()
+
+
+def read_hugging_face_token_from_cache() -> str:
+    try:
+        with open(HF_TOKEN_CACHE_PATH, "r") as file:
+            return file.read()
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"Could not find Hugging Face token cached at {HF_TOKEN_CACHE_PATH}."
+        )


### PR DESCRIPTION
Refactor the Hugging Face token fetching mechanism used in `batch-llm` template so that the common utility function can also be used in the Python script used for job submission.

Tested on [workspace](https://console.anyscale-staging.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/workspaces/expwrk_ad2uga9wmqi393sjkguu11nnh7/ses_ww5pylrj6fqsfimlfn48g4mtwq?workspace-tab=vscode)