### PR TITLE
Remove some friction from e2e LLM template

### DIFF
--- a/templates/e2e-llm-workflows/README.ipynb
+++ b/templates/e2e-llm-workflows/README.ipynb
@@ -828,6 +828,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "db6cceaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils import set_key_value_in_config_file\n",
+    "\n",
+    "# Set the dataset paths in the config file to the S3 URIs from the previous step\n",
+    "# Change the path to the training config if you are using a different model\n",
+    "set_key_value_in_config_file(\"configs/training/lora/llama-3-8b.yaml\", \"train_path\", train_dataset.storage_uri)\n",
+    "set_key_value_in_config_file(\"configs/training/lora/llama-3-8b.yaml\", \"valid_path\", val_dataset.storage_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 14,
    "id": "e573ddac",
    "metadata": {},

--- a/templates/e2e-llm-workflows/README.ipynb
+++ b/templates/e2e-llm-workflows/README.ipynb
@@ -61,16 +61,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "56497db9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install -U anyscale -q"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
    "id": "0881179b",
    "metadata": {

--- a/templates/e2e-llm-workflows/README.ipynb
+++ b/templates/e2e-llm-workflows/README.ipynb
@@ -61,6 +61,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "56497db9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U anyscale -q"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "0881179b",
    "metadata": {
@@ -211,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datasets import load_dataset\n",
+    "from datasets import DatasetDict, load_dataset\n",
     "ray.data.DataContext.get_current().enable_progress_bars = False"
    ]
   },
@@ -222,8 +232,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datasets import DatasetDict\n",
-    "\n",
     "# Load the VIGGO dataset\n",
     "dataset: DatasetDict = load_dataset(\"GEM/viggo\", trust_remote_code=True)  # type: ignore"
    ]
