### PR TITLE
Fix `wandb` API key export in finetuning template

### DIFF
--- a/templates/fine-tune-llm_v2/README.ipynb
+++ b/templates/fine-tune-llm_v2/README.ipynb
@@ -47,7 +47,8 @@
    "outputs": [],
    "source": [
     "# [Optional] You can set the WandB API key to track model performance\n",
-    "# !export WANDB_API_KEY={YOUR_WANDB_API_KEY}\n",
+    "# import os\n",
+    "# os.environ[\"WANDB_API_KEY\"]=\"YOUR_WANDB_API_KEY\"\n",
     "\n",
     "# Launch a LoRA fine-tuning job for Llama 3 8B with 16 A10s\n",
     "!python main.py training_configs/lora/llama-3-8b.yaml\n",

--- a/templates/fine-tune-llm_v2/README.md
+++ b/templates/fine-tune-llm_v2/README.md
@@ -26,7 +26,8 @@ Next, you can launch a fine-tuning job with your WandB API key passed as an envi
 
 ```python
 # [Optional] You can set the WandB API key to track model performance
-# !export WANDB_API_KEY={YOUR_WANDB_API_KEY}
+# import os
+# os.environ["WANDB_API_KEY"]="YOUR_WANDB_API_KEY"
 
 # Launch a LoRA fine-tuning job for Llama 3 8B with 16 A10s
 !python main.py training_configs/lora/llama-3-8b.yaml

--- a/templates/fine-tune-llm_v2/cookbooks/lora_vs_full_parameter/README.md
+++ b/templates/fine-tune-llm_v2/cookbooks/lora_vs_full_parameter/README.md
@@ -28,7 +28,8 @@ You can look at the respective yaml files to see how they differ in their config
 
 ```python
 # [Optional] You can set the WandB API key to track model performance
-# !export WANDB_API_KEY={YOUR_WANDB_API_KEY}
+# import os
+# os.environ["WANDB_API_KEY"]="YOUR_WANDB_API_KEY"
 
 # Run this command from the base directory of this template
 # Fine-tune Llama 3 8B with LoRA


### PR DESCRIPTION
# What does this PR do?

This is a tiny PR to fix `wandb` key export in the finetuning template. Currently, we exported the key through an iPython shell command `!export WANDB_API_KEY=xxx` . This, however, does not actually accomplish what we want, because training is launched with a separate shell command `!python main.py ...` . Each shell command gets executed in a different subshell, which means `WANDB_API_KEY` does not transfer over to the training script env. This PR fixes the issue by exporting env var through `os`.
 