### PR TITLE
[DNM] updating image for model-multiplexing

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -73,7 +73,7 @@
 - name: model-multiplexing
   dir: templates/model-multiplexing-forecast
   cluster_env:
-    image_uri: anyscale/ray:2.53.0-slim-py312-cu129
+    build_id: anyscaleray2530-slim-py312-cu129
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml


### PR DESCRIPTION
Reverting to build_id temporarily before product deployment accepts image_uri instead of build_id


Deployed to stage and tested: https://buildkite.com/anyscale/tmpl-publish/builds/204#
<img width="1690" height="899" alt="image" src="https://github.com/user-attachments/assets/c756efc0-54d6-435d-b850-461c21e361cf" />
