### PR TITLE
[Triton] drop gpu header dependency

### DIFF
--- a/configs/triton_services/aws.yaml
+++ b/configs/triton_services/aws.yaml
@@ -3,16 +3,5 @@ head_node_type:
   instance_type: m5.2xlarge
   resources:
     cpu: 0
-# TODO: revert this
-#worker_node_types: []
-#auto_select_worker_config: true
-worker_node_types:
-  - name: worker-node
-    instance_type: g5.4xlarge
-    resources:
-      custom_resources:
-        "accelerator_type:T4": 1
-      cpu: 64
-      gpu: 8
-    min_workers: 1
-    max_workers: 1
+worker_node_types: []
+auto_select_worker_config: true

--- a/configs/triton_services/aws.yaml
+++ b/configs/triton_services/aws.yaml
@@ -8,6 +8,11 @@ head_node_type:
 #auto_select_worker_config: true
 worker_node_types:
   - name: worker-node
-    instance_type: g4dn.16xlarge
+    instance_type: g5.4xlarge
+    resources:
+      custom_resources:
+        "accelerator_type:T4": 1
+      cpu: 64
+      gpu: 8
     min_workers: 1
     max_workers: 1

--- a/configs/triton_services/aws.yaml
+++ b/configs/triton_services/aws.yaml
@@ -1,7 +1,0 @@
-head_node_type:
-  name: head-node
-  instance_type: m5.2xlarge
-  resources:
-    cpu: 0
-worker_node_types: []
-auto_select_worker_config: true

--- a/configs/triton_services/aws.yaml
+++ b/configs/triton_services/aws.yaml
@@ -1,6 +1,7 @@
-head_node:
+head_node_type:
+  name: head-node
   instance_type: m5.2xlarge
   resources:
     cpu: 0
-worker_nodes: []
+worker_node_types: []
 auto_select_worker_config: true

--- a/configs/triton_services/aws.yaml
+++ b/configs/triton_services/aws.yaml
@@ -1,5 +1,5 @@
 head_node:
-  instance_type: g5.4xlarge
+  instance_type: m5.2xlarge
   resources:
     cpu: 0
 worker_nodes: []

--- a/configs/triton_services/aws.yaml
+++ b/configs/triton_services/aws.yaml
@@ -3,5 +3,11 @@ head_node_type:
   instance_type: m5.2xlarge
   resources:
     cpu: 0
-worker_node_types: []
-auto_select_worker_config: true
+# TODO: revert this
+#worker_node_types: []
+#auto_select_worker_config: true
+worker_node_types:
+  - name: worker-node
+    instance_type: g4dn.16xlarge
+    min_workers: 1
+    max_workers: 1

--- a/configs/triton_services/gce.yaml
+++ b/configs/triton_services/gce.yaml
@@ -1,7 +1,0 @@
-head_node_type:
-  name: head-node
-  instance_type: n2-standard-8
-  resources:
-    cpu: 0
-worker_node_types: []
-auto_select_worker_config: true

--- a/configs/triton_services/gce.yaml
+++ b/configs/triton_services/gce.yaml
@@ -1,5 +1,5 @@
 head_node:
-  instance_type: n1-standard-16-nvidia-t4-16gb-1
+  instance_type: n2-standard-8
   resources:
     cpu: 0
 worker_nodes: []

--- a/configs/triton_services/gce.yaml
+++ b/configs/triton_services/gce.yaml
@@ -1,6 +1,7 @@
-head_node:
+head_node_type:
+  name: head-node
   instance_type: n2-standard-8
   resources:
     cpu: 0
-worker_nodes: []
+worker_node_types: []
 auto_select_worker_config: true

--- a/templates/triton_services/README.md
+++ b/templates/triton_services/README.md
@@ -140,6 +140,13 @@ provides an environment variable `ANYSCALE_ARTIFACT_STORAGE` for customers to st
 model artifacts. To learn more about the storage, see
 [Object Storage (S3 or GCS buckets)](https://docs.anyscale.com/1.0.0/services/storage/#object-storage-s3-or-gcs-buckets).
 
+After the model is compiled and uploaded, you should kill the actor to free the
+resources. Run the following code to kill the actor.
+
+```python
+ray.kill(actor)
+```
+
 ## Run Triton Server on Ray Serve locally in Anyscale Workspaces
 
 The `triton_app.py` in this workspace demonstrates how to use a remote model repository

--- a/templates/triton_services/README.md
+++ b/templates/triton_services/README.md
@@ -68,7 +68,7 @@ MODEL_REPOSITORY = [LOCAL_MODEL_PATH]
 S3_PREFIX = "s3://"
 
 
-@ray.remote(num_gpus=1)
+@ray.remote(num_gpus=1, accelerator_type="T4")
 class TritonModelCompiler:
     def __init__(self):
         self.triton_server = tritonserver.Server(


### PR DESCRIPTION
Wrap model compile and upload in a ray actor to run on the GPU worker so we can remove the GPU head node dependency on this template. Also fix the configs. 

Full walkthrough video: https://drive.google.com/file/d/1HGOFNYneniECHuP4iX43_IsjiW9zYZRj/view?usp=sharing 