@@ -293,6 +301,16 @@
    "metadata": {},
    "source": [
     "We'll use [Ray](https://docs.ray.io/) to load our dataset and apply preprocessing to batches of our data at scale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7798f61f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ray.data import Dataset"
    ]
   },
   {
@@ -440,8 +458,6 @@
     }
    ],
    "source": [
-    "from ray.data import Dataset\n",
-    "\n",
     "# Distributed preprocessing\n",
     "ft_train_ds: Dataset = train_ds.map(to_schema, fn_kwargs={'system_content': system_content})\n",
     "ft_train_ds.take(1)"
@@ -454,8 +470,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ray.data import Dataset\n",
-    "\n",
     "# Repeat the steps for other splits\n",
     "ft_val_ds: Dataset = ray.data.from_items(val_set).map(to_schema, fn_kwargs={'system_content': system_content})\n",
     "ft_test_ds: Dataset = ray.data.from_items(test_set).map(to_schema, fn_kwargs={'system_content': system_content})"
@@ -475,6 +489,40 @@
    "metadata": {},
    "source": [
     "We can save our data locally and/or to remote storage to use later (training, evaluation, etc.). All workspaces come with a default [cloud storage locations and shared storage](https://docs.anyscale.com/workspaces/storage) that we can write to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1609e0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import anyscale\n",
+    "import os\n",
+    "from ray.data import Dataset\n",
+    "from rich import print as rprint\n",
+    "from src.utils import get_dataset_file_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adfab1b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload as an Anyscale Dataset\n",
+    "def upload_dataset(dataset: Dataset, filename: str):\n",
+    "    with get_dataset_file_path(dataset) as dataset_file_path:\n",
+    "        dataset = anyscale.llm.dataset.upload(\n",
+    "            dataset_file_path,\n",
+    "            # john_doe/viggo/train.jsonl\n",
+    "            name=f\"viggo/{filename}\",\n",
+    "        )\n",
+    "    rprint(f\"Metadata for '{filename}'\")\n",
+    "    rprint(dataset)\n",
+    "    return dataset"
    ]
   },
   {
@@ -773,25 +821,6 @@
     }
    ],
    "source": [
-    "import anyscale\n",
-    "import os\n",
-    "from ray.data import Dataset\n",
-    "from rich import print as rprint\n",
-    "from src.utils import get_dataset_file_path\n",
-    "\n",
-    "\n",
-    "# Upload as an Anyscale Dataset\n",
-    "def upload_dataset(dataset: Dataset, filename: str):\n",
-    "    with get_dataset_file_path(dataset) as dataset_file_path:\n",
-    "        dataset = anyscale.llm.dataset.upload(\n",
-    "            dataset_file_path,\n",
-    "            # john_doe/viggo/train.jsonl\n",
-    "            name=f\"viggo/{filename}\",\n",
-    "        )\n",
-    "    rprint(f\"Metadata for '{filename}'\")\n",
-    "    rprint(dataset)\n",
-    "    return dataset\n",
-    "\n",
     "train_dataset = upload_dataset(ft_train_ds, 'train.jsonl')\n",
     "val_dataset = upload_dataset(ft_val_ds, 'val.jsonl')\n",
     "test_dataset = upload_dataset(ft_test_ds, 'test.jsonl')"
@@ -1019,6 +1048,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "955632e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import anyscale\n",
+    "from anyscale.job import JobConfig"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 18,
    "id": "0c5684aa",
    "metadata": {},
@@ -1034,9 +1074,6 @@
     }
    ],
    "source": [
-    "import anyscale\n",
-    "from anyscale.job import JobConfig\n",
-    "\n",
     "# Job submission\n",
     "job_config = JobConfig.from_yaml(\"deploy/jobs/ft.yaml\")\n",
     "job_id = anyscale.job.submit(job_config)"
@@ -1069,7 +1106,7 @@
    "source": [
     "To retrieve information about your fine-tuned model, Anyscale provides a convenient SDK. \n",
     "\n",
-    "<b style=\"background-color: yellow;\">&nbsp;🔄 REPLACE&nbsp;</b>:  Update the `job_id` field with the Anyscale job ID for your fine-tuning run."
+    "**Note**: Wait for your fine-tuning job to finish first and then run the code below to programatically retrieve the model information."
    ]
   },
   {
@@ -1089,7 +1126,7 @@
    "id": "df0a0541",
    "metadata": {},
    "source": [
-    "`model_info` has a number of helpful model metadata, such as the id `meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba` , the base model ID, storage URI for the final checkpoint, the model generation config, etc. \n",
+    "`model_info` has a number of helpful model metadata, such as the id `meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli` , the base model ID, storage URI for the final checkpoint, the model generation config, etc. \n",
     "\n",
     "```\n",
     "FineTunedModel(\n",
@@ -1125,14 +1162,14 @@
     "The storage URI for the best checkpoint can look like:\n",
     "\n",
     "```\n",
-    "s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/sumanth__hegde_ilziamlndopyvjolzuglmhzzmkkkfgeewbyk/llmforge-finetuning/meta-llama/Meta-Llama-3-8B-Instruct/TorchTrainer_2024-09-10_16-35-42/epoch-3\n",
+    "s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/goku__mohandas_gkdbtlxwnwirhpgqqzhawjazxxldhngwkxoi/llmforge-finetuning/meta-llama/Meta-Llama-3-8B-Instruct/TorchTrainer_2024-09-10_16-35-42/epoch-3\n",
     "```\n",
     "\n",
     "Note that with LoRA, we automatically forward this checkpoint to a common folder in [artifact storage](https://docs.anyscale.com/platform/workspaces/workspaces-storage#object-storage-s3-or-gcs-buckets): `{ANYSCALE_ARTIFACT_STORAGE}/lora_fine_tuning` . This becomes extremely helpful while serving LoRA checkpoints, which we'll see soon. \n",
     "\n",
     "This information about the final checkpoint is also available in the logs for the job. For example, you might see: \n",
     "```\n",
-    "Successfully copied files to bucket: anyscale-customer-dataplane-data-production-us-east-2 and path: artifact_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba\n",
+    "Successfully copied files to bucket: anyscale-customer-dataplane-data-production-us-east-2 and path: artifact_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli\n",
     "```\n",
     "\n",
     "We'll now load the checkpoint from cloud storage to a local [cluster storage](https://docs.anyscale.com/workspaces/storage/#cluster-storage) to use for other workloads."
@@ -1149,14 +1186,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "14eb1192",
-   "metadata": {},
-   "source": [
-    "<b style=\"background-color: yellow;\">&nbsp;🔄 REPLACE&nbsp;</b>: Update the information below for the specific model and artifacts path for our fine-tuned model (retrieved from the logs from the Anyscale Job we launched above)."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "8e041050",
@@ -1165,7 +1194,7 @@
    "source": [
     "# Locations\n",
     "artifacts_dir = '/mnt/cluster_storage'  # storage accessible by head and worker nodes\n",
-    "model_id = model_info.id \n",
+    "model_id = model_info.id\n",
     "artifacts_path = f\"{os.environ['ANYSCALE_ARTIFACT_STORAGE']}/lora_fine_tuning/{model_id}\""
    ]
   },
@@ -1179,15 +1208,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/README.md to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/README.md\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/adapter_config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/adapter_config.json\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/adapter_model.safetensors to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/adapter_model.safetensors\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/config.json\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/new_embeddings.safetensors to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/new_embeddings.safetensors\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/rayllm_generation_config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/rayllm_generation_config.json\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/special_tokens_map.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/special_tokens_map.json\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/tokenizer.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/tokenizer.json\n",
-      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/tokenizer_config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba/tokenizer_config.json\n"
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/README.md to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/README.md\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/adapter_config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/adapter_config.json\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/adapter_model.safetensors to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/adapter_model.safetensors\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/config.json\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/new_embeddings.safetensors to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/new_embeddings.safetensors\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/rayllm_generation_config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/rayllm_generation_config.json\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/special_tokens_map.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/special_tokens_map.json\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/tokenizer.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/tokenizer.json\n",
+      "Downloaded org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/tokenizer_config.json to /mnt/cluster_storage/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning/meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli/tokenizer_config.json\n"
      ]
     }
    ],
