### PR TITLE
Change hyperlink for llmforge to docs instead of versions table

### DIFF
--- a/templates/fine-tune-llm_v2/README.ipynb
+++ b/templates/fine-tune-llm_v2/README.ipynb
@@ -9,7 +9,7 @@
     "**⏱️ Time to complete**: ~3 hours (includes the time for training the model)\n",
     "\n",
     "\n",
-    "This template comes with a installed library for training LLMs on Anyscale called [LLMForge](https://docs.anyscale.com/reference/llmforge-versions). It provides the fastest way to try out training LLMs with Ray on Anyscale. You can read more about this library and its features in the [docs](https://docs.anyscale.com/llms/finetuning/intro). For learning on how to serve the model online or offline for doing batch inference you can refer to the [serving template](https://console.anyscale.com/v2/template-preview/endpoints_v2) or the [offline batch inference template](https://console.anyscale.com/v2/template-preview/batch-llm), respecitvely.\n"
+    "This template comes with a installed library for training LLMs on Anyscale called [LLMForge](https://docs.anyscale.com/llms/finetuning/intro). It provides the fastest way to try out training LLMs with Ray on Anyscale. You can read more about this library and its features in the [docs](https://docs.anyscale.com/llms/finetuning/intro). For learning on how to serve the model online or offline for doing batch inference you can refer to the [serving template](https://console.anyscale.com/v2/template-preview/endpoints_v2) or the [offline batch inference template](https://console.anyscale.com/v2/template-preview/batch-llm), respecitvely.\n"
    ]
   },
   {

--- a/templates/fine-tune-llm_v2/README.md
+++ b/templates/fine-tune-llm_v2/README.md
@@ -3,7 +3,7 @@
 **⏱️ Time to complete**: ~3 hours (includes the time for training the model)
 
 
-This template comes with a installed library for training LLMs on Anyscale called [LLMForge](https://docs.anyscale.com/reference/llmforge-versions). It provides the fastest way to try out training LLMs with Ray on Anyscale. You can read more about this library and its features in the [docs](https://docs.anyscale.com/llms/finetuning/intro). For learning on how to serve the model online or offline for doing batch inference you can refer to the [serving template](https://console.anyscale.com/v2/template-preview/endpoints_v2) or the [offline batch inference template](https://console.anyscale.com/v2/template-preview/batch-llm), respecitvely.
+This template comes with a installed library for training LLMs on Anyscale called [LLMForge](https://docs.anyscale.com/llms/finetuning/intro). It provides the fastest way to try out training LLMs with Ray on Anyscale. You can read more about this library and its features in the [docs](https://docs.anyscale.com/llms/finetuning/intro). For learning on how to serve the model online or offline for doing batch inference you can refer to the [serving template](https://console.anyscale.com/v2/template-preview/endpoints_v2) or the [offline batch inference template](https://console.anyscale.com/v2/template-preview/batch-llm), respecitvely.
 
 
 ## Getting Started


### PR DESCRIPTION
# What does this PR do?

Tiny PR to fix a hyperlink. `LLMForge` should point to the intro page in the docs rather than the versions table. 