### PR TITLE
[llms-finetuning] add zero_2 deepspeed config + modify templates for 4xA10 to request specific shape

### DIFF
--- a/templates/fine-tune-llm_v2/deepspeed_configs/zero_2.json
+++ b/templates/fine-tune-llm_v2/deepspeed_configs/zero_2.json
@@ -1,0 +1,22 @@
+{
+    "fp16": {
+      "enabled": false
+    },
+    "bf16": {
+      "enabled": true
+    },
+    "zero_optimization": {
+      "stage": 2,
+      "contiguous_gradients": true,
+      "overlap_comm": true,
+      "reduce_scatter": true,
+      "reduce_bucket_size": 5e8,
+      "allgather_bucket_size": 5e8
+    },
+    "gradient_accumulation_steps": "auto",
+    "gradient_clipping": "auto",
+    "steps_per_print": 10,
+    "train_batch_size": "auto",
+    "train_micro_batch_size_per_gpu": "auto",
+    "wall_clock_breakdown": false
+}

--- a/templates/fine-tune-llm_v2/deepspeed_configs/zero_3_hpz.json
+++ b/templates/fine-tune-llm_v2/deepspeed_configs/zero_3_hpz.json
@@ -1,0 +1,25 @@
+{
+    "fp16": {
+      "enabled": false
+    },
+    "bf16": {
+      "enabled": true
+    },
+    "zero_optimization": {
+      "stage": 3,
+      "overlap_comm": true,
+      "contiguous_gradients": true,
+      "reduce_bucket_size": "auto",
+      "zero_hpz_partition_size": 8,
+      "stage3_prefetch_bucket_size": "auto",
+      "stage3_param_persistence_threshold": "auto",
+      "gather_16bit_weights_on_model_save": true,
+      "round_robin_gradients": true
+    },
+    "gradient_accumulation_steps": "auto",
+    "gradient_clipping": "auto",
+    "steps_per_print": 10,
+    "train_batch_size": "auto",
+    "train_micro_batch_size_per_gpu": "auto",
+    "wall_clock_breakdown": false
+  }

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-70B/full/16xA100-80G-4k.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-70B/full/16xA100-80G-4k.yaml
@@ -32,7 +32,7 @@ num_checkpoints_to_keep: 1
 
 # Deepspeed configuration, you can provide your own deepspeed setup
 deepspeed:
-  config_path: deepspeed_configs/zero_3_offload_optim+param.json
+  config_path: deepspeed_configs/zero_3_hpz.json
 
 # Accelerator type, we value of 0.001 is not important, as long as it is
 # beteween 0 and 1. This ensures that accelerator type is used per trainer

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-70B/lora/8xA100-80G-4k.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-70B/lora/8xA100-80G-4k.yaml
@@ -39,3 +39,22 @@ deepspeed:
 # worker.
 worker_resources:
   accelerator_type:A100-80G: 0.001
+
+# Lora configuration
+lora_config:
+  r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  target_modules:
+    - q_proj
+    - v_proj
+    - k_proj
+    - o_proj
+    - gate_proj
+    - up_proj
+    - down_proj
+    - embed_tokens
+    - lm_head
+  task_type: "CAUSAL_LM"
+  bias: "none"
+  modules_to_save: []

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-mlflow.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-mlflow.yaml
@@ -18,8 +18,10 @@ num_devices: 4
 num_epochs: 3
 
 # Change this to the batch size that you want to use
-train_batch_size_per_device: 4
+train_batch_size_per_device: 2
 eval_batch_size_per_device: 4
+gradient_accumulation_steps: 2
+
 
 # Change this to the learning rate that you want to use
 learning_rate: 1e-4

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-mlflow.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-mlflow.yaml
@@ -32,7 +32,7 @@ num_checkpoints_to_keep: 1
 
 # Deepspeed configuration, you can provide your own deepspeed setup
 deepspeed:
-  config_path: deepspeed_configs/zero_3_offload_optim+param.json
+  config_path: deepspeed_configs/zero_2.json
 
 # Logging config
 logger:
@@ -46,7 +46,7 @@ logger:
 # beteween 0 and 1. This ensures that accelerator type is used per trainer
 # worker.
 worker_resources:
