### PR TITLE
[ft-template] Update DPO configs to use older format

### DIFF
--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/README.ipynb
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/README.ipynb
@@ -787,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -815,13 +815,13 @@
       "deepspeed:\n",
       "  config_path: configs/zero_3.json\n",
       "worker_resources:\n",
-      "  accelerator_type:A10G: 1\n",
+      "  accelerator_type:A10G: 0.001\n",
       "padding: \"longest\"\n",
       "preference_tuning_config:\n",
       "  beta: 0.01\n",
       "  logprob_processor_scaling_config:\n",
-      "    custom_resources:\n",
-      "      accelerator_type:A10G: 1 # custom resource per worker.\n",
+      "    worker_resources:\n",
+      "      accelerator_type:A10G: 0.001 # custom resource per worker.\n",
       "    # Runs reference model logp calculation on 4 GPUs\n",
       "    concurrency: 4\n",
       "    batch_size: 2\n",

--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/README.md
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/README.md
@@ -687,13 +687,13 @@ To get started with DPO training, we provide the config for DPO in [configs/dpo-
     deepspeed:
       config_path: configs/zero_3.json
     worker_resources:
-      accelerator_type:A10G: 1
+      accelerator_type:A10G: 0.001
     padding: "longest"
     preference_tuning_config:
       beta: 0.01
       logprob_processor_scaling_config:
-        custom_resources:
-          accelerator_type:A10G: 1 # custom resource per worker.
+        worker_resources:
+          accelerator_type:A10G: 0.001 # custom resource per worker.
         # Runs reference model logp calculation on 4 GPUs
         concurrency: 4
         batch_size: 2

--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a10.yaml
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a10.yaml
@@ -24,7 +24,7 @@ padding: "longest"
 preference_tuning_config:
   beta: 0.01
   logprob_processor_scaling_config:
-    custom_resources:
+    worker_resources:
       accelerator_type:A10G: 0.001 # custom resource per worker.
     # Runs reference model logp calculation on 4 GPUs
     concurrency: 4

--- a/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a100.yaml
+++ b/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-preference/configs/dpo-training/mistral_a100.yaml
@@ -24,7 +24,7 @@ worker_resources:
 preference_tuning_config:
   beta: 0.01
   logprob_processor_scaling_config:
-    custom_resources:
+    worker_resources:
       accelerator_type:A100-80G: 0.001
     # Runs reference model logp calculation on 2 GPUs
     concurrency: 2


### PR DESCRIPTION
# What does this PR do?

Updates DPO configs to use the correct format for resource requests. In `llmforge` 0.5.3, the custom resource requests  for the logprob processor are supposed to be named `worker_resources` while it has been changed to `custom_resources` in the latest master. 