### PR TITLE
Remove anyscale install from e2e llm template

### DIFF
--- a/templates/e2e-llm-workflows/README.ipynb
+++ b/templates/e2e-llm-workflows/README.ipynb
@@ -60,13 +60,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56497db9",
+   "cell_type": "markdown",
+   "id": "07a04882",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "!pip install -U anyscale -q"
+    "We'll need a free [Hugging Face token](https://huggingface.co/settings/tokens) to load our base LLMs and tokenizers. And since we are using Llama models, we need to login and accept the terms and conditions [here](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct). \n",
+    "\n",
+    "<b style=\"background-color: yellow;\">&nbsp;🔄 REPLACE&nbsp;</b>: Place your unique HF token below. If you accidentally ran this code block before pasting your HF token, then click the `Restart` button up top to restart the notebook kernel."
    ]
   },
   {
@@ -87,16 +87,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "07a04882",
-   "metadata": {},
-   "source": [
-    "We'll need a free [Hugging Face token](https://huggingface.co/settings/tokens) to load our base LLMs and tokenizers. And since we are using Llama models, we need to login and accept the terms and conditions [here](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct). \n",
-    "\n",
-    "<b style=\"background-color: yellow;\">&nbsp;🔄 REPLACE&nbsp;</b>: Place your unique HF token below. If you accidentally ran this code block before pasting your HF token, then click the `Restart` button up top to restart the notebook kernel."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "d1498430",
@@ -106,14 +96,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:30:23,955\tINFO worker.py:1596 -- Connecting to existing Ray cluster at address: 10.0.10.187:6379...\n",
-      "2024-09-12 17:30:23,963\tINFO worker.py:1772 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-3sjkbyac1e3jd7qf55hum9qhsp.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
-      "2024-09-12 17:30:23,976\tINFO packaging.py:358 -- Pushing file package 'gcs://_ray_pkg_9f8218aed204ec2f1af15e0ab09e56de502310a4.zip' (2.56MiB) to Ray cluster...\n",
-      "2024-09-12 17:30:24,002\tINFO packaging.py:371 -- Successfully pushed file package 'gcs://_ray_pkg_9f8218aed204ec2f1af15e0ab09e56de502310a4.zip'.\n"
+      "2024-10-03 19:43:23,786\tINFO worker.py:1601 -- Connecting to existing Ray cluster at address: 10.0.8.121:6379...\n",
+      "2024-10-03 19:43:23,792\tINFO worker.py:1777 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32mhttps://session-fmdh7u2u6tsjg3fgylav1s48u8.i.anyscaleuserdata.com \u001b[39m\u001b[22m\n",
+      "2024-10-03 19:43:23,804\tINFO packaging.py:359 -- Pushing file package 'gcs://_ray_pkg_711ca045b15322646905868093582092332306ff.zip' (2.59MiB) to Ray cluster...\n",
+      "2024-10-03 19:43:23,830\tINFO packaging.py:372 -- Successfully pushed file package 'gcs://_ray_pkg_711ca045b15322646905868093582092332306ff.zip'.\n"
      ]
     },
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1f252c984aca40f6a8110066e0ac90ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/html": [
        "<div class=\"lm-Widget p-Widget lm-Panel p-Panel jp-Cell-outputWrapper\">\n",
        "    <div style=\"margin-left: 50px;display: flex;flex-direction: row;align-items: center\">\n",
@@ -138,11 +133,11 @@
        "    </tr>\n",
        "    <tr>\n",
        "        <td style=\"text-align: left\"><b>Ray version:</b></td>\n",
-       "        <td style=\"text-align: left\"><b>2.34.0</b></td>\n",
+       "        <td style=\"text-align: left\"><b>2.36.0</b></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "    <td style=\"text-align: left\"><b>Dashboard:</b></td>\n",
-       "    <td style=\"text-align: left\"><b><a href=\"http://session-3sjkbyac1e3jd7qf55hum9qhsp.i.anyscaleuserdata.com\" target=\"_blank\">http://session-3sjkbyac1e3jd7qf55hum9qhsp.i.anyscaleuserdata.com</a></b></td>\n",
+       "    <td style=\"text-align: left\"><b><a href=\"http://session-fmdh7u2u6tsjg3fgylav1s48u8.i.anyscaleuserdata.com\" target=\"_blank\">http://session-fmdh7u2u6tsjg3fgylav1s48u8.i.anyscaleuserdata.com</a></b></td>\n",
        "</tr>\n",
        "\n",
        "</table>\n",