@@ -1364,6 +1393,7 @@
    ],
    "source": [
     "# Extract chat template used during fine-tuning\n",
+    "artifacts_path = artifacts_path.split('/', 3)[-1]\n",
     "with open(os.path.join(artifacts_dir, artifacts_path, 'tokenizer_config.json')) as file:\n",
     "    tokenizer_config = json.load(file)\n",
     "chat_template = tokenizer_config['chat_template']\n",
@@ -1417,7 +1447,7 @@
    "id": "21f6944d",
    "metadata": {},
    "source": [
-    "We will use [vLLM](https://github.com/vllm-project/vllm)'s offline LLM class to load the model and use it for inference. We can easily load our LoRA weights and merge them with the base model (just pass in `lora_path`). And we'll wrap all of this functionality in a class that we can pass to [ray.data.Dataset.map_batches`](https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html) to apply batch inference at scale.\n",
+    "We will use [vLLM](https://github.com/vllm-project/vllm)'s offline LLM class to load the model and use it for inference. We can easily load our LoRA weights and merge them with the base model (just pass in `lora_path`). And we'll wrap all of this functionality in a class that we can pass to [ray.data.Dataset.map_batches](https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html) to apply batch inference at scale.\n",
     "\n",
     "<img src=\"assets/offline-detailed.png\" width=750>"
    ]
@@ -1430,7 +1460,7 @@
    "outputs": [],
    "source": [
     "from vllm import LLM, SamplingParams\n",
-    "from vllm.anyscale.lora.utils import LoRARequest"
+    "from vllm.lora.request import LoRARequest"
    ]
   },
   {
@@ -1814,7 +1844,7 @@
     "\n",
     "We can use the model metadata `model_info` for the model ID. For serving, we'll use the root folder for the LoRA checkpoints.  \n",
     "\n",
-    "**model**: `meta-llama/Meta-Llama-3-8B-Instruct:suman:cdrba` (`model_info.id`)\n",
+    "**model**: `meta-llama/Meta-Llama-3-8B-Instruct:gokum:yehli` (`model_info.id`)\n",
     "\n",
     "**LoRA weights storage URI**: `s3://org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/artifact_storage/lora_fine_tuning` ( or `{ANYSCALE_ARTIFACT_STORAGE}/lora_fine_tuning`)"
    ]
