### PR TITLE
[ft-template] remove stage3_prefetch_bucket_size 'auto' values since this is no longer supported

### DIFF
--- a/templates/fine-tune-llm_v2/deepspeed_configs/zero_3_hpz.json
+++ b/templates/fine-tune-llm_v2/deepspeed_configs/zero_3_hpz.json
@@ -11,7 +11,7 @@
       "contiguous_gradients": true,
       "reduce_bucket_size": "auto",
       "zero_hpz_partition_size": 8,
-      "stage3_prefetch_bucket_size": "auto",
+      "stage3_prefetch_bucket_size": 5e8,
       "stage3_param_persistence_threshold": "auto",
       "gather_16bit_weights_on_model_save": true,
       "round_robin_gradients": true

--- a/templates/fine-tune-llm_v2/deepspeed_configs/zero_3_offload_optim.json
+++ b/templates/fine-tune-llm_v2/deepspeed_configs/zero_3_offload_optim.json
@@ -14,7 +14,7 @@
     "overlap_comm": true,
     "contiguous_gradients": true,
     "reduce_bucket_size": "auto",
-    "stage3_prefetch_bucket_size": "auto",
+    "stage3_prefetch_bucket_size": 5e8,
     "stage3_param_persistence_threshold": "auto",
     "gather_16bit_weights_on_model_save": true,
     "round_robin_gradients": true


### PR DESCRIPTION
since we're updating deepspeed version in https://github.com/anyscale/llm-forge/pull/511, need to update defaults that are no longer supported