### PR TITLE
Fix Cursor env install: add Dockerfile, harden install.sh, pin tooling

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -11,7 +11,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates sudo gnupg lsb-release \
+      curl wget ca-certificates sudo gnupg lsb-release \
       git python3 python3-pip \
  && rm -rf /var/lib/apt/lists/*
 

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,18 @@
+# Cursor Cloud Agent base image for anyscale/templates.
+# Provides the minimum prerequisites .cursor/install.sh needs to bootstrap
+# at every VM startup (curl, sudo, apt, python/pip, git). Heavier deps
+# (gh, anyscale, gcloud, docker) are installed by install.sh idempotently.
+#
+# This Dockerfile's primary job is to put environment.json into "Manual
+# Dockerfile" mode so Cursor honors the install command instead of falling
+# back to its agent-driven setup which ignores it.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates sudo gnupg lsb-release \
+      git python3 python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,7 @@
 {
   "build": {
     "dockerfile": "Dockerfile"
+    // "context": ".."  // Re-enable if Dockerfile uses COPY/ADD on repo-root files; defaults to .cursor/
   },
   "install": "bash .cursor/install.sh",
   "start": "sudo service docker start"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,7 @@
 {
+  "build": {
+    "dockerfile": ".cursor/Dockerfile"
+  },
   "install": "bash .cursor/install.sh",
   "start": "sudo service docker start"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,7 @@
 {
   "build": {
-    "dockerfile": ".cursor/Dockerfile"
+    "dockerfile": "Dockerfile",
+    "context": ".."
   },
   "install": "bash .cursor/install.sh",
   "start": "sudo service docker start"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "dockerfile": "Dockerfile"
-    // "context": ".."  // Re-enable if Dockerfile uses COPY/ADD on repo-root files; defaults to .cursor/
   },
   "install": "bash .cursor/install.sh",
   "start": "sudo service docker start"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,6 @@
 {
   "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".."
+    "dockerfile": "Dockerfile"
   },
   "install": "bash .cursor/install.sh",
   "start": "sudo service docker start"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -17,7 +17,19 @@ if ! command -v gh &>/dev/null; then
   sudo apt-get install -y gh
 fi
 
-pip install -q --upgrade anyscale
+# --- Python tooling (versions pinned to match this repo's CI) ---
+python3 -m pip install --user --no-warn-script-location \
+  pre-commit==3.8.0 jupyter==1.1.1 anyscale==0.26.87
+export PATH="$HOME/.local/bin:$PATH"
+grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' ~/.bashrc 2>/dev/null \
+  || echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+# --- rayapp (version pinned via repo's download_rayapp.sh) ---
+if [ -f download_rayapp.sh ] && ! command -v rayapp &>/dev/null; then
+  bash download_rayapp.sh
+  mkdir -p "$HOME/.local/bin"
+  mv rayapp "$HOME/.local/bin/rayapp"
+fi
 
 if ! command -v gcloud &>/dev/null; then
   curl -sSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -31,28 +31,33 @@ if ! command -v docker &>/dev/null; then
   sudo apt-get install -y docker.io fuse-overlayfs iptables
 fi
 
-# --- Auth: gh ---
+# --- Auth: gh (hard requirement — used to clone debug-agent skills) ---
+: "${ANYSCALE_DEBUG_AGENT_GH_TOKEN:?secret ANYSCALE_DEBUG_AGENT_GH_TOKEN is empty/unset; add it in Cursor → Cloud Agents → My Secrets}"
 echo "$ANYSCALE_DEBUG_AGENT_GH_TOKEN" | gh auth login --with-token
 
 # --- Sideload private skills from anyscale-debug-agent ---
 rm -rf /tmp/debug-agent
-gh repo clone anyscale/anyscale-debug-agent /tmp/debug-agent
+GH_TOKEN="$ANYSCALE_DEBUG_AGENT_GH_TOKEN" gh repo clone anyscale/anyscale-debug-agent /tmp/debug-agent
 mkdir -p ~/.claude/skills
 cp -r /tmp/debug-agent/skills/* ~/.claude/skills/
 echo "User-scope skills:"
 ls ~/.claude/skills/
 
-# --- Auth: gcloud (for docker push to GCP artifact registry) ---
+# --- Auth: gcloud (for docker push to GCP artifact registry; soft — only needed for custom images) ---
 if [ -n "${GCP_TEMPLATE_REGISTRY_SA_KEY:-}" ]; then
   echo "$GCP_TEMPLATE_REGISTRY_SA_KEY" > /tmp/gcp-sa.json
   gcloud auth activate-service-account --key-file=/tmp/gcp-sa.json
   gcloud auth configure-docker us-docker.pkg.dev --quiet
+else
+  echo "WARN: GCP_TEMPLATE_REGISTRY_SA_KEY not set — custom-image rebuild + push to GCP will fail."
 fi
 
-# --- Auth: anyscale CLI ---
+# --- Auth: anyscale CLI (soft — only needed for templates that invoke the anyscale CLI) ---
 if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
   mkdir -p ~/.anyscale
   cat > ~/.anyscale/credentials.json <<EOF
 {"cli_token": "$ANYSCALE_CLI_TOKEN"}
 EOF
+else
+  echo "WARN: ANYSCALE_CLI_TOKEN not set — anyscale CLI commands will fail."
 fi


### PR DESCRIPTION
## Summary

Makes Cursor's Cloud Agent env install actually run our `install.sh` and pre-installs the tooling Cursor's auto-setup was already pulling in.

- **Add `.cursor/Dockerfile`** + `build.dockerfile` in `environment.json`. Per Cursor docs, "Manual Dockerfile setup requires both a `.cursor/Dockerfile` AND `environment.json`." Without a Dockerfile, Cursor falls back to its agent-driven LLM setup and ignores our `install` field — observed on initial runs.
- **Harden `install.sh`** — fail fast on missing `ANYSCALE_DEBUG_AGENT_GH_TOKEN` (was silently failing into a 10-min browser-auth timeout), pass `GH_TOKEN` explicitly to `gh repo clone`, warn on missing optional secrets.
- **Pin Python tooling** — `pre-commit==3.8.0 jupyter==1.1.1 anyscale==0.26.87` (versions Cursor's auto-setup was inferring), install via `pip --user`, ensure `~/.local/bin` is on PATH.
- **Install `rayapp`** via the repo's existing `download_rayapp.sh` (source of truth for the version CI uses).

## Test plan

- [ ] Re-run Cursor env setup against `main` after merge
- [ ] Run log shows `bash .cursor/install.sh` executing (not Cursor's auto-generated commands)
- [ ] `~/.claude/skills/` lists `fix`, `inspect`, `template`
- [ ] `which rayapp anyscale pre-commit` all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)