### PR TITLE
[maketmpl] stub a readme markdown file

### DIFF
--- a/ci/maketmpl/README.md
+++ b/ci/maketmpl/README.md
@@ -1,0 +1,1 @@
+Go language library for building and releasing templates for Anyscale.


### PR DESCRIPTION
so that github will not pick up and show the `readme.go` file instead when browsing this directory.