### PR TITLE
Clarify service URLs and remove unused auth token

### DIFF
--- a/templates/endpoints_v2/README.ipynb
+++ b/templates/endpoints_v2/README.ipynb
@@ -113,7 +113,7 @@
     "# TODO: Replace this model ID with your own.\n",
     "MODEL_ID = \"mistralai/Mistral-7B-Instruct-v0.1\"\n",
     "\n",
-    "def query(base_url: str, api_key: str):\n",
+    "def query(base_url: str, api_key: str = \"notarealapikey\"):\n",
     "    if not base_url.endswith(\"/\"):\n",
     "        base_url += \"/\"\n",
     "    \n",
@@ -200,7 +200,7 @@
     "\n",
     "## Step 5 - Query the service endpoint\n",
     "\n",
-    "The above command should print something like `(anyscale +2.9s) curl -H 'Authorization: Bearer XXXXXXXXX_XXXXXX-XXXXXXXXXXXX' https://YYYYYYYYYYYY.anyscaleuserdata.com`, which contains information you need to query the service.\n",
+    "The above command should print something like `(anyscale +2.9s) curl https://YYYYYYYYYYYY.anyscaleuserdata.com`, which contains the URL you need to query the service.\n",
     "\n",
     "You can also find this information by clicking the \"Query\" button in the Service UI.\n",
     "\n",
@@ -216,9 +216,18 @@
     "# Query the remote serve application we just deployed.\n",
     "\n",
     "service_url = \"https://YYYYYYYYYYYYY.anyscaleuserdata.com\"  # FILL ME IN\n",
-    "service_bearer_token = \"XXXXXXXXXX_XXXXXXX-XXXXXXXXXXXXXX\"  # FILL ME IN\n",
+    "query(service_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case you don't want to use the function above, make sure you use the appropriate API endpoint for the query:\n",
     "\n",
-    "query(service_url, service_bearer_token)"
+    "```\n",
+    "https://YYYYYYYYYYYYY.anyscaleuserdata.com/v1/chat/completions\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
The auth token doesn't seem to be necessary to actually query the service. I've also added a line that makes explicit which API endpoint is being used.