### PR TITLE
Fix pip dependency and resize image in `text-embeddings` template

### DIFF
--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q langchain==0.1.16 && echo 'Install complete!'"
+    "!pip install -q langchain==0.1.17 && echo 'Install complete!'"
    ]
   },
   {
@@ -352,7 +352,7 @@
     "\n",
     "If you do not need to select a particular instance type, you can omit this parameter and select \"Auto-select worker nodes\" under the compute configuration to have Ray select the best worker nodes from the available types:\n",
     "\n",
-    "![title](assets/ray-data-gpu.png)"
+    "<center><img src=\"assets/ray-data-gpu.png\" width=\"400\"></center>"
    ]
   },
   {

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -19,7 +19,7 @@ First, install additional required dependencies using `pip`.
 
 
 ```python
-!pip install -q langchain==0.1.16 && echo 'Install complete!'
+!pip install -q langchain==0.1.17 && echo 'Install complete!'
 ```
 
 
@@ -234,7 +234,7 @@ You can also specify which accelerator type (for example, if your model requires
 
 If you do not need to select a particular instance type, you can omit this parameter and select "Auto-select worker nodes" under the compute configuration to have Ray select the best worker nodes from the available types:
 
-<img src="https://raw.githubusercontent.com/anyscale/templates/main/templates/text-embeddings/assets/ray-data-gpu.png"/>
+<center><img src="https://raw.githubusercontent.com/anyscale/templates/main/templates/text-embeddings/assets/ray-data-gpu.png" width="400"></center>
 
 
 ```python


### PR DESCRIPTION
- Upgrade `langchain` to remove a pip dependency warning
- Resize image in notebook

Video walkthrough of template:
https://github.com/anyscale/templates/assets/5122851/b19f7293-a094-47bd-8a72-9a56b1807b23

