### PR TITLE
Refine Hugging Face token auth in `batch-llm` template

### DIFF
--- a/templates/batch-llm/README.ipynb
+++ b/templates/batch-llm/README.ipynb
@@ -494,7 +494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.11.0 (main, Oct 25 2022, 14:13:24) [Clang 14.0.0 (clang-1400.0.29.202)]"
   },
   "vscode": {
    "interpreter": {

--- a/templates/batch-llm/README.ipynb
+++ b/templates/batch-llm/README.ipynb
@@ -77,9 +77,7 @@
     "        * [`meta-llama/Llama-2-70b-chat-hf`](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)\n",
     "        * [`codellama/CodeLlama-70b-Instruct-hf`](https://huggingface.co/codellama/CodeLlama-70b-Instruct-hf)\n",
     "* The [sampling parameters object](https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py) used by vLLM.\n",
-    "* The output path where results will be written as parquet files.\n",
-    "\n",
-    "*Note*: Some models will require you to input your [Hugging Face user access token](https://huggingface.co/docs/hub/en/security-tokens). This will be used to authenticate/download the model and **is required for official LLaMA, Mistral, and Gemma models**. You can use one of the other models which don't require a token if you don't have access to this model (for example, `mlabonne/NeuralHermes-2.5-Mistral-7B`)."
+    "* The output path where results will be written as parquet files."
    ]
   },
   {
@@ -103,8 +101,24 @@
     "    # See: https://docs.anyscale.com/workspaces/storage#object-storage-s3-or-gcs-buckets\n",
     "    os.environ.get(\"ANYSCALE_ARTIFACT_STORAGE\"),\n",
     "    HF_MODEL,\n",
-    ")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some models will require you to input your [Hugging Face user access token](https://huggingface.co/docs/hub/en/security-tokens). This will be used to authenticate/download the model and **is required for official LLaMA, Mistral, and Gemma models**. You can use one of the other models which don't require a token if you don't have access to this model (for example, `mlabonne/NeuralHermes-2.5-Mistral-7B`).\n",
     "\n",
+    "Run the following cell to start the authentication flow. A VS Code overlay will appear and prompt you to enter your Hugging Face token if your selected model requires authentication. The token will be cached to a file in the workspace so it can be used to launch an Anyscale Job later without needing to re-authenticate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Prompts the user for Hugging Face token if required by the model.\n",
     "HF_TOKEN = prompt_for_hugging_face_token(HF_MODEL)"
    ]
@@ -404,9 +418,7 @@
     "### Handling GPU out-of-memory failures\n",
     "If you run into CUDA out of memory, your batch size is likely too large. Decrease the batch size as described above.\n",
     "\n",
-    "If your batch size is already set to 1, then use either a smaller model or GPU devices with more memory.\n",
-    "\n",
-    "For advanced users working with large models, you can use model parallelism to shard the model across multiple GPUs."
+    "If your batch size is already set to 1, then use either a smaller model or GPU devices with more memory."
    ]
   },
   {
@@ -482,7 +494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0 (main, Oct 25 2022, 14:13:24) [Clang 14.0.0 (clang-1400.0.29.202)]"
+   "version": "3.9.19"
   },
   "vscode": {
    "interpreter": {

--- a/templates/batch-llm/README.md
+++ b/templates/batch-llm/README.md
@@ -57,8 +57,6 @@ Set up values that will be used in the batch inference workflow:
 * The [sampling parameters object](https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py) used by vLLM.
 * The output path where results will be written as parquet files.
 
-*Note*: Some models will require you to input your [Hugging Face user access token](https://huggingface.co/docs/hub/en/security-tokens). This will be used to authenticate/download the model and **is required for official LLaMA, Mistral, and Gemma models**. You can use one of the other models which don't require a token if you don't have access to this model (for example, `mlabonne/NeuralHermes-2.5-Mistral-7B`).
-
 
 ```python
 # Set to the name of the Hugging Face model that you wish to use from the preceding list.
@@ -77,7 +75,14 @@ output_path = generate_output_path(
     os.environ.get("ANYSCALE_ARTIFACT_STORAGE"),
     HF_MODEL,
 )
+```
 
+Some models will require you to input your [Hugging Face user access token](https://huggingface.co/docs/hub/en/security-tokens). This will be used to authenticate/download the model and **is required for official LLaMA, Mistral, and Gemma models**. You can use one of the other models which don't require a token if you don't have access to this model (for example, `mlabonne/NeuralHermes-2.5-Mistral-7B`).
+
+Run the following cell to start the authentication flow. A VS Code overlay will appear and prompt you to enter your Hugging Face token if your selected model requires authentication. The token will be cached to a file in the workspace so it can be used to launch an Anyscale Job later without needing to re-authenticate.
+
+
+```python
 # Prompts the user for Hugging Face token if required by the model.
 HF_TOKEN = prompt_for_hugging_face_token(HF_MODEL)
 ```
@@ -279,8 +284,6 @@ We can use the Ray Dashboard to monitor the Dataset execution. In the Ray Dashbo
 If you run into CUDA out of memory, your batch size is likely too large. Decrease the batch size as described above.
 
 If your batch size is already set to 1, then use either a smaller model or GPU devices with more memory.
-
-For advanced users working with large models, you can use model parallelism to shard the model across multiple GPUs.
 
 ### Reading back results
 We can also use Ray Data to read back the output files to ensure the results are as expected.

--- a/templates/batch-llm/main.py
+++ b/templates/batch-llm/main.py
@@ -4,7 +4,12 @@ import numpy as np
 import ray
 import os
 
-from util.utils import generate_output_path, get_a10g_or_equivalent_accelerator_type, read_hugging_face_token_from_cache
+from util.utils import (
+    HF_TOKEN_LOCAL_PATH,
+    generate_output_path,
+    get_a10g_or_equivalent_accelerator_type,
+    read_hugging_face_token_from_cache,
+)
 
 
 # Set to the model that you wish to use. Note that using the llama models will require a hugging face token to be set.
@@ -22,7 +27,7 @@ INPUT_TEXT_COLUMN = "text"
 output_path = generate_output_path(os.environ.get("ANYSCALE_ARTIFACT_STORAGE"), HF_MODEL)
 
 # Read the Hugging Face token from cached file.
-HF_TOKEN = read_hugging_face_token_from_cache()
+HF_TOKEN = read_hugging_face_token_from_cache(HF_TOKEN_LOCAL_PATH)
 
 # Initialize Ray with a Runtime Environment.
 ray.init(


### PR DESCRIPTION
This PR refines the logic in `batch-llm` workspace template for authenticatin Hugging Face token from user input. 
- Instead of relying on environment variable read from the file cached by Hugging Face, we copy the token to a local file in the working directory of the workspace template, which can be read by the job we launch later.
- Also replace the model config loading with a simpler HTTP request to their model registry, which serves as a check to see if the model requires a token.
- Move the token authentication to its own cell to denote importance

Also remove text related to tensor parallelism, since it is confusing for most non-advanced users without documentation (we currently don't have good documentation around this)