### PR TITLE
[ft-template] Update DPO training configs for the right resource requests

### DIFF
--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a10.yaml
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a10.yaml
@@ -19,13 +19,13 @@ no_gradient_checkpoint: False
 deepspeed:
   config_path: configs/zero_3.json
 worker_resources:
-  accelerator_type:A10G: 1
+  accelerator_type:A10G: 0.001
 padding: "longest"
 preference_tuning_config:
   beta: 0.01
   logprob_processor_scaling_config:
     custom_resources:
-      accelerator_type:A10G: 1 # custom resource per worker.
+      accelerator_type:A10G: 0.001 # custom resource per worker.
     # Runs reference model logp calculation on 4 GPUs
     concurrency: 4
     batch_size: 2

--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a100.yaml
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a100.yaml
@@ -19,9 +19,13 @@ no_gradient_checkpoint: False
 deepspeed:
   config_path: configs/zero_3.json
 padding: "longest"
+worker_resources:
+  accelerator_type:A100-80G: 0.001
 preference_tuning_config:
   beta: 0.01
   logprob_processor_scaling_config:
+    custom_resources:
+      accelerator_type:A100-80G: 0.001
     # Runs reference model logp calculation on 2 GPUs
     concurrency: 2
     batch_size: 16

--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/jobs/training/mistral_a10.yaml
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/jobs/training/mistral_a10.yaml
@@ -1,3 +1,5 @@
 name: "llmforge-mistral-dpo-summarization-job"
 entrypoint: "llmforge anyscale finetune configs/dpo-training/mistral_a10.yaml"
 max_retries: 0
+env_vars:
+  RAY_OVERRIDE_JOB_RUNTIME_ENV: "1"

--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/jobs/training/mistral_a100.yaml
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/jobs/training/mistral_a100.yaml
@@ -1,3 +1,5 @@
 name: "llmforge-mistral-dpo-summarization-job"
 entrypoint: "llmforge anyscale finetune configs/dpo-training/mistral_a100.yaml"
 max_retries: 0
+env_vars:
+  RAY_OVERRIDE_JOB_RUNTIME_ENV: "1"


### PR DESCRIPTION
# What does this PR do?

Updates DPO training configs for the right resource requests. With Ray, all gpu-based instances have `accelerator_type` custom resource value set to 1.  The recommended way is thus to  use something like `{"GPU": 1, "accelerator_type:A10G":  0.001}` instead of ` {"GPU": 1, "accelerator_type:A10G":  1}`  Because instances with 4xA10s and 1xA10s both have `{"accelerator_type:A10G":  1}` in the custom resource labels. This can thus give you a faulty allocation of nodes (even if you get 4 4xA10 nodes, you would have only satisfied "4" quantity of the custom resource `accelerator_type:A10G`, even if you have 16 GPUs i.e satisfy "16" for `GPU` resource).

Reference comment: https://github.com/ray-project/ray/pull/40286/files#r1361443657 


I'm also adding an override flag for the job config due to our internal `llmforge` ray initialization. This can be removed after the next llmforge release. 
