### PR TITLE
Adding in try_create_dir=False to unblock OA release

### DIFF
--- a/templates/batch-llm/README.ipynb
+++ b/templates/batch-llm/README.ipynb
@@ -383,7 +383,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.write_parquet(output_path)\n",
+    "ds.write_parquet(output_path, try_create_dir=False)\n",
     "print(f\"Batch inference result is written into {output_path}.\")"
    ]
   },

--- a/templates/batch-llm/README.md
+++ b/templates/batch-llm/README.md
@@ -266,7 +266,7 @@ Running the following cell will trigger execution for the full Dataset, which wi
 
 
 ```python
-ds.write_parquet(output_path)
+ds.write_parquet(output_path, try_create_dir=False)
 print(f"Batch inference result is written into {output_path}.")
 ```
 

--- a/templates/batch-llm/main.py
+++ b/templates/batch-llm/main.py
@@ -128,7 +128,7 @@ ds = ds.map_batches(
 # Write inference output data out as Parquet files to S3.
 # Multiple files would be written to the output destination,
 # and each task would write one or more files separately.
-ds.write_parquet(output_path)
+ds.write_parquet(output_path, try_create_dir=False)
 
 print(f"Batch inference result is written into {output_path}.")
 

--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -403,7 +403,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedded_ds.write_parquet(OUTPUT_PATH)"
+    "embedded_ds.write_parquet(OUTPUT_PATH, try_create_dir=False)"
    ]
   },
   {

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -266,7 +266,7 @@ Finally, write the computed embeddings out to Parquet files on S3. Running the f
 
 
 ```python
-embedded_ds.write_parquet(OUTPUT_PATH)
+embedded_ds.write_parquet(OUTPUT_PATH, try_create_dir=False)
 ```
 
 We can also use Ray Data to read back the output files to ensure the results are as expected.

--- a/templates/text-embeddings/main.py
+++ b/templates/text-embeddings/main.py
@@ -101,6 +101,6 @@ embedded_ds = chunked_ds.map_batches(
 )
 
 # Write results to cloud storage
-embedded_ds.write_parquet(OUTPUT_PATH)
+embedded_ds.write_parquet(OUTPUT_PATH, try_create_dir=False)
 
 print(f"Computed embeddings are written into {OUTPUT_PATH}.")


### PR DESCRIPTION
Due to how the Anyscale Artifact Storage IAM policy is configured and how the PyArrow s3fs tries to create directories we were getting errors from these templates when we tried to write to the Anyscale Artifact Storage. More context on that issue [in slack here](https://anyscaleteam.slack.com/archives/C0695Q8TZSN/p1713828788038729). 

We plan to fix the behavior on the Ray Data side to by default not try to create directories for s3 as this call is not necessary, but for now this patch in the templates will resolve the issue while we wait for the next Ray release (will happen after the OA release).