-  accelerator_type:A10G: 0.001
+  anyscale/accelerator_shape:4xA10G: 0.001
 
 # Lora configuration
 lora_config:

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-wandb.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-wandb.yaml
@@ -32,7 +32,7 @@ num_checkpoints_to_keep: 1
 
 # Deepspeed configuration, you can provide your own deepspeed setup
 deepspeed:
-  config_path: deepspeed_configs/zero_3_offload_optim+param.json
+  config_path: deepspeed_configs/zero_2.json
 
 logger:
   provider: wandb
@@ -41,7 +41,7 @@ logger:
 # beteween 0 and 1. This ensures that accelerator type is used per trainer
 # worker.
 worker_resources:
-  accelerator_type:A10G: 0.001
+  anyscale/accelerator_shape:4xA10G: 0.001
 
 # Lora configuration
 lora_config:

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-wandb.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512-wandb.yaml
@@ -18,8 +18,10 @@ num_devices: 4
 num_epochs: 3
 
 # Change this to the batch size that you want to use
-train_batch_size_per_device: 4
+train_batch_size_per_device: 2
 eval_batch_size_per_device: 4
+gradient_accumulation_steps: 2
+
 
 # Change this to the learning rate that you want to use
 learning_rate: 1e-4

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512.yaml
@@ -32,13 +32,13 @@ num_checkpoints_to_keep: 1
 
 # Deepspeed configuration, you can provide your own deepspeed setup
 deepspeed:
-  config_path: deepspeed_configs/zero_3_offload_optim+param.json
+  config_path: deepspeed_configs/zero_2.json
 
 # Accelerator type, we value of 0.001 is not important, as long as it is
 # beteween 0 and 1. This ensures that accelerator type is used per trainer
 # worker.
 worker_resources:
-  accelerator_type:A10G: 0.001
+  anyscale/accelerator_shape:4xA10G: 0.001
 
 # Lora configuration
 lora_config:

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-3-8B/lora/4xA10-512.yaml
@@ -18,8 +18,9 @@ num_devices: 4
 num_epochs: 3
 
 # Change this to the batch size that you want to use
-train_batch_size_per_device: 4
+train_batch_size_per_device: 2
 eval_batch_size_per_device: 4
+gradient_accumulation_steps: 2
 
 # Change this to the learning rate that you want to use
 learning_rate: 1e-4

--- a/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-Guard-2-8B/lora/llama-guard-2.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/meta-llama/Meta-Llama-Guard-2-8B/lora/llama-guard-2.yaml
@@ -37,7 +37,7 @@ deepspeed:
 
 # Accelerator type
 worker_resources:
-  accelerator_type:A10G: 0.001
+  anyscale/accelerator_shape:4xA10G: 0.001
 
 # Lora configuration
 lora_config:

--- a/templates/fine-tune-llm_v2/training_configs/custom/mistralai/mistral-7b/lora/4xA10-512.yaml
+++ b/templates/fine-tune-llm_v2/training_configs/custom/mistralai/mistral-7b/lora/4xA10-512.yaml
@@ -32,13 +32,13 @@ num_checkpoints_to_keep: 1
 
 # Deepspeed configuration, you can provide your own deepspeed setup
 deepspeed:
-  config_path: deepspeed_configs/zero_3_offload_optim+param.json
+  config_path: deepspeed_configs/zero_2.json
 
 # Accelerator type, the value of 0.001 is not important, as long as it is
 # between 0 and 1. This ensures that the given accelerator is available for each trainer
 # worker.
 worker_resources:
-  accelerator_type:A10G: 0.001
+  anyscale/accelerator_shape:4xA10G: 0.001
 
 # Lora configuration
 lora_config:


### PR DESCRIPTION
Edit template configs that do single node training with A10Gs to use ZeRO stage 2 - per new user guide on cluster shape + ZeRO stage recommendation.

WandB run for 4xA10G Llama-3-8B that works: https://wandb.ai/anyscale-llm-forge/llmforge/runs/jxg1sm1c
WandB run for 4xA10G Mistral-7B that works: https://wandb.ai/anyscale-llm-forge/llmforge/runs/rua1w3x2