### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,13 @@ Required Cursor secrets (already provisioned at team scope):
 - `GCP_TEMPLATE_REGISTRY_SA_KEY`
 
 If any issues, just read `.cursor/Dockerfile` and `.cursor/install.sh` and reproduce their steps yourself.
+
+## Cursor Cloud specific instructions
+
+- **No services to run.** This is a content repository of ~73 self-contained templates. There are no backend servers, databases, or long-running processes. The dev loop is: edit templates → run `pre-commit run --all-files` → push → CI validates.
+- **Lint:** `pre-commit run --all-files` (the `pre-commit install` hook won't activate because Cursor sets `core.hooksPath`; run manually before committing).
+- **Build:** `rayapp build all` — builds all templates (exits 0 on success; non-self-closing `<img>` warnings are benign).
+- **Validate:** `python3 ci/validate_build_yaml.py --no-network` — schema + path check on `BUILD.yaml`.
+- **Depsets:** `bash ./update_deps.sh --check` — verifies dependency lockfiles are current. Requires a `python` symlink (Ubuntu 22.04 only ships `python3`); create with `sudo ln -sf /usr/bin/python3 /usr/bin/python` if missing.
+- **PATH:** Always ensure `$HOME/.local/bin` and `$HOME/google-cloud-sdk/bin` are on `PATH` (the install script appends to `~/.bashrc`, but subshells may not source it).
+- **Private skills clone** at the end of `install.sh` (`anyscale/anyscale-debug-agent`) may fail if the GitHub token lacks access — this is non-fatal and doesn't affect core dev workflows.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious caveats discovered during environment setup:

- **No services to run** — this is a content repository; the dev loop is edit → lint → push → CI.
- **Lint/Build/Validate/Depsets** commands documented for quick reference.
- **`python` symlink** — Ubuntu 22.04 only ships `python3`; `update_deps.sh --check` needs `python`.
- **PATH note** — `$HOME/.local/bin` and `$HOME/google-cloud-sdk/bin` must be on PATH.
- **Private skills clone** may fail if the GH token lacks access (non-fatal).

All CI checks verified passing:

[dev_environment_checks.log](https://cursor.com/agents/bc-ab79ff59-252e-4607-b9c5-6bd46e566e3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_checks.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab79ff59-252e-4607-b9c5-6bd46e566e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab79ff59-252e-4607-b9c5-6bd46e566e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