@@ -151,7 +146,7 @@
        "</div>\n"
       ],
       "text/plain": [
-       "RayContext(dashboard_url='session-3sjkbyac1e3jd7qf55hum9qhsp.i.anyscaleuserdata.com', python_version='3.9.19', ray_version='2.34.0', ray_commit='a0b19139efa1e2749677886e37ef4a09dd0bc111')"
+       "RayContext(dashboard_url='session-fmdh7u2u6tsjg3fgylav1s48u8.i.anyscaleuserdata.com', python_version='3.9.19', ray_version='2.36.0', ray_commit='115e0fd7d642480f0262e3cea9596a7f37acb518')"
       ]
      },
      "execution_count": 2,
@@ -162,7 +157,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(autoscaler +1m37s) Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n"
+      "(autoscaler +1m39s) Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.\n"
      ]
     }
    ],
@@ -305,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "7798f61f",
    "metadata": {},
    "outputs": [],
@@ -315,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "0e484dad",
    "metadata": {},
    "outputs": [
@@ -323,9 +318,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:30:37,897\tINFO dataset.py:2414 -- Tip: Use `take_batch()` instead of `take() / show()` to return records in pandas or numpy batch format.\n",
-      "2024-09-12 17:30:37,900\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-09-12_17-21-47_756836_2485/logs/ray-data\n",
-      "2024-09-12 17:30:37,901\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> LimitOperator[limit=1]\n"
+      "2024-10-03 19:43:27,073\tINFO dataset.py:2416 -- Tip: Use `take_batch()` instead of `take() / show()` to return records in pandas or numpy batch format.\n",
+      "2024-10-03 19:43:27,076\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-10-03_19-40-56_737796_2248/logs/ray-data\n",
+      "2024-10-03 19:43:27,077\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> LimitOperator[limit=1]\n"
      ]
     },
     {
@@ -337,7 +332,7 @@
        "  'references': [\"Dirt: Showdown from 2012 is a sport racing game for the PlayStation, Xbox, PC rated E 10+ (for Everyone 10 and Older). It's not available on Steam, Linux, or Mac.\"]}]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -373,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "dbca0744",
    "metadata": {},
    "outputs": [],
@@ -397,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "5797c779",
    "metadata": {},
    "outputs": [],
@@ -429,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "1333aeb5",
    "metadata": {},
    "outputs": [
@@ -437,8 +432,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:30:43,597\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-09-12_17-21-47_756836_2485/logs/ray-data\n",
-      "2024-09-12 17:30:43,598\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> LimitOperator[limit=1]\n"
+      "2024-10-03 19:43:28,650\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-10-03_19-40-56_737796_2248/logs/ray-data\n",
+      "2024-10-03 19:43:28,650\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> LimitOperator[limit=1]\n"
      ]
     },
     {
@@ -452,7 +447,7 @@
        "    'role': 'assistant'}]}]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "59975860",
    "metadata": {},
    "outputs": [],
@@ -493,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "d1609e0e",
    "metadata": {},
    "outputs": [],
@@ -507,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "adfab1b8",
    "metadata": {},
    "outputs": [],
@@ -527,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "0c7ce57d",
    "metadata": {},
    "outputs": [
@@ -535,9 +530,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:31:13,725\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-09-12_17-21-47_756836_2485/logs/ray-data\n",
-      "2024-09-12 17:31:13,726\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[Write]\n"
+      "2024-10-03 19:43:33,551\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-10-03_19-40-56_737796_2248/logs/ray-data\n",
+      "2024-10-03 19:43:33,552\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[Write]\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "70514d34aae44af884e4d095494a8316",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
@@ -592,34 +601,34 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Dataset</span><span style=\"font-weight: bold\">(</span>\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'dataset_gnw82eyahbevp8y6sb6l9lmrsu'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'dataset_rbla1vkqejfdclhme8fcdf5926'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'viggo/train.jsonl'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">filename</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'28_000000_000000.json'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">storage_uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'s3://anyscale-production-data-cld-puimr4zjusn646fbl9zvgdgbq9/org_qvrjku61be1xl1ebynlg5bzvge/cld_pu</span>\n",
-       "<span style=\"color: #008000; text-decoration-color: #008000\">imr4zjusn646fbl9zvgdgbq9/datasets/dataset_gnw82eyahbevp8y6sb6l9lmrsu/1/28_000000_000000.json'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">version</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">num_versions</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">created_at</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2024</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">9</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">17</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">31</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">14</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">718198</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">tzlocal</span><span style=\"font-weight: bold\">())</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">creator_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'usr_buxzyw3dyfbvl5cxyb51mjsg4w'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">project_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'prj_qc1twugbhy9mfegbcz7yw9ny3p'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">cloud_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'cld_puimr4zjusn646fbl9zvgdgbq9'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">storage_uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ld</span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">m5ez4edlp7yh4yiakp2u294w/datasets/dataset_rbla1vkqejfdclhme8fcdf5926/5/28_000000_000000.json'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">version</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">num_versions</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">created_at</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2024</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">10</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">19</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">43</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">36</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">642586</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">tzlocal</span><span style=\"font-weight: bold\">())</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">creator_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'usr_2j3rrmjkqlx7wrlecsz273hcaq'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">project_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'prj_f4ldjckyhzxgtlr6c26d3e223x'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">cloud_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'cld_ldm5ez4edlp7yh4yiakp2u294w'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">description</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
        "<span style=\"font-weight: bold\">)</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[1;35mDataset\u001b[0m\u001b[1m(\u001b[0m\n",
-       "    \u001b[33mid\u001b[0m=\u001b[32m'dataset_gnw82eyahbevp8y6sb6l9lmrsu'\u001b[0m,\n",
+       "    \u001b[33mid\u001b[0m=\u001b[32m'dataset_rbla1vkqejfdclhme8fcdf5926'\u001b[0m,\n",
        "    \u001b[33mname\u001b[0m=\u001b[32m'viggo/train.jsonl'\u001b[0m,\n",
        "    \u001b[33mfilename\u001b[0m=\u001b[32m'28_000000_000000.json'\u001b[0m,\n",
-       "    \u001b[33mstorage_uri\u001b[0m=\u001b[32m's3://anyscale-production-data-cld-puimr4zjusn646fbl9zvgdgbq9/org_qvrjku61be1xl1ebynlg5bzvge/cld_pu\u001b[0m\n",
-       "\u001b[32mimr4zjusn646fbl9zvgdgbq9/datasets/dataset_gnw82eyahbevp8y6sb6l9lmrsu/1/28_000000_000000.json'\u001b[0m,\n",
-       "    \u001b[33mversion\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "    \u001b[33mnum_versions\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "    \u001b[33mcreated_at\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2024\u001b[0m, \u001b[1;36m9\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m17\u001b[0m, \u001b[1;36m31\u001b[0m, \u001b[1;36m14\u001b[0m, \u001b[1;36m718198\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mtzlocal\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
-       "    \u001b[33mcreator_id\u001b[0m=\u001b[32m'usr_buxzyw3dyfbvl5cxyb51mjsg4w'\u001b[0m,\n",
-       "    \u001b[33mproject_id\u001b[0m=\u001b[32m'prj_qc1twugbhy9mfegbcz7yw9ny3p'\u001b[0m,\n",
-       "    \u001b[33mcloud_id\u001b[0m=\u001b[32m'cld_puimr4zjusn646fbl9zvgdgbq9'\u001b[0m,\n",
+       "    \u001b[33mstorage_uri\u001b[0m=\u001b[32m's3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ld\u001b[0m\n",
+       "\u001b[32mm5ez4edlp7yh4yiakp2u294w/datasets/dataset_rbla1vkqejfdclhme8fcdf5926/5/28_000000_000000.json'\u001b[0m,\n",
+       "    \u001b[33mversion\u001b[0m=\u001b[1;36m5\u001b[0m,\n",
+       "    \u001b[33mnum_versions\u001b[0m=\u001b[1;36m5\u001b[0m,\n",
+       "    \u001b[33mcreated_at\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2024\u001b[0m, \u001b[1;36m10\u001b[0m, \u001b[1;36m3\u001b[0m, \u001b[1;36m19\u001b[0m, \u001b[1;36m43\u001b[0m, \u001b[1;36m36\u001b[0m, \u001b[1;36m642586\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mtzlocal\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mcreator_id\u001b[0m=\u001b[32m'usr_2j3rrmjkqlx7wrlecsz273hcaq'\u001b[0m,\n",
+       "    \u001b[33mproject_id\u001b[0m=\u001b[32m'prj_f4ldjckyhzxgtlr6c26d3e223x'\u001b[0m,\n",
+       "    \u001b[33mcloud_id\u001b[0m=\u001b[32m'cld_ldm5ez4edlp7yh4yiakp2u294w'\u001b[0m,\n",
        "    \u001b[33mdescription\u001b[0m=\u001b[3;35mNone\u001b[0m\n",
        "\u001b[1m)\u001b[0m\n"
       ]
@@ -631,9 +640,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:31:15,571\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-09-12_17-21-47_756836_2485/logs/ray-data\n",
-      "2024-09-12 17:31:15,572\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[Write]\n"
+      "2024-10-03 19:43:37,445\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-10-03_19-40-56_737796_2248/logs/ray-data\n",
+      "2024-10-03 19:43:37,445\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[Write]\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f0bd9945d1964f18815f162df329492a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
@@ -688,34 +711,34 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Dataset</span><span style=\"font-weight: bold\">(</span>\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'dataset_tjvg63t3vqnk28sfhu4ew4izw3'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'dataset_f6e7855eyiy2xup9q2nqcm8tk9'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'viggo/val.jsonl'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">filename</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'32_000000_000000.json'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">storage_uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'s3://anyscale-production-data-cld-puimr4zjusn646fbl9zvgdgbq9/org_qvrjku61be1xl1ebynlg5bzvge/cld_pu</span>\n",
-       "<span style=\"color: #008000; text-decoration-color: #008000\">imr4zjusn646fbl9zvgdgbq9/datasets/dataset_tjvg63t3vqnk28sfhu4ew4izw3/1/32_000000_000000.json'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">version</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">num_versions</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">created_at</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2024</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">9</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">17</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">31</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">16</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">308849</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">tzlocal</span><span style=\"font-weight: bold\">())</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">creator_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'usr_buxzyw3dyfbvl5cxyb51mjsg4w'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">project_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'prj_qc1twugbhy9mfegbcz7yw9ny3p'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">cloud_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'cld_puimr4zjusn646fbl9zvgdgbq9'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">storage_uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ld</span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">m5ez4edlp7yh4yiakp2u294w/datasets/dataset_f6e7855eyiy2xup9q2nqcm8tk9/5/32_000000_000000.json'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">version</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">num_versions</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">created_at</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2024</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">10</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">19</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">43</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">39</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">308730</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">tzlocal</span><span style=\"font-weight: bold\">())</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">creator_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'usr_2j3rrmjkqlx7wrlecsz273hcaq'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">project_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'prj_f4ldjckyhzxgtlr6c26d3e223x'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">cloud_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'cld_ldm5ez4edlp7yh4yiakp2u294w'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">description</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
        "<span style=\"font-weight: bold\">)</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[1;35mDataset\u001b[0m\u001b[1m(\u001b[0m\n",
-       "    \u001b[33mid\u001b[0m=\u001b[32m'dataset_tjvg63t3vqnk28sfhu4ew4izw3'\u001b[0m,\n",
+       "    \u001b[33mid\u001b[0m=\u001b[32m'dataset_f6e7855eyiy2xup9q2nqcm8tk9'\u001b[0m,\n",
        "    \u001b[33mname\u001b[0m=\u001b[32m'viggo/val.jsonl'\u001b[0m,\n",
        "    \u001b[33mfilename\u001b[0m=\u001b[32m'32_000000_000000.json'\u001b[0m,\n",
-       "    \u001b[33mstorage_uri\u001b[0m=\u001b[32m's3://anyscale-production-data-cld-puimr4zjusn646fbl9zvgdgbq9/org_qvrjku61be1xl1ebynlg5bzvge/cld_pu\u001b[0m\n",
-       "\u001b[32mimr4zjusn646fbl9zvgdgbq9/datasets/dataset_tjvg63t3vqnk28sfhu4ew4izw3/1/32_000000_000000.json'\u001b[0m,\n",
-       "    \u001b[33mversion\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "    \u001b[33mnum_versions\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "    \u001b[33mcreated_at\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2024\u001b[0m, \u001b[1;36m9\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m17\u001b[0m, \u001b[1;36m31\u001b[0m, \u001b[1;36m16\u001b[0m, \u001b[1;36m308849\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mtzlocal\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
-       "    \u001b[33mcreator_id\u001b[0m=\u001b[32m'usr_buxzyw3dyfbvl5cxyb51mjsg4w'\u001b[0m,\n",
-       "    \u001b[33mproject_id\u001b[0m=\u001b[32m'prj_qc1twugbhy9mfegbcz7yw9ny3p'\u001b[0m,\n",
-       "    \u001b[33mcloud_id\u001b[0m=\u001b[32m'cld_puimr4zjusn646fbl9zvgdgbq9'\u001b[0m,\n",
+       "    \u001b[33mstorage_uri\u001b[0m=\u001b[32m's3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ld\u001b[0m\n",
+       "\u001b[32mm5ez4edlp7yh4yiakp2u294w/datasets/dataset_f6e7855eyiy2xup9q2nqcm8tk9/5/32_000000_000000.json'\u001b[0m,\n",
+       "    \u001b[33mversion\u001b[0m=\u001b[1;36m5\u001b[0m,\n",
+       "    \u001b[33mnum_versions\u001b[0m=\u001b[1;36m5\u001b[0m,\n",
+       "    \u001b[33mcreated_at\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2024\u001b[0m, \u001b[1;36m10\u001b[0m, \u001b[1;36m3\u001b[0m, \u001b[1;36m19\u001b[0m, \u001b[1;36m43\u001b[0m, \u001b[1;36m39\u001b[0m, \u001b[1;36m308730\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mtzlocal\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mcreator_id\u001b[0m=\u001b[32m'usr_2j3rrmjkqlx7wrlecsz273hcaq'\u001b[0m,\n",
+       "    \u001b[33mproject_id\u001b[0m=\u001b[32m'prj_f4ldjckyhzxgtlr6c26d3e223x'\u001b[0m,\n",
+       "    \u001b[33mcloud_id\u001b[0m=\u001b[32m'cld_ldm5ez4edlp7yh4yiakp2u294w'\u001b[0m,\n",
        "    \u001b[33mdescription\u001b[0m=\u001b[3;35mNone\u001b[0m\n",
        "\u001b[1m)\u001b[0m\n"
       ]
@@ -727,9 +750,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:31:17,171\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-09-12_17-21-47_756836_2485/logs/ray-data\n",
-      "2024-09-12 17:31:17,172\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[Write]\n"
+      "2024-10-03 19:43:40,505\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-10-03_19-40-56_737796_2248/logs/ray-data\n",
+      "2024-10-03 19:43:40,506\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[Map(to_schema)] -> AllToAllOperator[Repartition] -> TaskPoolMapOperator[Write]\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d22b255809174b0081b5bce821703610",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
@@ -784,34 +821,34 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Dataset</span><span style=\"font-weight: bold\">(</span>\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'dataset_8ixed8qh7wisppn6plpna272e2'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'dataset_lrqggz6xdm99qvwns5qiirdusi'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'viggo/test.jsonl'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">filename</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'36_000000_000000.json'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">storage_uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'s3://anyscale-production-data-cld-puimr4zjusn646fbl9zvgdgbq9/org_qvrjku61be1xl1ebynlg5bzvge/cld_pu</span>\n",
-       "<span style=\"color: #008000; text-decoration-color: #008000\">imr4zjusn646fbl9zvgdgbq9/datasets/dataset_8ixed8qh7wisppn6plpna272e2/1/36_000000_000000.json'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">version</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">num_versions</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">created_at</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2024</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">9</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">12</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">17</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">31</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">18</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">26626</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">tzlocal</span><span style=\"font-weight: bold\">())</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">creator_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'usr_buxzyw3dyfbvl5cxyb51mjsg4w'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">project_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'prj_qc1twugbhy9mfegbcz7yw9ny3p'</span>,\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">cloud_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'cld_puimr4zjusn646fbl9zvgdgbq9'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">storage_uri</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ld</span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">m5ez4edlp7yh4yiakp2u294w/datasets/dataset_lrqggz6xdm99qvwns5qiirdusi/5/36_000000_000000.json'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">version</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">num_versions</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">created_at</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">datetime</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">.datetime</span><span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2024</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">10</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">19</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">43</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">41</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">289363</span>, <span style=\"color: #808000; text-decoration-color: #808000\">tzinfo</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">tzlocal</span><span style=\"font-weight: bold\">())</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">creator_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'usr_2j3rrmjkqlx7wrlecsz273hcaq'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">project_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'prj_f4ldjckyhzxgtlr6c26d3e223x'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">cloud_id</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'cld_ldm5ez4edlp7yh4yiakp2u294w'</span>,\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">description</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
        "<span style=\"font-weight: bold\">)</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[1;35mDataset\u001b[0m\u001b[1m(\u001b[0m\n",
-       "    \u001b[33mid\u001b[0m=\u001b[32m'dataset_8ixed8qh7wisppn6plpna272e2'\u001b[0m,\n",
+       "    \u001b[33mid\u001b[0m=\u001b[32m'dataset_lrqggz6xdm99qvwns5qiirdusi'\u001b[0m,\n",
        "    \u001b[33mname\u001b[0m=\u001b[32m'viggo/test.jsonl'\u001b[0m,\n",
        "    \u001b[33mfilename\u001b[0m=\u001b[32m'36_000000_000000.json'\u001b[0m,\n",
-       "    \u001b[33mstorage_uri\u001b[0m=\u001b[32m's3://anyscale-production-data-cld-puimr4zjusn646fbl9zvgdgbq9/org_qvrjku61be1xl1ebynlg5bzvge/cld_pu\u001b[0m\n",
-       "\u001b[32mimr4zjusn646fbl9zvgdgbq9/datasets/dataset_8ixed8qh7wisppn6plpna272e2/1/36_000000_000000.json'\u001b[0m,\n",
-       "    \u001b[33mversion\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "    \u001b[33mnum_versions\u001b[0m=\u001b[1;36m1\u001b[0m,\n",
-       "    \u001b[33mcreated_at\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2024\u001b[0m, \u001b[1;36m9\u001b[0m, \u001b[1;36m12\u001b[0m, \u001b[1;36m17\u001b[0m, \u001b[1;36m31\u001b[0m, \u001b[1;36m18\u001b[0m, \u001b[1;36m26626\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mtzlocal\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
-       "    \u001b[33mcreator_id\u001b[0m=\u001b[32m'usr_buxzyw3dyfbvl5cxyb51mjsg4w'\u001b[0m,\n",
-       "    \u001b[33mproject_id\u001b[0m=\u001b[32m'prj_qc1twugbhy9mfegbcz7yw9ny3p'\u001b[0m,\n",
-       "    \u001b[33mcloud_id\u001b[0m=\u001b[32m'cld_puimr4zjusn646fbl9zvgdgbq9'\u001b[0m,\n",
+       "    \u001b[33mstorage_uri\u001b[0m=\u001b[32m's3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ld\u001b[0m\n",
+       "\u001b[32mm5ez4edlp7yh4yiakp2u294w/datasets/dataset_lrqggz6xdm99qvwns5qiirdusi/5/36_000000_000000.json'\u001b[0m,\n",
+       "    \u001b[33mversion\u001b[0m=\u001b[1;36m5\u001b[0m,\n",
+       "    \u001b[33mnum_versions\u001b[0m=\u001b[1;36m5\u001b[0m,\n",
+       "    \u001b[33mcreated_at\u001b[0m=\u001b[1;35mdatetime\u001b[0m\u001b[1;35m.datetime\u001b[0m\u001b[1m(\u001b[0m\u001b[1;36m2024\u001b[0m, \u001b[1;36m10\u001b[0m, \u001b[1;36m3\u001b[0m, \u001b[1;36m19\u001b[0m, \u001b[1;36m43\u001b[0m, \u001b[1;36m41\u001b[0m, \u001b[1;36m289363\u001b[0m, \u001b[33mtzinfo\u001b[0m=\u001b[1;35mtzlocal\u001b[0m\u001b[1m(\u001b[0m\u001b[1m)\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "    \u001b[33mcreator_id\u001b[0m=\u001b[32m'usr_2j3rrmjkqlx7wrlecsz273hcaq'\u001b[0m,\n",
+       "    \u001b[33mproject_id\u001b[0m=\u001b[32m'prj_f4ldjckyhzxgtlr6c26d3e223x'\u001b[0m,\n",
+       "    \u001b[33mcloud_id\u001b[0m=\u001b[32m'cld_ldm5ez4edlp7yh4yiakp2u294w'\u001b[0m,\n",
        "    \u001b[33mdescription\u001b[0m=\u001b[3;35mNone\u001b[0m\n",
        "\u001b[1m)\u001b[0m\n"
       ]
@@ -828,7 +865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "db6cceaa",
    "metadata": {},
    "outputs": [],
@@ -843,7 +880,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "e573ddac",
    "metadata": {},
    "outputs": [
@@ -851,15 +888,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-09-12 17:31:37,615\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-09-12_17-21-47_756836_2485/logs/ray-data\n",
-      "2024-09-12 17:31:37,616\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[ExpandPaths] -> TaskPoolMapOperator[ReadFiles] -> LimitOperator[limit=1]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "(ExpandPaths pid=8823) Failed to interpret messages as multi-dimensional arrays. It will be pickled.\n"
+      "2024-10-03 19:43:43,609\tINFO streaming_executor.py:108 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-10-03_19-40-56_737796_2248/logs/ray-data\n",
+      "2024-10-03 19:43:43,609\tINFO streaming_executor.py:109 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[ExpandPaths] -> TaskPoolMapOperator[ReadFiles] -> LimitOperator[limit=1]\n"
      ]
     },
     {
@@ -873,7 +903,7 @@
        "    'role': 'assistant'}]}]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -924,7 +954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "e077dbc4",
    "metadata": {},
    "outputs": [
@@ -932,46 +962,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "model_id: meta-llama/Meta-Llama-3-8B-Instruct # <-- change this to the model you want to fine-tune\n",
-      "train_path: s3://llm-guide/data/viggo/train.jsonl # <-- change this to the path to your training data\n",
-      "valid_path: s3://llm-guide/data/viggo/val.jsonl # <-- change this to the path to your validation data. This is optional\n",
-      "context_length: 512 # <-- change this to the context length you want to use\n",
-      "num_devices: 16 # <-- change this to total number of GPUs that you want to use\n",
-      "num_epochs: 4 # <-- change this to the number of epochs that you want to train for\n",
-      "train_batch_size_per_device: 16\n",
-      "eval_batch_size_per_device: 16\n",
-      "learning_rate: 1e-4\n",
-      "padding: \"longest\" # This will pad batches to the longest sequence. Use \"max_length\" when profiling to profile the worst case.\n",
-      "num_checkpoints_to_keep: 1\n",
+      "context_length: 512\n",
       "dataset_size_scaling_factor: 10000\n",
-      "output_dir: /mnt/local_storage\n",
       "deepspeed:\n",
       "  config_path: configs/deepspeed/zero_3_offload_optim+param.json\n",
-      "dataset_size_scaling_factor: 10000 # internal flag. No need to change\n",
+      "eval_batch_size_per_device: 16\n",
       "flash_attention_2: true\n",
-      "trainer_resources:\n",
-      "  memory: 53687091200 # 50 GB memory\n",
-      "worker_resources:\n",
-      "  accelerator_type:A10G: 0.001\n",
+      "learning_rate: 1e-4\n",
       "lora_config:\n",
-      "  r: 8\n",
+      "  bias: none\n",
+      "  fan_in_fan_out: false\n",
+      "  init_lora_weights: true\n",
       "  lora_alpha: 16\n",
       "  lora_dropout: 0.05\n",
-      "  target_modules:\n",
-      "    - q_proj\n",
-      "    - v_proj\n",
-      "    - k_proj\n",
-      "    - o_proj\n",
-      "    - gate_proj\n",
-      "    - up_proj\n",
-      "    - down_proj\n",
-      "    - embed_tokens\n",
-      "    - lm_head\n",
-      "  task_type: \"CAUSAL_LM\"\n",
       "  modules_to_save: []\n",
-      "  bias: \"none\"\n",
-      "  fan_in_fan_out: false\n",
-      "  init_lora_weights: true\n"
+      "  r: 8\n",
+      "  target_modules:\n",
+      "  - q_proj\n",
+      "  - v_proj\n",
+      "  - k_proj\n",
+      "  - o_proj\n",
+      "  - gate_proj\n",
+      "  - up_proj\n",
+      "  - down_proj\n",
+      "  - embed_tokens\n",
+      "  - lm_head\n",
+      "  task_type: CAUSAL_LM\n",
+      "model_id: meta-llama/Meta-Llama-3-8B-Instruct\n",
+      "num_checkpoints_to_keep: 1\n",
+      "num_devices: 16\n",
+      "num_epochs: 4\n",
+      "output_dir: /mnt/local_storage\n",
+      "padding: longest\n",
+      "train_batch_size_per_device: 16\n",
+      "train_path: s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/datasets/dataset_rbla1vkqejfdclhme8fcdf5926/5/28_000000_000000.json\n",
+      "trainer_resources:\n",
+      "  memory: 53687091200\n",
+      "valid_path: s3://anyscale-production-data-cld-ldm5ez4edlp7yh4yiakp2u294w/org_4snvy99zwbmh4gbtk64jfqggmj/cld_ldm5ez4edlp7yh4yiakp2u294w/datasets/dataset_f6e7855eyiy2xup9q2nqcm8tk9/5/32_000000_000000.json\n",
+      "worker_resources:\n",
+      "  accelerator_type:A10G: 0.001\n"
      ]
     }
    ],
@@ -1012,7 +1041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "85db636c",
    "metadata": {},
    "outputs": [
@@ -1063,7 +1092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "955632e3",
    "metadata": {},
    "outputs": [],
@@ -1074,7 +1103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "0c5684aa",
    "metadata": {},
    "outputs": [
@@ -1082,9 +1111,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "(anyscale +17m7.0s) Uploading local dir '.' to cloud storage.\n",
-      "(anyscale +17m8.7s) Job 'e2e-llm-workflows' submitted, ID: 'prodjob_q1tzjcngnrwrp2yzpnbh4v7n8w'.\n",
-      "(anyscale +17m8.7s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_q1tzjcngnrwrp2yzpnbh4v7n8w\n"
+      "(anyscale +17.2s) Uploading local dir '.' to cloud storage.\n",
+      "(anyscale +18.5s) Job 'e2e-llm-workflows' submitted, ID: 'prodjob_3753ch6c1bry6mgt7gyj2km9np'.\n",
+      "(anyscale +18.5s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_3753ch6c1bry6mgt7gyj2km9np\n"
      ]
     }
    ],
@@ -1192,7 +1221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5270b731",
    "metadata": {},
    "outputs": [],
@@ -1202,7 +1231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "8e041050",
    "metadata": {},
    "outputs": [],
@@ -2204,7 +2233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In https://github.com/anyscale/templates/commit/e635e7a98b0515aa45fba1bfb600f21877abb236, An unpinned `pip install -U anyscale` was added which broke after a later anyscale package release. 


The new endpoints image already comes with the latest anyscale installation so we can remove this now

