### PR TITLE
Add workaround for broken `from_huggingface` call

### DIFF
--- a/templates/ray-data-llm/README.ipynb
+++ b/templates/ray-data-llm/README.ipynb
@@ -40,7 +40,7 @@
    "outputs": [],
    "source": [
     "# Install datasets library.\n",
-    "!pip install datasets"
+    "!pip install \"datasets<4\""
    ]
   },
   {
@@ -49,15 +49,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from huggingface_hub import HfFileSystem\n",
+    "\n",
     "import ray \n",
-    "import datasets\n",
     "\n",
     "# Load the dataset from Hugging Face into Ray Data. Refer to Ray Data APIs\n",
     "# https://docs.ray.io/en/latest/data/api/input_output.html for details.\n",
     "# For example, you can use ray.data.read_json(dataset_file) to load dataset in JSONL.\n",
-    "\n",
-    "df = datasets.load_dataset(\"cnn_dailymail\", \"3.0.0\")\n",
-    "ds = ray.data.from_huggingface(df[\"train\"])\n"
+    "ds = ray.data.read_parquet(\n",
+    "    \"hf://datasets/cnn_dailymail\", \n",
+    "    file_extensions=[\"parquet\"], \n",
+    "    filesystem=HfFileSystem()\n",
+    ")"
    ]
   },
   {

--- a/templates/ray-data-llm/README.md
+++ b/templates/ray-data-llm/README.md
@@ -26,21 +26,23 @@ Ray Data LLM runs batch inference for LLMs on Ray Data datasets. This tutorial r
 
 ```python
 # Install datasets library.
-!pip install datasets
+!pip install "datasets<4"
 ```
 
 
 ```python
+from huggingface_hub import HfFileSystem
+
 import ray 
-import datasets
 
 # Load the dataset from Hugging Face into Ray Data. Refer to Ray Data APIs
 # https://docs.ray.io/en/latest/data/api/input_output.html for details.
 # For example, you can use ray.data.read_json(dataset_file) to load dataset in JSONL.
-
-df = datasets.load_dataset("cnn_dailymail", "3.0.0")
-ds = ray.data.from_huggingface(df["train"])
-
+ds = ray.data.read_parquet(
+    "hf://datasets/cnn_dailymail", 
+    file_extensions=["parquet"], 
+    filesystem=HfFileSystem()
+)
 ```
 
 ## Step 2: Define the processor config for the vLLM engine


### PR DESCRIPTION
`from_huggingface` can occasionally fail due to https://github.com/ray-project/ray/issues/54101.

This PR updates the template to read the dataset in a different way to prevent the issue.