### PR TITLE
Add /template skill, Cursor agent env, AGENTS.md

### DIFF
--- a/.claude/skills/template/SKILL.md
+++ b/.claude/skills/template/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: template
+description: Work with Anyscale console templates. Covers maintenance (Ray version bumps), formatting (repo conventions), and publishing (S3 via Buildkite). Use for any BUILD.yaml edit, image bump, or template lifecycle task.
+---
+
+# Template skill
+
+Read the reference matching your task:
+
+- **How to update** a template to a specific Ray release → `references/update.md`
+- **How to format** a template to repo conventions → `references/format.md`
+- **How to publish** a template to dev/staging/production (S3 via Buildkite) → `references/publish.md`
+- **Recognize the different image URI cases** (stock / custom-GCP / third-party) → `references/image-cases.md`
+- **How to publish Custom image to our GCP artifact registry** → `references/custom-image-publishing.md`
+- **How to reproduce CI test locally** (rayapp setup) → `references/local-testing.md`
+- **BUILD.yaml schema guidance** lookup → `references/build-yaml-schema.yaml`
+- **Compute config schema guidance** lookup → `references/compute-config-schema.yaml`

--- a/.claude/skills/template/references/build-yaml-schema.yaml
+++ b/.claude/skills/template/references/build-yaml-schema.yaml
@@ -1,0 +1,58 @@
+# BUILD.yaml Entry Schema
+#
+# Each entry in BUILD.yaml is a list item defining a template.
+# The file is parsed as a YAML list of Template objects.
+#
+# Template names must match: ^[a-zA-Z0-9][a-zA-Z0-9_-]*$
+
+# --- Full schema with all fields ---
+
+- name: <template-name>          # REQUIRED. Unique identifier. Appears in console URL.
+  dir: templates/<dir-name>      # REQUIRED. Path to template content (relative to repo root).
+
+  # REQUIRED. Exactly one of: image_uri, build_id, or byod.
+  cluster_env:
+    # Option 1: Stock Anyscale image
+    image_uri: anyscale/ray:2.54.1-py312-cu128
+
+    # Option 2: BYOD (Bring Your Own Docker)
+    # Set docker_image to the GCP Artifact Registry URI of the built image URI from `anyscale image build`.
+    # ray_version must be the same as the version used to build the image.
+    # byod:
+    #   docker_image: us-docker.pkg.dev/anyscale-workspace-templates/workspace-templates/<image-name>:<ray-version>
+    #   ray_version: <ray-version>
+
+    # Option 3: BYOD from an external (third-party) registry
+    # docker_image points to an external registry that we do not own or rebuild.
+    # When bumping Ray, keep the same repo and tag pattern — pick the latest available tag with the highest Ray version.
+    # Do NOT swap to anyscale/ray. ray_version must match the Ray version embedded in the upstream tag.
+    # byod:
+    #   docker_image: <registry>/<image-name>      # e.g. novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8
+    #   ray_version: <ray-version>                 # Infer from the image's metadata/Dockerfile
+
+  # REQUIRED. Map of cloud provider to compute config file path.
+  compute_config:
+    AWS: configs/<config-dir>/aws.yaml
+    GCP: configs/<config-dir>/gce.yaml
+
+  # REQUIRED.
+  test:
+    command: bash tests.sh            # REQUIRED.
+    tests_path: tests/<name>/         # REQUIRED. Relative path (no absolute, no "..").
+    timeout_in_sec: 900               # REQUIRED. Default: 3600. Must be non-negative.
+
+# --- Image URI conventions ---
+#
+# Format: anyscale/<base>:<ray-version>-<variant>-<python>-<cuda>
+#
+# Base images. Must be one of the following:
+#   anyscale/ray          - Standard Ray image
+#   anyscale/ray-llm      - Ray + LLM serving dependencies
+#
+# Common variants:
+#   anyscale/ray:<ray-version>-py312-cu128          - Full GPU image
+#   anyscale/ray:<ray-version>-slim-py312-cu128     - Slim GPU image
+#   anyscale/ray:<ray-version>-py311                - CPU-only image
+#   anyscale/ray-llm:<ray-version>-py311-cu128      - LLM serving image
+#
+# See: https://docs.anyscale.com/reference/base-images

