### PR TITLE
ci: clean up premerge workflow

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -5,18 +5,22 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: premerge-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
     # Install pre-commit dependencies
     - name: Install pre-commit
-      run: pip install pre-commit==3.8.0 jupyter==1.1.1
+      run: pip install pre-commit==3.8.0
 
     # Run pre-commit hooks with verbose logging
     - name: Run pre-commit
@@ -25,19 +29,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-    - uses: actions/setup-go@v5
-      with:
-        go-version: 1.25
 
-    - name: Install pre-commit
-      run: pip install jupyter==1.1.1
-
-    - name: Build
-      run: bash -ec "(cd ci; go install ./...)"
+    - name: Install nbconvert
+      run: pip install nbconvert==7.17.1
 
     - name: Build templates
       run: |

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -18,9 +18,10 @@ jobs:
       with:
         python-version: '3.9'
 
-    # Install pre-commit dependencies
+    # Install pre-commit dependencies (nbconvert provides the jupyter CLI
+    # that the existing generate-readme local hook needs)
     - name: Install pre-commit
-      run: pip install pre-commit==3.8.0
+      run: pip install pre-commit==3.8.0 nbconvert==7.17.1
 
     # Run pre-commit hooks with verbose logging
     - name: Run pre-commit

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -1,8 +1,0 @@
-module github.com/anyscale/templates/ci
-
-go 1.25.3
-
-require (
-	golang.org/x/net v0.46.0
-	gopkg.in/yaml.v2 v2.4.0
-)

--- a/ci/go.sum
+++ b/ci/go.sum
@@ -1,6 +1,0 @@
-golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
-golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## Summary
Pure infra cleanup of the premerge workflow:

- Add `concurrency` so PR pushes cancel superseded runs (main runs still finish).
- Bump deprecated actions: `actions/checkout@v3 → @v4`, `actions/setup-python@v3 → @v5`.
- Pre-commit job: replace `jupyter==1.1.1` with `nbconvert==7.17.1`. The existing `generate-readme` local hook needs the `jupyter` CLI, which `nbconvert` brings in via its `jupyter_core` dep. Net effect: keeps the hook working, drops the heavy `jupyter` meta-package (notebook + jupyterlab + ipykernel + …) we don't need.
- Build job: replace `jupyter==1.1.1` with `nbconvert==7.17.1`. `rayapp build all` shells out to `jupyter-nbconvert`.
- Remove `ci/go.mod`, `ci/go.sum`, `actions/setup-go`, and `go install ./...` — leftovers from `maketmpl` (replaced by `rayapp` in #509). With no Go source in this repo, the install was a no-op.

## Test plan
- [x] Premerge runs green on this PR
- [ ] Sanity-check after merge that `rayapp build all` still completes against main

Split out from #621 along with #625 (the verifier hooks + URL migration). Lands cleanly in either order — both PRs set the pre-commit pip line to the same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)