### PR TITLE
Bump template-test buildkite timeout to 75 min

### DIFF
--- a/.buildkite/pipeline.template-test.yaml
+++ b/.buildkite/pipeline.template-test.yaml
@@ -16,7 +16,7 @@ steps:
       sudo apt-get update && sudo apt-get install -y rsync
       sudo pip install anyscale==0.26.87
       ./rayapp test $$TEMPLATE_NAME
-    timeout_in_minutes: 20
+    timeout_in_minutes: 75
     agents:
       queue: small
     retry:


### PR DESCRIPTION
## Summary
- Raise `timeout_in_minutes` in `.buildkite/pipeline.template-test.yaml` from 20 to 75.

## Why
Several templates declare inner test timeouts in BUILD.yaml longer than 20 min (e.g. `unstructured_data_ingestion: 1500s`, `entity-recognition-with-llms: 3600s`) and rayapp enforces those via \`timeout(1)\`. The outer buildkite step was capped at 20 min, so it killed those tests before the inner timeout could even trigger. Builds #71 (unstructured) and the entity-recognition run both failed due to this.

75 min covers the current longest \`timeout_in_sec\` (3600) plus headroom for docker pull (~30s), workspace provisioning (~90s), push/unzip (~30s), and cleanup.

## Test plan
- [ ] Merge, then re-comment `/test-template unstructured_data_ingestion` on #583 and `/test-template entity-recognition-with-llms` on #573; verify the builds run past 20 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)