### PR TITLE
Fix Llama 3 prompt format used in example deployment configs

### DIFF
--- a/templates/endpoints/models/llama/meta-llama--Meta-Llama-3-70B_a100-40g_tp8.yaml
+++ b/templates/endpoints/models/llama/meta-llama--Meta-Llama-3-70B_a100-40g_tp8.yaml
@@ -27,13 +27,14 @@ engine_config:
   max_total_tokens: 4096
   generation:
     prompt_format:
-      system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s>"
-      trailing_assistant: ""
-      user: "[INST] {system}{instruction} [/INST]"
-      system_in_user: true
+      system: "<|start_header_id|>system<|end_header_id|>\n\n{instruction}<|eot_id|>"
+      assistant: "<|start_header_id|>assistant<|end_header_id|>\n\n{instruction}<|eot_id|>"
+      trailing_assistant: "<|start_header_id|>assistant<|end_header_id|>\n\n"
+      user: "<|start_header_id|>user<|end_header_id|>\n\n{instruction}<|eot_id|>"
+      system_in_user: false
+      bos: "<|begin_of_text|>"
       default_system_message: ""
-    stopping_sequences: ["<unk>"]
+    stopping_sequences: ["<|end_of_text|>", "<|eot_id|>"]
 scaling_config:
   num_workers: 8
   num_gpus_per_worker: 1

--- a/templates/endpoints_v2/models/llama/meta-llama--Meta-Llama-3-70B_a100-40g_tp8.yaml
+++ b/templates/endpoints_v2/models/llama/meta-llama--Meta-Llama-3-70B_a100-40g_tp8.yaml
@@ -27,13 +27,14 @@ engine_config:
   max_total_tokens: 4096
   generation:
     prompt_format:
-      system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
-      assistant: " {instruction} </s><s>"
-      trailing_assistant: ""
-      user: "[INST] {system}{instruction} [/INST]"
-      system_in_user: true
+      system: "<|start_header_id|>system<|end_header_id|>\n\n{instruction}<|eot_id|>"
+      assistant: "<|start_header_id|>assistant<|end_header_id|>\n\n{instruction}<|eot_id|>"
+      trailing_assistant: "<|start_header_id|>assistant<|end_header_id|>\n\n"
+      user: "<|start_header_id|>user<|end_header_id|>\n\n{instruction}<|eot_id|>"
+      system_in_user: false
+      bos: "<|begin_of_text|>"
       default_system_message: ""
-    stopping_sequences: ["<unk>"]
+    stopping_sequences: ["<|end_of_text|>", "<|eot_id|>"]
 scaling_config:
   num_workers: 8
   num_gpus_per_worker: 1


### PR DESCRIPTION
# What does this PR do?

Llama 3 prompt format used in the example configs is incorrect. This is a tiny PR to fix the prompt format following the [official guide](https://github.com/meta-llama/llama-recipes)