### PR TITLE
[ft-template] Update `llmforge` versions table with v0.5.2 release

### DIFF
--- a/templates/fine-tune-llm_v2/README.ipynb
+++ b/templates/fine-tune-llm_v2/README.ipynb
@@ -181,6 +181,7 @@
     "\n",
     "| version | image_uri |\n",
     "|---------|-----------|\n",
+    "| `0.5.2`  | `localhost:5555/anyscale/llm-forge:0.5.2` |\n",
     "| `0.5.1`  | `localhost:5555/anyscale/llm-forge:0.5.1` |\n",
     "| `0.5.0.1`  | `localhost:5555/anyscale/llm-forge:0.5.0.1-ngmM6BdcEdhWo0nvedP7janPLKS9Cdz2` |"
    ]

--- a/templates/fine-tune-llm_v2/README.md
+++ b/templates/fine-tune-llm_v2/README.md
@@ -117,6 +117,7 @@ Here is a list of LLMForge image versions:
 
 | version | image_uri |
 |---------|-----------|
+| `0.5.2`  | `localhost:5555/anyscale/llm-forge:0.5.2` |
 | `0.5.1`  | `localhost:5555/anyscale/llm-forge:0.5.1` |
 | `0.5.0.1`  | `localhost:5555/anyscale/llm-forge:0.5.0.1-ngmM6BdcEdhWo0nvedP7janPLKS9Cdz2` |
 


### PR DESCRIPTION
# What does this PR do?

A tiny PR to update `llmforge` versions table with the latest release (v0.5.2)