--- a/.claude/skills/template/references/compute-config-schema.yaml
+++ b/.claude/skills/template/references/compute-config-schema.yaml
@@ -1,0 +1,76 @@
+# Compute Config Schema (Legacy API format)
+#
+# These YAML files live under configs/<template-name>/{aws,gce}.yaml
+# They use the LEGACY compute config format (not the workspace_v2 CLI format).
+#
+# IMPORTANT: Omit fields that match their default value. Only include what you
+# actually need to override. This keeps configs minimal and avoids confusion
+# about which values are intentional vs just restating defaults.
+
+# --- Full schema (with defaults noted) ---
+
+head_node_type:                        # REQUIRED
+  name: head                           # REQUIRED. Node type name.
+  instance_type: m5.2xlarge            # Optional. Cloud instance type.
+  resources:                           # Optional. Only include to override defaults.
+    cpu: 0                             #   Default: auto-detected. Set 0 to exclude from scheduling.
+    gpu: 0                             #   Default: auto-detected. Set 0 to exclude from scheduling.
+    # memory: 0                        #   Default: auto-detected.
+    # object_store_memory: 0           #   Default: auto-detected.
+    # custom_resources: {}             #   Default: empty.
+  # required_resources: {}             # Optional. Default: none. Omit if not needed.
+  # labels: {}                         # Optional. Default: empty. Omit if not needed.
+  # required_labels: {}                # Optional. Default: empty. Omit if not needed.
+  # flags: {}                          # Optional. Default: empty. Omit if not needed.
+  # aws_advanced_configurations_json: {}  # Omit unless needed.
+  # gcp_advanced_configurations_json: {}  # Omit unless needed.
+
+worker_node_types:                     # Default: []. Omit or use [] if auto_select_worker_config is true.
+  - name: gpu-worker                   # REQUIRED per worker type.
+    instance_type: g4dn.12xlarge       # Optional. Cloud instance type.
+    min_workers: 2                     # Optional. Default: 0. Omit if 0.
+    max_workers: 2                     # Optional. Default: 0. Omit if 0.
+    # use_spot: false                  # Default: false. Omit unless true.
+    # fallback_to_ondemand: false      # Default: false. Omit unless true.
+    # resources: {}                    # Optional. Same as head_node_type.resources. Omit if auto-detected.
+    # required_resources: {}           # Optional. Omit if not needed.
+    # labels: {}                       # Optional. Omit if not needed.
+    # required_labels: {}              # Optional. Omit if not needed.
+    # flags: {}                        # Optional. Omit if not needed.
+
+auto_select_worker_config: true        # Default: false. Omit if false.
+                                       # When true, worker_node_types can be empty [].
+
+# flags: {}                            # Optional. Default: empty. Omit if not needed.
+#   allow-cross-zone-autoscaling: true # Common flag for multi-AZ scheduling.
+
+# --- Common patterns ---
+#
+# CPU-only single node (auto workers):
+#   head_node_type:
+#     name: head
+#     instance_type: m5.2xlarge        # AWS
+#     # instance_type: n2-standard-8   # GCP
+#   worker_node_types: []
+#   auto_select_worker_config: true
+#
+# GPU workers (explicit):
+#   head_node_type:
+#     name: head
+#     instance_type: m5.2xlarge
+#     resources: { cpu: 0, gpu: 0 }    # Head excluded from scheduling
+#   worker_node_types:
+#     - name: gpu-worker
+#       instance_type: g4dn.12xlarge
+#       min_workers: 2
+#       max_workers: 2
+#
+# AWS instance types commonly used:
+#   CPU: m5.2xlarge, m5.4xlarge
+#   GPU: g5.xlarge (1x A10G), g5.2xlarge (1x A10G), g6.2xlarge (1x L4),
+#        p4d.24xlarge (8x A100)
+#
+# GCP instance types commonly used:
+#   CPU: n2-standard-8, n2-standard-16
+#   GPU: g2-standard-8-nvidia-l4-1, g2-standard-12-nvidia-l4-1 (1x L4),
+#        a2-highgpu-1g-nvidia-a100-40gb-1 (1x A100)