@@ -2114,14 +2144,29 @@
    "source": [
     "We have a lot more guides that address more nuanced use cases:\n",
     "\n",
-    "- [Batch text embeddings with Ray data](https://github.com/anyscale/templates/tree/main/templates/text-embeddings)\n",
+    "Fine-tuning:\n",
+    "- [Control over 50+ hyperparameters](https://docs.anyscale.com/llms/finetuning/guides/modify_hyperparams/)\n",
+    "- [Fine-tune any HF model](https://docs.anyscale.com/llms/finetuning/guides/bring_any_hf_model/)\n",
+    "- [Full-parameter or LoRA fine-tuning](https://docs.anyscale.com/llms/finetuning/guides/lora_vs_full_param/)\n",
+    "- [Classification fine-tuning / Routing](https://www.anyscale.com/blog/building-an-llm-router-for-high-quality-and-cost-effective-responses)\n",
+    "- [Function calling fine-tuning](https://github.com/anyscale/templates/blob/main/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-function-calling/README.ipynb)\n",
+    "- [Longer context fine-tuning](https://www.anyscale.com/blog/fine-tuning-llms-for-longer-context-and-better-rag-systems)\n",
     "- [Continued fine-tuning from checkpoint](https://github.com/anyscale/templates/tree/main/templates/fine-tune-llm_v2/cookbooks/continue_from_checkpoint)\n",
-    "- [Serving multiple LoRA adapters with same base model](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/examples/lora/DeployLora.ipynb) (+ multiplexing)\n",
-    "- [Deploy models for embedding generation](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/examples/embedding/EmbeddingModels.ipynb)\n",
-    "- Function calling [fine-tuning](https://github.com/anyscale/templates/tree/main/templates/fine-tune-llm_v2/end-to-end-examples/fine-tune-function-calling) and [deployment](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/examples/function_calling/DeployFunctionCalling.ipynb)\n",
-    "- [Configs to optimize the latency/throughput](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/examples/OptimizeModels.ipynb)\n",
-    "- [Configs to control optimization parameters and tensor-parallelism](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/examples/AdvancedModelConfigs.ipynb)\n",
-    "- Creating a [Router](https://github.com/anyscale/llm-router) between different models (base, fine-tuned, closed-source) to optimize for cost and quality.\n",
+    "- Training on more available hardware (ex. A10s) with model parallelism\n",
+    "- [End-to-end LLM workflows (including batch data processing, batch inference)](https://www.anyscale.com/blog/end-to-end-llm-workflows-guide)\n",
+    "- Distillation (Coming in <2 weeks)\n",
+    "\n",
+    "Serving:\n",
+    "- [Deploy with autoscaling + optimize for latency vs. throughput](https://docs.anyscale.com/examples/deploy-llms/)\n",
+    "- [Serving multiple LoRA adapters](https://docs.anyscale.com/llms/serving/guides/multi_lora/)\n",
+    "- [Migration from OpenAI](https://docs.anyscale.com/llms/serving/guides/openai_to_oss/)\n",
+    "- [Spot to on-demand fallback (vice versa)](https://docs.anyscale.com/1.0.0/configure/compute-configs/ondemand-to-spot-fallback/)\n",
+    "- [Batch inference with vLLM](https://docs.anyscale.com/examples/batch-llm/)\n",
+    "\n",
+    "And more!\n",
+    "- [Batch text embeddings with Ray data](https://github.com/anyscale/templates/tree/main/templates/text-embeddings)\n",
+    "- [Production RAG applications](https://www.anyscale.com/blog/a-comprehensive-guide-for-building-rag-based-llm-applications-part-1)\n",
+    "- [Router](https://github.com/anyscale/llm-router) between different models (base, fine-tuned, closed-source) to optimize for cost and quality\n",
     "- Stable diffusion [fine-tuning](https://github.com/anyscale/templates/tree/main/templates/fine-tune-stable-diffusion) and [serving](https://github.com/anyscale/templates/tree/main/templates/serve-stable-diffusion)\n",
     "\n",
     "And if you're interested in using our hosted Anyscale or connecting it to your own cloud, reach out to us at [Anyscale](https://www.anyscale.com/get-started?utm_source=goku). And follow us on [Twitter](https://x.com/anyscalecompute) and [LinkedIn](https://www.linkedin.com/company/joinanyscale/) for more real-time updates on new features!"
@@ -2144,7 +2189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/templates/e2e-llm-workflows/src/utils.py
+++ b/templates/e2e-llm-workflows/src/utils.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 import boto3
 from urllib.parse import urlparse
 from ray.data import Dataset
+import yaml
 
 
 def download_files_from_s3(s3_uri, local_dir):
@@ -63,3 +64,20 @@ def get_dataset_file_path(dataset: Dataset):
         assert len(os.listdir(temp_path)) == 1, "The dataset should be written to a single file"
         dataset_file_path = f"{temp_path}/{os.listdir(temp_path)[0]}"
         yield dataset_file_path
+
+def set_key_value_in_config_file(config_path: str, key: str, value: str):
+    """Take a path to a .json config file and update the key to a value, then save the file"""
+    with open(config_path, 'r') as stream:
+        try:
+            loaded = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+            exit()
+    # Modify the fields from the dict
+    loaded[key] = value
+    # Save it again
+    with open(config_path, 'w') as stream:
+        try:
+            yaml.dump(loaded, stream, default_flow_style=False)
+        except yaml.YAMLError as exc:
+            print(exc)

--- a/templates/e2e-llm-workflows/src/utils.py
+++ b/templates/e2e-llm-workflows/src/utils.py
@@ -68,11 +68,7 @@ def get_dataset_file_path(dataset: Dataset):
 def set_key_value_in_config_file(config_path: str, key: str, value: str):
     """Take a path to a .json config file and update the key to a value, then save the file"""
     with open(config_path, 'r') as stream:
-        try:
-            loaded = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
-            exit()
+        loaded = yaml.safe_load(stream)
     # Modify the fields from the dict
     loaded[key] = value
     # Save it again

--- a/templates/e2e-llm-workflows/src/utils.py
+++ b/templates/e2e-llm-workflows/src/utils.py
@@ -73,7 +73,4 @@ def set_key_value_in_config_file(config_path: str, key: str, value: str):
     loaded[key] = value
     # Save it again
     with open(config_path, 'w') as stream:
-        try:
-            yaml.dump(loaded, stream, default_flow_style=False)
-        except yaml.YAMLError as exc:
-            print(exc)
+        yaml.dump(loaded, stream, default_flow_style=False)


### PR DESCRIPTION
- Remove potentially breaking `pip install -U anyscale`, since it's no longer needed.
- Automatically parse in the S3 bucket locations to the train config yaml