### PR TITLE
[data][llm] Limit input data size to 10k

### DIFF
--- a/templates/ray-data-llm/README.ipynb
+++ b/templates/ray-data-llm/README.ipynb
@@ -196,7 +196,7 @@
     "    postprocess=postprocess,\n",
     ")\n",
     "\n",
-    "processed_ds = processor(ds)\n",
+    "processed_ds = processor(ds.limit(10_000))\n",
     "# Materialize the dataset to memory. User can also use writing APIs like\n",
     "# `write_parquet`(https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.write_parquet.html#ray.data.Dataset.write_parquet)\n",
     "# `write_csv`(https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.write_csv.html#ray.data.Dataset.write_csv)\n",

--- a/templates/ray-data-llm/README.md
+++ b/templates/ray-data-llm/README.md
@@ -143,7 +143,7 @@ processor = build_llm_processor(
     postprocess=postprocess,
 )
 
-processed_ds = processor(ds)
+processed_ds = processor(ds.limit(10_000))
 # Materialize the dataset to memory. User can also use writing APIs like
 # `write_parquet`(https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.write_parquet.html#ray.data.Dataset.write_parquet)
 # `write_csv`(https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.write_csv.html#ray.data.Dataset.write_csv)


### PR DESCRIPTION
Issue: https://github.com/anyscale/templates/issues/442

At the moment the processing rate is ~5 rows/s, so processing 1.44M rows will take 80 hours. Limiting it to 10k rows lowers processing time to ~0.5 hours, which is better UX.