--- a/.claude/skills/template/references/custom-image-publishing.md
+++ b/.claude/skills/template/references/custom-image-publishing.md
@@ -1,0 +1,31 @@
+# Publishing Custom Images to Anyscale Google Artifact Registry
+
+## Setup
+
+```bash
+export IMAGE_NAME=<image-name>        # e.g., template_deployment-serve-llm
+export RAY_VERSION=<X.Y.Z>            # e.g., 2.54.1
+export REGISTRY=us-docker.pkg.dev/anyscale-workspace-templates/workspace-templates
+```
+
+## Build and push
+
+```bash
+# Always use --platform linux/amd64 to match Anyscale VM architecture
+docker build --platform linux/amd64 -t $REGISTRY/$IMAGE_NAME:$RAY_VERSION .
+
+# Push (assumes docker is already authenticated with the registry)
+docker push $REGISTRY/$IMAGE_NAME:$RAY_VERSION
+```
+
+If the push fails with an authentication error, ask the user to authenticate:
+```bash
+# Interactive (dev machine):
+gcloud auth configure-docker us-docker.pkg.dev
+
+# Non-interactive (CI / service account):
+gcloud auth activate-service-account --key-file=<key.json>
+gcloud auth configure-docker us-docker.pkg.dev --quiet
+```
+
+Do NOT attempt to handle credentials yourself. If auth fails, stop and tell the user.

--- a/.claude/skills/template/references/format.md
+++ b/.claude/skills/template/references/format.md
@@ -1,0 +1,34 @@
+# Format a template to repo conventions
+
+Validate the specified template against the conventions below. If the template doesn't follow them, format it so it does.
+
+## Rules
+
+- **Only validate and format existing files.** If required files are missing (compute configs, test scripts, etc.), report what's missing and ask the user to add them — do NOT generate them yourself.
+- **Do not run tests.** This guide only checks formatting, not functionality.
+- **Minimal changes.** Only fix what doesn't follow conventions. Don't refactor or "improve" code.
+
+---
+
+## Repository Structure
+
+```
+templates/
+├── BUILD.yaml              # Template definitions
+├── templates/<dir>/        # Template content (code, notebooks, Dockerfiles)
+├── tests/<name>/           # Test scripts
+├── configs/<name>/         # Compute configs (AWS/GCP)
+└── .claude/skills/template/references/  # Schema docs
+```
+
+---
+
+## What to validate
+
+- **BUILD.yaml entry**: matches `build-yaml-schema.yaml`. A template must use either `image_uri` OR `byod` — never both. For image bumps, see `image-cases.md`.
+- **Compute configs**: present at `configs/<name>/aws.yaml` and `configs/<name>/gce.yaml`. Schema in `compute-config-schema.yaml`.
+- **Tests**: `tests/<name>/tests.sh` exists.
+
+⚠️ **Compute configs use the OLD API format**, NOT the new ComputeConfig API. ALWAYS use existing entries under `configs/` as reference. Do NOT refer to the anyscale docs — they only document the new schema.
+
+**If anything is missing**: report to the user, do NOT generate from scratch unless explicitly requested.

