### PR TITLE
[GCE] [Head Nodes] Switch from n1-standard-8 to n2-standard-8

### DIFF
--- a/configs/basic-serverless-config/gce.yaml
+++ b/configs/basic-serverless-config/gce.yaml
@@ -1,5 +1,5 @@
 head_node_type:
   name: head
-  instance_type: n1-standard-8
+  instance_type: n2-standard-8
 worker_node_types: []
 auto_select_worker_config: true

--- a/configs/serve-stable-diffusion/gce.yaml
+++ b/configs/serve-stable-diffusion/gce.yaml
@@ -1,6 +1,6 @@
 head_node_type:
   name: head
-  instance_type: n1-standard-8
+  instance_type: n2-standard-8
 worker_node_types:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1


### PR DESCRIPTION
* The n2-standard machines are `$0.508121` vs `$0.428` for n1-standard, but they are more widely available across different GCP regions & zones, since they are a newer processor type.