### PR TITLE
Update batch sizes for llama 3 8B to counter pytorch allocator cache flushes

### DIFF
--- a/templates/fine-tune-llm_v2/training_configs/full_param/llama-3-8b.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/full_param/llama-3-8b.yaml
@@ -4,8 +4,8 @@ valid_path: s3://air-example-data/gsm8k/test.jsonl # <-- change this to the path
 context_length: 512 # <-- change this to the context length you want to use
 num_devices: 16 # <-- change this to total number of GPUs that you want to use
 num_epochs: 3 # <-- change this to the number of epochs that you want to train for
-train_batch_size_per_device: 8
-eval_batch_size_per_device: 16
+train_batch_size_per_device: 4
+eval_batch_size_per_device: 4
 learning_rate: 5e-6
 padding: "longest" # This will pad batches to the longest sequence. Use "max_length" when profiling to profile the worst case.
 num_checkpoints_to_keep: 1

--- a/templates/fine-tune-llm_v2/training_configs/lora/llama-3-8b.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/lora/llama-3-8b.yaml
@@ -4,8 +4,8 @@ valid_path: s3://air-example-data/gsm8k/test.jsonl # <-- change this to the path
 context_length: 512 # <-- change this to the context length you want to use
 num_devices: 16 # <-- change this to total number of GPUs that you want to use
 num_epochs: 3 # <-- change this to the number of epochs that you want to train for
-train_batch_size_per_device: 16
-eval_batch_size_per_device: 16
+train_batch_size_per_device: 8
+eval_batch_size_per_device: 8
 learning_rate: 1e-4
 padding: "longest" # This will pad batches to the longest sequence. Use "max_length" when profiling to profile the worst case.
 num_checkpoints_to_keep: 1


### PR DESCRIPTION
While releasing the 0.5.0.0 llm-forge image, we realized that we can some "_pytorch allocator cache flushes_" warnings.
According to pytorch, these slow down training and should be eliminated.
In some instances, they have also led to GPU OOMs.

Process behind this PR:
I launched every possible configuration (lora and full-parameter).
If the warning occured at the beginning, I'd let the training continue for a couple of iterations to see if we stabilize and the warning goes away. If it goes away, I didn't take action (in accordance with the pytorch warning message).
If the warning would occur from time to time, I'd reduce batch size.

I went through this process for all models and configurations to dogfood the template and see if this problem occurs elsewhere. The problem only occured for llama 3 8b (lora and full-param).