### PR TITLE
[parallel-experiments] use s3fs for s3 storage

### DIFF
--- a/templates/intro-tune/README.ipynb
+++ b/templates/intro-tune/README.ipynb
@@ -137,7 +137,7 @@
     "    criterion = nn.CrossEntropyLoss()\n",
     "    optimizer = optim.SGD(net.parameters(), lr=config[\"lr\"], momentum=0.9)\n",
     "\n",
-    "    trainset, _ = load_data()\n",
+    "    trainset, _ = load_data(\"/mnt/local_storage/cifar_data\")\n",
     "\n",
     "    test_abs = int(len(trainset) * 0.8)\n",
     "    train_subset, val_subset = random_split(\n",

--- a/templates/intro-tune/README.ipynb
+++ b/templates/intro-tune/README.ipynb
@@ -221,12 +221,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from filesystem_utils import get_path_and_fs\n",
     "from ray import tune, train\n",
     "import os\n",
     "\n",
     "# Define where results are stored. We'll use the Anyscale artifact storage path to\n",
     "# save results to cloud storage.\n",
     "STORAGE_PATH = os.environ[\"ANYSCALE_ARTIFACT_STORAGE\"] + \"/tune_results\"\n",
+    "storage_path, fs = get_path_and_fs(STORAGE_PATH)\n",
     "\n",
     "# Define trial sweep parameters across l1, l2, and lr.\n",
     "trial_space = {\n",
@@ -244,7 +246,7 @@
     "tuner = tune.Tuner(\n",
     "    train_cifar,\n",
     "    param_space=trial_space,\n",
-    "    run_config=train.RunConfig(storage_path=STORAGE_PATH),\n",
+    "    run_config=train.RunConfig(storage_path=storage_path, storage_filesystem=fs),\n",
     ")\n",
     "results = tuner.fit()\n",
     "print(results)"

--- a/templates/intro-tune/filesystem_utils.py
+++ b/templates/intro-tune/filesystem_utils.py
@@ -1,0 +1,22 @@
+from s3fs import S3FileSystem
+import pyarrow.fs
+from typing import Optional, Tuple
+
+
+def get_path_and_fs(storage_path: str) -> Tuple[str, Optional[pyarrow.fs.FileSystem]]:
+    """Get the final storage path and corresponding filesystem, if applicable.
+
+    For S3, this will use s3fs.
+    For others, this will use the default filesystem(None).
+    """
+    s3_prefix = "s3://"
+
+    if storage_path.startswith(s3_prefix):
+        s3fs_storage_path = storage_path[len(s3_prefix) :]
+
+        s3fs_fs = S3FileSystem()
+        pyarrow_fs = pyarrow.fs.PyFileSystem(pyarrow.fs.FSSpecHandler(s3fs_fs))
+
+        return s3fs_storage_path, pyarrow_fs
+
+    return storage_path, None


### PR DESCRIPTION
Use `s3fs` instead of the default `pyarrow` `S3FileSystem`.

`ANYSCALE_ARTIFACT_STORAGE` uses a shared bucket.  The `pyarrow` implementation makes (unneeded) requests that require permissions that are (intentionally) not given.

A long term fix will be to remove these calls from the `pyarrow` imeplementation.