--- a/.claude/skills/template/references/image-cases.md
+++ b/.claude/skills/template/references/image-cases.md
@@ -1,0 +1,7 @@
+# Image URI cases
+
+Infer the case based on the current `BUILD.yaml` image URI:
+
+- **Anyscale base** (`image_uri: anyscale/ray:...`): bump `image_uri` to the new Ray version.
+- **Anyscale custom on GCP** (`byod.docker_image: us-docker.pkg.dev/...`): Bump the Dockerfile `FROM` to the new Ray version → `docker build + push` per `custom-image-publishing.md` → update `byod.docker_image` and `ray_version`. If CI later fails, `/fix` will iterate (via `anyscale image build` for fast dev) and we'll republish to GCP before the next CI run.
+- **Third-party** (e.g. `novaskyai/skyrl-train-ray-2.48.0-py3.12-cu12.8`): same repo, pick the latest available tag with the highest Ray version, update `byod.docker_image` and `ray_version`. Don't swap to `anyscale/ray`.

--- a/.claude/skills/template/references/local-testing.md
+++ b/.claude/skills/template/references/local-testing.md
@@ -1,0 +1,43 @@
+# Run tests locally
+
+Install rayapp and run a template's tests on your dev machine. Useful for validating changes before opening a PR or reproducing a CI failure.
+
+## Install rayapp
+
+The rayapp version used in CI is pinned in `download_rayapp.sh` at the repo root (source of truth). Use the same version locally:
+
+```bash
+# Linux: just run the repo's CI script
+bash download_rayapp.sh && sudo mv rayapp /usr/local/bin/
+
+# macOS / other: pull the version from download_rayapp.sh, swap the platform
+RAYAPP_VERSION=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' download_rayapp.sh)
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -sL "https://github.com/ray-project/rayci/releases/download/${RAYAPP_VERSION}/rayapp-${PLATFORM}" -o ~/.local/bin/rayapp && chmod +x ~/.local/bin/rayapp
+```
+
+## Set credentials
+
+```bash
+export ANYSCALE_CLI_TOKEN="$$(aws --region=us-west-2 secretsmanager get-secret-value --secret-id $$ANYSCALE_CLI_TOKEN_SECRET_NAME | jq -r .SecretString)"
+export ANYSCALE_HOST="https://console.anyscale-staging.com"
+pip install anyscale==0.26.87
+```
+
+If auth issues, stop here and ask user to provide valid authentication for the staging console.
+
+## Run a template's tests
+
+```bash
+rayapp test <template-name>
+```
+
+## How rayapp test works
+
+1. Creates a workspace using the BUILD.yaml image
+2. Copies `templates/<dir>/` and `tests/<name>/` into the workspace
+3. Runs `tests.sh` from the workspace root
+
+## Custom images (byod)
+
+Pre-build with `anyscale image build` and update BUILD.yaml's `byod.docker_image` before testing. When finished iterating, `docker push` to GCP per `custom-image-publishing.md` and update BUILD.yaml again with the GCP URI.

--- a/.claude/skills/template/references/publish.md
+++ b/.claude/skills/template/references/publish.md
@@ -1,0 +1,24 @@
+# Publish Template
+
+Publish a template to dev/staging/predeploy/production via the `anyscale/tmpl-publish` Buildkite pipeline.
+
+Use the Buildkite MCP. `<template-id>` must match the template's `name` in `BUILD.yaml`. If multiple templates are requested, run one independent flow per template in parallel.
+
+1. **Trigger build**: `org_slug=anyscale`, `pipeline_slug=tmpl-publish`, `branch=master`, `commit=HEAD`, `message=<template-id>`. Init runs ~10–60s.
+
+2. **Unblock `input-tmpl-name`** with fields:
+   - `tmpl-name=<template-id>`
+   - `tmpl-branch=main`
+   - `tmpl-commit=HEAD`
+
+3. Wait `build-template` (~2–3 min) AND `test-template` (~5–10 min, up to ~45–60 min for some templates) → passed. **Do not unblock any publish step unless `test-template` is passed.** If `test-template` fails, `retry_job` and wait again — retry at least once before giving up. Then **unblock `block-publish-dev`**.
+
+4. Wait `publish-dev` → passed (~3–5 min). **Unblock `block-publish-staging`**.
+
+5. Wait `publish-staging` → passed (~3–5 min). **Unblock `block-publish-production`**.
+
+6. Wait `publish-production` → passed (~3–5 min).
+
+## Updates
+
+For subsequent publishes of the same template, rebuild an existing build instead of step 1. Find it via `list_builds` filtered by `message=<template-id>`; canonical match is product commit `f2a547b88525845df7cf99636a420a0f5523ad07` + templates `main`. Steps 2–6 still apply.

