### PR TITLE
Revert "Add Docs team to CODEOWNERS for templates/"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Configs
 /configs @shomilj @yifeif @ericl
-/templates @emmy


### PR DESCRIPTION
Reverts anyscale/templates#226

Going to postpone being a blocker until we have more cycles. We are at capacity with finishing up the docs migration. We will do this again later, and with the correct handle. 