### PR TITLE
ci: /test-template supports multiple templates with parallel fan-out

### DIFF
--- a/.buildkite/pipeline.template-test.yaml
+++ b/.buildkite/pipeline.template-test.yaml
@@ -1,42 +1,5 @@
 steps:
-  - label: "Test template: {{matrix.template}}"
-    env:
-      TEMPLATE_NAME: "{{matrix.template}}"
-    commands:
-      - |
-        set -euo pipefail
-        export ANYSCALE_CLI_TOKEN="$$(aws --region=us-west-2 secretsmanager get-secret-value --secret-id $$ANYSCALE_CLI_TOKEN_SECRET_NAME | jq -r .SecretString)"
-        export ANYSCALE_HOST="https://console.anyscale-staging.com"
-        bash download_rayapp.sh
-        sudo apt-get update && sudo apt-get install -y rsync
-        sudo pip install anyscale==0.26.87
-        LOG=/tmp/rayapp-$$TEMPLATE_NAME.log
-        set +e
-        ./rayapp test $$TEMPLATE_NAME 2>&1 | tee "$$LOG"
-        EXIT=$${PIPESTATUS[0]}
-        set -e
-        URL=$$(grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' "$$LOG" | head -1 | sed 's/?.*//')
-        if [ -n "$$URL" ]; then
-          printf '**%s** workspace: %s\n' "$$TEMPLATE_NAME" "$$URL" | \
-            buildkite-agent annotate --style info --context "ws-$$TEMPLATE_NAME"
-        fi
-        exit $$EXIT
-    matrix:
-      setup:
-        template: ${TEMPLATE_NAMES_JSON}
-    timeout_in_minutes: 75
+  - label: ":pipeline: Fan out template tests"
+    commands: ci/render-template-pipeline.sh | buildkite-agent pipeline upload
     agents:
       queue: small
-    retry:
-      automatic: true
-    plugins:
-      - docker#v5.9.0:
-          image: "830883877497.dkr.ecr.us-west-2.amazonaws.com/anyscale/forge:241125"
-          propagate-aws-auth-tokens: true
-          mount-buildkite-agent: true
-          shell: ["/bin/bash", "-e", "-c"]
-          environment:
-            - "BUILDKITE"
-            - "BUILDKITE_PIPELINE_ID"
-            - "TEMPLATE_NAME"
-            - "ANYSCALE_CLI_TOKEN_SECRET_NAME"

--- a/.buildkite/pipeline.template-test.yaml
+++ b/.buildkite/pipeline.template-test.yaml
@@ -10,7 +10,17 @@ steps:
         bash download_rayapp.sh
         sudo apt-get update && sudo apt-get install -y rsync
         sudo pip install anyscale==0.26.87
-        ./rayapp test $$TEMPLATE_NAME
+        LOG=/tmp/rayapp-$$TEMPLATE_NAME.log
+        set +e
+        ./rayapp test $$TEMPLATE_NAME 2>&1 | tee "$$LOG"
+        EXIT=$${PIPESTATUS[0]}
+        set -e
+        URL=$$(grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' "$$LOG" | head -1 | sed 's/?.*//')
+        if [ -n "$$URL" ]; then
+          printf '**%s** workspace: %s\n' "$$TEMPLATE_NAME" "$$URL" | \
+            buildkite-agent annotate --style info --context "ws-$$TEMPLATE_NAME"
+        fi
+        exit $$EXIT
     matrix:
       setup:
         template: ${TEMPLATE_NAMES_JSON}

--- a/.buildkite/pipeline.template-test.yaml
+++ b/.buildkite/pipeline.template-test.yaml
@@ -1,21 +1,19 @@
-env:
-  TEMPLATE_NAME: "${TEMPLATE_NAME}"
-
 steps:
-  - name: "Test template: ${TEMPLATE_NAME}"
+  - label: "Test template: {{matrix.template}}"
+    env:
+      TEMPLATE_NAME: "{{matrix.template}}"
     commands:
-    - |
-      set -euo pipefail
-      if [ -z "$$TEMPLATE_NAME" ]; then
-        echo "Error: TEMPLATE_NAME environment variable is required"
-        exit 1
-      fi
-      export ANYSCALE_CLI_TOKEN="$$(aws --region=us-west-2 secretsmanager get-secret-value --secret-id $$ANYSCALE_CLI_TOKEN_SECRET_NAME | jq -r .SecretString)"
-      export ANYSCALE_HOST="https://console.anyscale-staging.com"
-      bash download_rayapp.sh
-      sudo apt-get update && sudo apt-get install -y rsync
-      sudo pip install anyscale==0.26.87
-      ./rayapp test $$TEMPLATE_NAME
+      - |
+        set -euo pipefail
+        export ANYSCALE_CLI_TOKEN="$$(aws --region=us-west-2 secretsmanager get-secret-value --secret-id $$ANYSCALE_CLI_TOKEN_SECRET_NAME | jq -r .SecretString)"
+        export ANYSCALE_HOST="https://console.anyscale-staging.com"
+        bash download_rayapp.sh
+        sudo apt-get update && sudo apt-get install -y rsync
+        sudo pip install anyscale==0.26.87
+        ./rayapp test $$TEMPLATE_NAME
+    matrix:
+      setup:
+        template: ${TEMPLATE_NAMES_JSON}
     timeout_in_minutes: 75
     agents:
       queue: small

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -53,7 +53,7 @@ jobs:
           -d "$(jq -n \
             --arg branch "${{ steps.pr.outputs.branch }}" \
             --arg sha "${{ steps.pr.outputs.sha }}" \
-            --arg templates_json "${{ steps.parse.outputs.templates_json }}" \
+            --arg templates "${{ steps.parse.outputs.templates }}" \
             --arg msg "Test templates: ${{ steps.parse.outputs.templates }} (PR #${{ github.event.issue.number }})" \
             --arg secret "${{ secrets.ANYSCALE_CLI_TOKEN_SECRET_NAME }}" \
             '{
@@ -61,7 +61,7 @@ jobs:
               commit: $sha,
               branch: $branch,
               env: {
-                TEMPLATE_NAMES_JSON: $templates_json,
+                TEMPLATE_NAMES: $templates,
                 ANYSCALE_CLI_TOKEN_SECRET_NAME: $secret
               }
             }'

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -12,18 +12,6 @@ jobs:
       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-    - name: Parse template name from comment
-      id: parse
-      env:
-        COMMENT_BODY: ${{ github.event.comment.body }}
-      run: |
-        TEMPLATE=$(echo "$COMMENT_BODY" | awk '/^\/test-template / { print $2; exit }')
-        if [[ ! "$TEMPLATE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-          echo "::error::Invalid template name: $TEMPLATE"
-          exit 1
-        fi
-        echo "template=$TEMPLATE" >> "$GITHUB_OUTPUT"
-
     - name: Get PR ref
       id: pr
       uses: actions/github-script@v7
@@ -41,6 +29,36 @@ jobs:
           core.setOutput('branch', pr.data.head.ref);
           core.setOutput('sha', pr.data.head.sha);
 
+    - name: Checkout PR
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.pr.outputs.sha }}
+
+    - name: Parse and validate template names
+      id: parse
+      env:
+        COMMENT_BODY: ${{ github.event.comment.body }}
+      run: |
+        TEMPLATES=$(echo "$COMMENT_BODY" | tr -d '\r' | awk '/^\/test-template / { for (i=2; i<=NF; i++) printf "%s ", $i; exit }' | xargs)
+        if [ -z "$TEMPLATES" ]; then
+          echo "::error::No template names provided"
+          exit 1
+        fi
+        VALID=$(awk '/^- name:/ {print $3}' BUILD.yaml)
+        for t in $TEMPLATES; do
+          if [[ ! "$t" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "::error::Invalid template name: $t"
+            exit 1
+          fi
+          if ! grep -qxF "$t" <<< "$VALID"; then
+            echo "::error::Template '$t' not found in BUILD.yaml"
+            exit 1
+          fi
+        done
+        TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -Rc 'split(" ")')
+        echo "templates=$TEMPLATES" >> "$GITHUB_OUTPUT"
+        echo "templates_json=$TEMPLATES_JSON" >> "$GITHUB_OUTPUT"
+
     - name: Trigger Buildkite build
       env:
         BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
@@ -54,15 +72,15 @@ jobs:
           -d "$(jq -n \
             --arg branch "${{ steps.pr.outputs.branch }}" \
             --arg sha "${{ steps.pr.outputs.sha }}" \
-            --arg template "${{ steps.parse.outputs.template }}" \
-            --arg msg "Test template: ${{ steps.parse.outputs.template }} (PR #${{ github.event.issue.number }})" \
+            --arg templates_json "${{ steps.parse.outputs.templates_json }}" \
+            --arg msg "Test templates: ${{ steps.parse.outputs.templates }} (PR #${{ github.event.issue.number }})" \
             --arg secret "${{ secrets.ANYSCALE_CLI_TOKEN_SECRET_NAME }}" \
             '{
               message: $msg,
               commit: $sha,
               branch: $branch,
               env: {
-                TEMPLATE_NAME: $template,
+                TEMPLATE_NAMES_JSON: $templates_json,
                 ANYSCALE_CLI_TOKEN_SECRET_NAME: $secret
               }
             }'

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -44,14 +44,14 @@ jobs:
           echo "::error::No template names provided"
           exit 1
         fi
-        VALID=$(awk '/^- name:/ {print $3}' BUILD.yaml)
-        # 'all' expands to every template in BUILD.yaml (still fans out as N parallel matrix jobs)
-        if [[ " $TEMPLATES " == *" all "* ]]; then
-          EXPANDED=$(echo "$VALID" | tr '\n' ' ' | xargs)
-        else
-          EXPANDED="$TEMPLATES"
+        # Cap to keep CI cost bounded; bump if the team agrees a higher cap is fine.
+        COUNT=$(echo "$TEMPLATES" | wc -w | xargs)
+        if [ "$COUNT" -gt 3 ]; then
+          echo "::error::Too many templates ($COUNT); max 3 per /test-template comment"
+          exit 1
         fi
-        for t in $EXPANDED; do
+        VALID=$(awk '/^- name:/ {print $3}' BUILD.yaml)
+        for t in $TEMPLATES; do
           if [[ ! "$t" =~ ^[a-zA-Z0-9_-]+$ ]]; then
             echo "::error::Invalid template name: $t"
             exit 1
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
         done
-        TEMPLATES_JSON=$(echo "$EXPANDED" | jq -Rc 'split(" ")')
+        TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -Rc 'split(" ")')
         echo "templates=$TEMPLATES" >> "$GITHUB_OUTPUT"
         echo "templates_json=$TEMPLATES_JSON" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -38,32 +38,7 @@ jobs:
       id: parse
       env:
         COMMENT_BODY: ${{ github.event.comment.body }}
-      run: |
-        TEMPLATES=$(echo "$COMMENT_BODY" | tr -d '\r' | awk '/^\/test-template / { for (i=2; i<=NF; i++) printf "%s ", $i; exit }' | xargs)
-        if [ -z "$TEMPLATES" ]; then
-          echo "::error::No template names provided"
-          exit 1
-        fi
-        # Cap to keep CI cost bounded; bump if the team agrees a higher cap is fine.
-        COUNT=$(echo "$TEMPLATES" | wc -w | xargs)
-        if [ "$COUNT" -gt 3 ]; then
-          echo "::error::Too many templates ($COUNT); max 3 per /test-template comment"
-          exit 1
-        fi
-        VALID=$(awk '/^- name:/ {print $3}' BUILD.yaml)
-        for t in $TEMPLATES; do
-          if [[ ! "$t" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-            echo "::error::Invalid template name: $t"
-            exit 1
-          fi
-          if ! grep -qxF "$t" <<< "$VALID"; then
-            echo "::error::Template '$t' not found in BUILD.yaml"
-            exit 1
-          fi
-        done
-        TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -Rc 'split(" ")')
-        echo "templates=$TEMPLATES" >> "$GITHUB_OUTPUT"
-        echo "templates_json=$TEMPLATES_JSON" >> "$GITHUB_OUTPUT"
+      run: bash ci/parse-test-template-comment.sh
 
     - name: Trigger Buildkite build
       env:

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -45,7 +45,13 @@ jobs:
           exit 1
         fi
         VALID=$(awk '/^- name:/ {print $3}' BUILD.yaml)
-        for t in $TEMPLATES; do
+        # 'all' expands to every template in BUILD.yaml (still fans out as N parallel matrix jobs)
+        if [[ " $TEMPLATES " == *" all "* ]]; then
+          EXPANDED=$(echo "$VALID" | tr '\n' ' ' | xargs)
+        else
+          EXPANDED="$TEMPLATES"
+        fi
+        for t in $EXPANDED; do
           if [[ ! "$t" =~ ^[a-zA-Z0-9_-]+$ ]]; then
             echo "::error::Invalid template name: $t"
             exit 1
@@ -55,7 +61,7 @@ jobs:
             exit 1
           fi
         done
-        TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -Rc 'split(" ")')
+        TEMPLATES_JSON=$(echo "$EXPANDED" | jq -Rc 'split(" ")')
         echo "templates=$TEMPLATES" >> "$GITHUB_OUTPUT"
         echo "templates_json=$TEMPLATES_JSON" >> "$GITHUB_OUTPUT"
 

--- a/ci/parse-test-template-comment.sh
+++ b/ci/parse-test-template-comment.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Parse a /test-template comment body and emit two GH-Actions outputs to
+# the path given as $GITHUB_OUTPUT:
+#   templates       — space-separated template names
+#   templates_json  — JSON array, e.g. ["foo","bar"]
+#
+# Inputs:
+#   COMMENT_BODY  — the PR comment body
+#   GITHUB_OUTPUT — path to the GH Actions outputs file (set by the runner)
+#
+# Validation:
+#   - non-empty list of names
+#   - max 3 templates per comment (cost cap)
+#   - each name matches ^[a-zA-Z0-9_-]+$
+#   - each name appears in BUILD.yaml's `- name:` entries
+
+set -euo pipefail
+
+: "${COMMENT_BODY:?COMMENT_BODY env var required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT env var required}"
+
+MAX_TEMPLATES=3
+
+TEMPLATES=$(
+  echo "$COMMENT_BODY" \
+    | tr -d '\r' \
+    | awk '/^\/test-template / { for (i=2; i<=NF; i++) printf "%s ", $i; exit }' \
+    | xargs
+)
+
+if [ -z "$TEMPLATES" ]; then
+  echo "::error::No template names provided"
+  exit 1
+fi
+
+COUNT=$(echo "$TEMPLATES" | wc -w | xargs)
+if [ "$COUNT" -gt "$MAX_TEMPLATES" ]; then
+  echo "::error::Too many templates ($COUNT); max $MAX_TEMPLATES per /test-template comment"
+  exit 1
+fi
+
+VALID=$(awk '/^- name:/ {print $3}' BUILD.yaml)
+for t in $TEMPLATES; do
+  if [[ ! "$t" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo "::error::Invalid template name: $t"
+    exit 1
+  fi
+  if ! grep -qxF "$t" <<< "$VALID"; then
+    echo "::error::Template '$t' not found in BUILD.yaml"
+    exit 1
+  fi
+done
+
+TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -Rc 'split(" ")')
+echo "templates=$TEMPLATES" >> "$GITHUB_OUTPUT"
+echo "templates_json=$TEMPLATES_JSON" >> "$GITHUB_OUTPUT"

--- a/ci/parse-test-template-comment.sh
+++ b/ci/parse-test-template-comment.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-# Parse a /test-template comment body and emit two GH-Actions outputs to
-# the path given as $GITHUB_OUTPUT:
-#   templates       — space-separated template names
-#   templates_json  — JSON array, e.g. ["foo","bar"]
+# Parse a /test-template comment body and emit one GH-Actions output to
+# $GITHUB_OUTPUT:
+#   templates — space-separated template names
 #
 # Inputs:
 #   COMMENT_BODY  — the PR comment body
@@ -51,6 +50,4 @@ for t in $TEMPLATES; do
   fi
 done
 
-TEMPLATES_JSON=$(echo "$TEMPLATES" | jq -Rc 'split(" ")')
 echo "templates=$TEMPLATES" >> "$GITHUB_OUTPUT"
-echo "templates_json=$TEMPLATES_JSON" >> "$GITHUB_OUTPUT"

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -39,7 +39,12 @@ for t in $TEMPLATES; do
         (
           set +eo pipefail
           while :; do
-            WS_ID=\$\$(grep -oE 'expwrk_[a-z0-9]+' "\$\$LOG" 2>/dev/null | head -1)
+            # Anchor on the anyscale CLI's "Workspace created successfully id:"
+            # line to make sure we pick up the workspace rayapp just created,
+            # not some unrelated expwrk_ string that a template's logs might
+            # contain.
+            WS_ID=\$\$(grep 'Workspace created successfully id:' "\$\$LOG" 2>/dev/null \\
+              | grep -oE 'expwrk_[a-z0-9]+' | head -1)
             if [ -n "\$\$WS_ID" ]; then
               JSON=\$\$(anyscale workspace_v2 get --id "\$\$WS_ID" -j 2>/dev/null)
               CLOUD_ID=\$\$(echo "\$\$JSON" | jq -r '.cloud_id // empty')

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -32,7 +32,10 @@ for t in $TEMPLATES; do
         : > "\$\$LOG"
         # Background watcher: post the workspace URL annotation as soon as
         # anyscale CLI prints the "View and update dependencies here:" line.
+        # Disable -e/pipefail in the subshell — grep returns non-zero when the
+        # log doesn't yet contain the line, which would otherwise kill the watcher.
         (
+          set +eo pipefail
           while :; do
             URL=\$\$(grep 'View and update dependencies here:' "\$\$LOG" 2>/dev/null \\
               | grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' \\

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -30,20 +30,26 @@ for t in $TEMPLATES; do
         sudo pip install anyscale==0.26.87
         LOG=/tmp/rayapp-\$\$TEMPLATE_NAME.log
         : > "\$\$LOG"
-        # Background watcher: post the workspace URL annotation as soon as
-        # anyscale CLI prints the "View and update dependencies here:" line.
-        # Disable -e/pipefail in the subshell — grep returns non-zero when the
-        # log doesn't yet contain the line, which would otherwise kill the watcher.
+        # Background watcher: as soon as rayapp logs the workspace ID
+        # (always printed via "Workspace created successfully id: expwrk_..."),
+        # query the anyscale CLI for cloud_id/project_id and post a
+        # buildkite annotation with the canonical workspace URL.
+        # Disable -e/pipefail in the subshell — grep returns non-zero while
+        # the log is empty, which would otherwise kill the watcher.
         (
           set +eo pipefail
           while :; do
-            URL=\$\$(grep 'View and update dependencies here:' "\$\$LOG" 2>/dev/null \\
-              | grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' \\
-              | head -1)
-            if [ -n "\$\$URL" ]; then
-              printf '**%s** workspace: %s\n' "\$\$TEMPLATE_NAME" "\$\$URL" \\
-                | buildkite-agent annotate --style info --context "ws-\$\$TEMPLATE_NAME"
-              break
+            WS_ID=\$\$(grep -oE 'expwrk_[a-z0-9]+' "\$\$LOG" 2>/dev/null | head -1)
+            if [ -n "\$\$WS_ID" ]; then
+              JSON=\$\$(anyscale workspace_v2 get --id "\$\$WS_ID" -j 2>/dev/null)
+              CLOUD_ID=\$\$(echo "\$\$JSON" | jq -r '.cloud_id // empty')
+              PROJECT_ID=\$\$(echo "\$\$JSON" | jq -r '.project_id // empty')
+              if [ -n "\$\$CLOUD_ID" ] && [ -n "\$\$PROJECT_ID" ]; then
+                URL="\$\$ANYSCALE_HOST/\$\$CLOUD_ID/\$\$PROJECT_ID/workspaces/\$\$WS_ID"
+                printf '**%s** workspace: %s\n' "\$\$TEMPLATE_NAME" "\$\$URL" \\
+                  | buildkite-agent annotate --style info --context "ws-\$\$TEMPLATE_NAME"
+                break
+              fi
             fi
             sleep 2
           done

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -29,15 +29,29 @@ for t in $TEMPLATES; do
         sudo apt-get update && sudo apt-get install -y rsync
         sudo pip install anyscale==0.26.87
         LOG=/tmp/rayapp-\$\$TEMPLATE_NAME.log
+        : > "\$\$LOG"
+        # Background watcher: post the workspace URL annotation as soon as
+        # anyscale CLI prints the "View and update dependencies here:" line.
+        (
+          while :; do
+            URL=\$\$(grep 'View and update dependencies here:' "\$\$LOG" 2>/dev/null \\
+              | grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' \\
+              | head -1)
+            if [ -n "\$\$URL" ]; then
+              printf '**%s** workspace: %s\n' "\$\$TEMPLATE_NAME" "\$\$URL" \\
+                | buildkite-agent annotate --style info --context "ws-\$\$TEMPLATE_NAME"
+              break
+            fi
+            sleep 2
+          done
+        ) &
+        WATCHER_PID=\$\$!
         set +e
         ./rayapp test \$\$TEMPLATE_NAME 2>&1 | tee "\$\$LOG"
         EXIT=\$\${PIPESTATUS[0]}
         set -e
-        URL=\$\$(grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' "\$\$LOG" | head -1 | sed 's/?.*//')
-        if [ -n "\$\$URL" ]; then
-          printf '**%s** workspace: %s\n' "\$\$TEMPLATE_NAME" "\$\$URL" | \\
-            buildkite-agent annotate --style info --context "ws-\$\$TEMPLATE_NAME"
-        fi
+        kill "\$\$WATCHER_PID" 2>/dev/null || true
+        wait "\$\$WATCHER_PID" 2>/dev/null || true
         exit \$\$EXIT
     timeout_in_minutes: 75
     agents:

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -30,19 +30,13 @@ for t in $TEMPLATES; do
         sudo pip install anyscale==0.26.87
         LOG=/tmp/rayapp-\$\$TEMPLATE_NAME.log
         : > "\$\$LOG"
-        # Background watcher: as soon as rayapp logs the workspace ID
-        # (always printed via "Workspace created successfully id: expwrk_..."),
-        # query the anyscale CLI for cloud_id/project_id and post a
-        # buildkite annotation with the canonical workspace URL.
-        # Disable -e/pipefail in the subshell — grep returns non-zero while
-        # the log is empty, which would otherwise kill the watcher.
+        # Watch for "Workspace created successfully id: expwrk_..." (always
+        # printed by anyscale CLI), then build the canonical workspace URL
+        # from cloud_id/project_id and post a buildkite annotation.
+        # set +eo pipefail: grep returns non-zero when the log is still empty.
         (
           set +eo pipefail
           while :; do
-            # Anchor on the anyscale CLI's "Workspace created successfully id:"
-            # line to make sure we pick up the workspace rayapp just created,
-            # not some unrelated expwrk_ string that a template's logs might
-            # contain.
             WS_ID=\$\$(grep 'Workspace created successfully id:' "\$\$LOG" 2>/dev/null \\
               | grep -oE 'expwrk_[a-z0-9]+' | head -1)
             if [ -n "\$\$WS_ID" ]; then

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${TEMPLATE_NAMES_JSON:?TEMPLATE_NAMES_JSON env var is required}"
+
+TEMPLATES=$(echo "$TEMPLATE_NAMES_JSON" | jq -r '.[]')
+
+for t in $TEMPLATES; do
+  case "$t" in
+    *[!a-zA-Z0-9_-]*)
+      echo "Invalid template name: $t" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "steps:"
+for t in $TEMPLATES; do
+  cat <<STEP
+  - label: "Test template: $t"
+    env:
+      TEMPLATE_NAME: "$t"
+    commands:
+      - |
+        set -euo pipefail
+        export ANYSCALE_CLI_TOKEN="\$\$(aws --region=us-west-2 secretsmanager get-secret-value --secret-id \$\$ANYSCALE_CLI_TOKEN_SECRET_NAME | jq -r .SecretString)"
+        export ANYSCALE_HOST="https://console.anyscale-staging.com"
+        bash download_rayapp.sh
+        sudo apt-get update && sudo apt-get install -y rsync
+        sudo pip install anyscale==0.26.87
+        LOG=/tmp/rayapp-\$\$TEMPLATE_NAME.log
+        set +e
+        ./rayapp test \$\$TEMPLATE_NAME 2>&1 | tee "\$\$LOG"
+        EXIT=\$\${PIPESTATUS[0]}
+        set -e
+        URL=\$\$(grep -oE 'https://console\.anyscale[^ ]+/workspaces/expwrk_[a-z0-9]+' "\$\$LOG" | head -1 | sed 's/?.*//')
+        if [ -n "\$\$URL" ]; then
+          printf '**%s** workspace: %s\n' "\$\$TEMPLATE_NAME" "\$\$URL" | \\
+            buildkite-agent annotate --style info --context "ws-\$\$TEMPLATE_NAME"
+        fi
+        exit \$\$EXIT
+    timeout_in_minutes: 75
+    agents:
+      queue: small
+    retry:
+      automatic: true
+    plugins:
+      - docker#v5.9.0:
+          image: "830883877497.dkr.ecr.us-west-2.amazonaws.com/anyscale/forge:241125"
+          propagate-aws-auth-tokens: true
+          mount-buildkite-agent: true
+          shell: ["/bin/bash", "-e", "-c"]
+          environment:
+            - "BUILDKITE"
+            - "BUILDKITE_PIPELINE_ID"
+            - "TEMPLATE_NAME"
+            - "ANYSCALE_CLI_TOKEN_SECRET_NAME"
+STEP
+done

--- a/ci/render-template-pipeline.sh
+++ b/ci/render-template-pipeline.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-: "${TEMPLATE_NAMES_JSON:?TEMPLATE_NAMES_JSON env var is required}"
+: "${TEMPLATE_NAMES:?TEMPLATE_NAMES env var is required}"
 
-TEMPLATES=$(echo "$TEMPLATE_NAMES_JSON" | jq -r '.[]')
+TEMPLATES="$TEMPLATE_NAMES"
 
 for t in $TEMPLATES; do
   case "$t" in


### PR DESCRIPTION
## What
Comment `/test-template foo bar baz` on a PR → fans out into one parallel Buildkite job per template (cap 3), each posting a clickable workspace URL annotation as soon as its workspace is created.

## Why
Today only one template can be tested per comment, and the URL it spawns isn't surfaced — you have to dig through Buildkite logs to find it.

## How

**GH Actions (`.github/workflows/test-template.yaml`)**
Parses `/test-template a b c` from the comment, validates names against `BUILD.yaml`, caps at 3, and dispatches one Buildkite build with `TEMPLATE_NAMES="a b c"`. Logic lives in `ci/parse-test-template-comment.sh`.

**Buildkite pipeline (`.buildkite/pipeline.template-test.yaml`)**
Thin bootstrap step: `ci/render-template-pipeline.sh | buildkite-agent pipeline upload`. The render script reads `TEMPLATE_NAMES` (space-separated) and emits one parallel step per template using Buildkite's dynamic pipeline pattern.

**Per-template watcher**
Each child step spawns a background watcher that grep's the always-printed line `Workspace created successfully id: expwrk_...`, fetches `cloud_id`/`project_id` via `anyscale workspace_v2 get -j`, and posts a Buildkite annotation:

> **`<template>`** workspace: `${ANYSCALE_HOST}/${CLOUD_ID}/${PROJECT_ID}/workspaces/${WS_ID}`

Annotation lands within seconds of workspace creation, well before the test finishes. Each annotation uses `--context "ws-<template>"`, so they coexist without overwriting.

## Manual Buildkite trigger
For one-off testing without the comment flow: New Build with these env vars:
```
TEMPLATE_NAMES=foo bar
ANYSCALE_CLI_TOKEN_SECRET_NAME=anyscale_cli_token_ci_staging
```

## Test plan
- [x] Local: parser handles 1/3-name (accept), 4-name (reject), `all` (rejected via BUILD.yaml lookup), shell-meta injection, empty
- [x] Manual build: 2 templates fanned out, all 2 annotations posted 
   - https://buildkite.com/anyscale/template-test/builds/130
- [ ] Post-merge: `/test-template a b` on a follow-up PR → both annotations visible on the build page

## Caveats
- GH Actions runs `issue_comment` workflows from the **default branch**, so the parser change only takes effect after merge. The Buildkite-side change is fully validated by manual builds against this branch.
- For "newer comment cancels older in-flight build", enable **Cancel Intermediate Builds** on the `template-test` pipeline (Buildkite UI → Pipeline Settings → Builds). UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)