--- a/.claude/skills/template/references/update.md
+++ b/.claude/skills/template/references/update.md
@@ -1,0 +1,61 @@
+# Update a template to a new Ray release
+
+Bump an Anyscale console template to a new Ray version. Opens a PR, validates via CI, iterates via `/fix` on failure.
+
+## Tasks
+
+Create at session start:
+
+1. `update-version` — Bump image (+ GCP publish if custom) and any version strings
+2. `open-pr` — Commit, push, open PR
+3. `validate-ci` — Comment `/test-template <id>` on PR, wait for CI
+4. `fix` — If CI fails, spawn `/fix`, push new commit, re-validate (cap 2 retries)
+5. `report` — Session report
+
+---
+
+## Step 1: Update version
+
+Get latest Ray version with `pip index versions ray`. Pick the right image case from `image-cases.md` and apply it to `BUILD.yaml`.
+
+Grep and update any remaining version strings in template code.
+
+## Step 2: Open PR
+
+1. Commit: `Update <template-name> to Ray <version>`
+2. Push to `update/<template-name>/ray-<version>`
+3. PR title: `[ray-update-<version>] Update <template-name> to Ray <version>`. Body: what changed and why.
+4. Apply the `ray-update` label.
+
+## Step 3: Validate via CI
+
+Comment `/test-template <template-id>` on the PR, wait for CI.
+
+- **PASSED** → Step 5
+- **FAILED** → Step 4
+
+## Step 4: Fix
+
+Spawn `/fix` subagent (explicitly authorized):
+
+```
+/fix templates/<template-name>
+
+CI failed on PR #<num>. <paste relevant CI error>
+
+Fix minimally — code, notebooks, Dockerfiles, configs. Don't touch BUILD.yaml (orchestrator owns it).
+Iterate until `tests/<template-name>/tests.sh` passes. For custom images, rebuild as needed (See `anyscale image build` CLI for fast iteration) and report the working URI and Dockerfile.
+Notes: .claude/.artifacts/<template-name>/update-ray-<version>/notes-fix-<timestamp-epoch>.md
+```
+
+After `/fix` returns:
+1. If a new image was built, `docker build + push` to GCP per `custom-image-publishing.md`; update BUILD.yaml `byod.docker_image` with the published URI.
+2. Follow instructions at `format.md` to normalize.
+3. Commit and push fixes to the PR branch.
+4. Back to Step 3.
+
+Cap: 2 CI retries, then stop and report what was tried.
+
+## Step 5: Report
+
+Write to `.claude/.artifacts/<template-name>/update-ray-<version>/notes-session-<timestamp-epoch>.md`: what changed, issues, fixes.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "bash .cursor/install.sh",
+  "start": "sudo service docker start"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Cursor Cloud Agent install script.
+# Idempotent: runs on every VM startup. Cached via Cursor's snapshot.
+# Required secrets (set in Cursor → My Secrets, exposed as env vars):
+#   ANYSCALE_DEBUG_AGENT_GH_TOKEN  GitHub PAT with read on anyscale/anyscale-debug-agent
+#   ANYSCALE_CLI_TOKEN             For the anyscale CLI
+#   GCP_TEMPLATE_REGISTRY_SA_KEY   GCP SA JSON for docker push to us-docker.pkg.dev
+set -euo pipefail
+
+# --- CLIs ---
+if ! command -v gh &>/dev/null; then
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y gh
+fi
+
+pip install -q --upgrade anyscale
+
+if ! command -v gcloud &>/dev/null; then
+  curl -sSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh
+  bash /tmp/gcloud-install.sh --disable-prompts --install-dir="$HOME"
+  echo 'export PATH=$PATH:$HOME/google-cloud-sdk/bin' >> ~/.bashrc
+fi
+export PATH=$PATH:$HOME/google-cloud-sdk/bin
+
+if ! command -v docker &>/dev/null; then
+  sudo apt-get update -qq
+  sudo apt-get install -y docker.io fuse-overlayfs iptables
+fi
+
+# --- Auth: gh ---
+echo "$ANYSCALE_DEBUG_AGENT_GH_TOKEN" | gh auth login --with-token
+
+# --- Sideload private skills from anyscale-debug-agent ---
+rm -rf /tmp/debug-agent
+gh repo clone anyscale/anyscale-debug-agent /tmp/debug-agent
+mkdir -p ~/.claude/skills
+cp -r /tmp/debug-agent/skills/* ~/.claude/skills/
+echo "User-scope skills:"
+ls ~/.claude/skills/
+
+# --- Auth: gcloud (for docker push to GCP artifact registry) ---
+if [ -n "${GCP_TEMPLATE_REGISTRY_SA_KEY:-}" ]; then
+  echo "$GCP_TEMPLATE_REGISTRY_SA_KEY" > /tmp/gcp-sa.json
+  gcloud auth activate-service-account --key-file=/tmp/gcp-sa.json
+  gcloud auth configure-docker us-docker.pkg.dev --quiet
+fi
+
+# --- Auth: anyscale CLI ---
+if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
+  mkdir -p ~/.anyscale
+  cat > ~/.anyscale/credentials.json <<EOF
+{"cli_token": "$ANYSCALE_CLI_TOKEN"}
+EOF
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent guidance for anyscale/templates
+
+Anyscale console templates. For any template-related work (bump Ray, format, publish, debug a test failure), use the `template` skill (`/template`) — canonical entry point for procedures and references.
+
+For cloud agents, companion skills `/fix`, `/run`, and `/inspect` are loaded at user scope via `.cursor/environment.json` for debugging. Advice: `/fix` is a powerful skill that handles the entire debug loop, you might want to wrap it with a subagent to avoid cluttering your main context too much.
+
+**CI invariant** — `.github/workflows/test-template.yaml` only runs when a PR comment matches `/test-template <template-id>`. After any push to a PR, comment to trigger or re-trigger validation.
+
+**Known automation** — the `template-updater` Cursor automation owns Ray-version bumps end-to-end (open PR → CI → fix-loop) on every major/minor Ray release. Its PRs use label `ray-update` and branches `update/*/ray-*`.


### PR DESCRIPTION
## Summary

Groundwork for the `template-updater` Cursor automation that opens one PR per template on every Ray major/minor release.

- **`.claude/skills/template/`**: dispatcher skill with on-demand references (update, format, publish, image-cases, local-testing, schemas). Canonical entry point any agent uses for template work — invoked as `/template`.
- **`.cursor/environment.json` + `install.sh`**: Cursor Cloud Agent VM installs CLIs (`gh`, `anyscale`, `gcloud`, `docker`) and sideloads private `/fix` + `/inspect` skills from `anyscale-debug-agent` at session start.
- **`AGENTS.md`**: repo constitution pointing agents at `/template` and documenting the CI invariant (`/test-template <id>` PR comment retriggers validation).

All net-new files; no existing repo content modified.

## Test plan

- [ ] Cursor env setup against `anyscale/templates`: install completes, `~/.claude/skills/` lists `fix`, `inspect`, `template`
- [ ] Manual webhook curl on `model-multiplexing` opens a PR + comments `/test-template`
- [ ] Deliberate-failure run validates the in-session `/fix` loop (2-retry cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)