### PR TITLE
s/serve deploy/anyscale service deploy

### DIFF
--- a/templates/intro-services/README.ipynb
+++ b/templates/intro-services/README.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!serve deploy main:my_app --name=my_service"
+    "!anyscale service deploy main:my_app --name=my_service"
    ]
   },
   {
@@ -131,10 +131,10 @@
     "2. Add the authorization token as a header in the HTTP request.\n",
     "\n",
     "Find the `HOST` and authorization token values in:\n",
-    "- The output of `serve deploy`\n",
+    "- The output of `anyscale service deploy`\n",
     "- On the service page by clicking on the **Query**\n",
     "\n",
-    "For example, look for the following in the `serve deploy` output: \n",
+    "For example, look for the following in the `anyscale service deploy` output: \n",
     "\n",
     "```bash\n",
     "(anyscale +4.0s) You can query the service endpoint using the curl request below:\n",
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!serve deploy main:my_app --name=my_service"
+    "!anyscale service deploy main:my_app --name=my_service"
    ]
   },
   {

--- a/templates/intro-services/README.md
+++ b/templates/intro-services/README.md
@@ -65,7 +65,7 @@ Use the following command to deploy your app as `my_service`.
 
 
 ```python
-!serve deploy main:my_app --name=my_service
+!anyscale service deploy --name=my_service main:my_app
 ```
 
 ### Service Overview page in the console
@@ -83,10 +83,10 @@ Once the service is running, query the service from the public internet using si
 2. Add the authorization token as a header in the HTTP request.
 
 Find the `HOST` and authorization token values in:
-- The output of `serve deploy`
+- The output of `anyscale service deploy`
 - On the service page by clicking on the **Query**
 
-For example, look for the following in the `serve deploy` output: 
+For example, look for the following in the `anyscale service deploy` output: 
 
 ```bash
 (anyscale +4.0s) You can query the service endpoint using the curl request below:
@@ -157,7 +157,7 @@ On the production service, deploy the update, making sure to include the `--name
 
 
 ```python
-!serve deploy main:my_app --name=my_service
+!anyscale service deploy main:my_app --name=my_service
 ```
 
 Monitor the status of the rollout in the service Overview page. Once the new cluster with the updated app config is running, Ray Serve shuts down the previous cluster:

--- a/templates/serve-stable-diffusion/README.ipynb
+++ b/templates/serve-stable-diffusion/README.ipynb
@@ -100,7 +100,7 @@
    "source": [
     "## Step 4: Deploy the model to production as a service\n",
     "\n",
-    "Deploy the model to production using the `serve deploy` command.\n",
+    "Deploy the model to production using the `anyscale service deploy` command.\n",
     "\n",
     "This creates a long-running [service](https://docs.anyscale.com/services/get-started) with a stable endpoint to query the application.\n",
     "\n",
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!serve deploy --name stable_diffusion_service main:stable_diffusion_app"
+    "!anyscale service deploy --name stable_diffusion_service main:stable_diffusion_app"
    ]
   },
   {
@@ -126,7 +126,7 @@
     "1. Update the `HOST` to the service endpoint.\n",
     "2. Add the authorization token as a header in the HTTP request.\n",
     "\n",
-    "Both of these values are printed when you run `serve deploy`. You can also find them on the service page. For example, if the output looks like:\n",
+    "Both of these values are printed when you run `anyscale service deploy`. You can also find them on the service page. For example, if the output looks like:\n",
     "```bash\n",
     "(anyscale +4.0s) You can query the service endpoint using the curl request below:\n",
     "(anyscale +4.0s) curl -H 'Authorization: Bearer 26hTWi2kZwEz0Tdi1_CKRep4NLXbuuaSTDb3WMXK9DM' https://stable_diffusion_app-4rq8m.cld-ltw6mi8dxaebc3yf.s.anyscaleuserdata-staging.com\n",

--- a/templates/serve-stable-diffusion/README.md
+++ b/templates/serve-stable-diffusion/README.md
@@ -62,7 +62,7 @@ Image(filename=filename)
 
 ## Step 4: Deploy the model to production as a service
 
-Deploy the model to production using the `serve deploy` command.
+Deploy the model to production using the `anyscale service deploy` command.
 
 This creates a long-running [service](https://docs.anyscale.com/services/get-started) with a stable endpoint to query the application.
 
@@ -70,7 +70,7 @@ Local files and dependencies installed in the workspace are automatically includ
 
 
 ```python
-!serve deploy --name stable_diffusion_service main:stable_diffusion_app
+!anyscale service deploy --name stable_diffusion_service main:stable_diffusion_app
 ```
 
 ## Step 5: Send a test request to the model running in the service
@@ -79,7 +79,7 @@ Query the service using the same logic as when testing it locally, with two chan
 1. Update the `HOST` to the service endpoint.
 2. Add the authorization token as a header in the HTTP request.
 
-Both of these values are printed when you run `serve deploy`. You can also find them on the service page. For example, if the output looks like:
+Both of these values are printed when you run `anyscale service deploy`. You can also find them on the service page. For example, if the output looks like:
 ```bash
 (anyscale +4.0s) You can query the service endpoint using the curl request below:
 (anyscale +4.0s) curl -H 'Authorization: Bearer 26hTWi2kZwEz0Tdi1_CKRep4NLXbuuaSTDb3WMXK9DM' https://stable_diffusion_app-4rq8m.cld-ltw6mi8dxaebc3yf.s.anyscaleuserdata-staging.com


### PR DESCRIPTION
Moving to use the un-aliased `anyscale service deploy` because:

- Documentation/discovery is clearer (https://docs.endpoints.anyscale.com/preview/reference/service-api/)
- Matches other commands like `anyscale service status`
- Also works from outside of workspaces (where `serve deploy` won't because it's an alias)