### PR TITLE
[maketmpl] add support to save a different file or inlined bytes in zip

### DIFF
--- a/ci/maketmpl/util.go
+++ b/ci/maketmpl/util.go
@@ -19,6 +19,17 @@ func checkIsDir(path string) error {
 	return nil
 }
 
+func addToZip(z *zip.Writer, r io.Reader, pathInZip string) error {
+	w, err := z.Create(pathInZip)
+	if err != nil {
+		return fmt.Errorf("create file in zip: %w", err)
+	}
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+	return nil
+}
+
 func addFileToZip(z *zip.Writer, file, pathInZip string) error {
 	f, err := os.Open(file)
 	if err != nil {
@@ -26,17 +37,23 @@ func addFileToZip(z *zip.Writer, file, pathInZip string) error {
 	}
 	defer f.Close()
 
-	w, err := z.Create(pathInZip)
-	if err != nil {
-		return fmt.Errorf("create file in zip: %w", err)
-	}
-	if _, err := io.Copy(w, f); err != nil {
-		return fmt.Errorf("copy file to zip: %w", err)
-	}
-	return nil
+	return addToZip(z, f, pathInZip)
 }
 
-func buildZip(dir string, files []string, out string) error {
+type zipFile struct {
+	// Path to use in the zip file. When srcFilePath is empty,
+	// the same file path will be used for finding the source file.
+	path string
+
+	// Optional. If set, the content will be read from this reader.
+	rc io.ReadCloser
+
+	// Optional. If set, the content will be read from this file.
+	// If rc is set, this field is ignored.
+	srcFilePath string
+}
+
+func buildZip(srcDir string, files []*zipFile, out string) error {
 	outFile, err := os.Create(out)
 	if err != nil {
 		return fmt.Errorf("create release zip file: %w", err)
@@ -45,8 +62,18 @@ func buildZip(dir string, files []string, out string) error {
 
 	z := zip.NewWriter(outFile)
 	for _, f := range files {
-		if err := addFileToZip(z, filepath.Join(dir, f), f); err != nil {
-			return fmt.Errorf("add file to zip: %w", err)
+		if f.rc == nil {
+			src := f.srcFilePath
+			if src == "" {
+				src = filepath.Join(srcDir, f.path)
+			}
+			if err := addFileToZip(z, src, f.path); err != nil {
+				return fmt.Errorf("add file %q to zip: %w", f, err)
+			}
+		} else {
+			if err := addToZip(z, f.rc, f.path); err != nil {
+				return fmt.Errorf("add %q to zip: %w", f.path, err)
+			}
 		}
 	}
 	if err := z.Close(); err != nil {


### PR DESCRIPTION
makes it possible to put a properly converted readme file into the built zip archive