### PR TITLE
Remove HTML <center> to comply with mdx

### DIFF
--- a/templates/text-embeddings/README.ipynb
+++ b/templates/text-embeddings/README.ipynb
@@ -352,7 +352,7 @@
     "\n",
     "If you do not need to select a particular instance type, you can omit this parameter and select \"Auto-select worker nodes\" under the compute configuration to have Ray select the best worker nodes from the available types:\n",
     "\n",
-    "<center><img src=\"assets/ray-data-gpu.png\" width=\"400\"></center>"
+    "<img src=\"assets/ray-data-gpu.png\" width=\"400\">"
    ]
   },
   {

--- a/templates/text-embeddings/README.md
+++ b/templates/text-embeddings/README.md
@@ -234,7 +234,7 @@ You can also specify which accelerator type (for example, if your model requires
 
 If you do not need to select a particular instance type, you can omit this parameter and select "Auto-select worker nodes" under the compute configuration to have Ray select the best worker nodes from the available types:
 
-<center><img src="https://raw.githubusercontent.com/anyscale/templates/main/templates/text-embeddings/assets/ray-data-gpu.png" width="400"></center>
+<img src="https://raw.githubusercontent.com/anyscale/templates/main/templates/text-embeddings/assets/ray-data-gpu.png" width="400">
 
 
 ```python


### PR DESCRIPTION
Having the <center> tags makes the file break MDX file compatibility on the conversion from ipynb to mdx, which breaks the docs. Removing it for now, and if we need a more aesthetic screenshot, then we can follow-up in a separate PR.