### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,13 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **Branch naming:** Cursor auto-assigns `cursor/...`. (Outside Cursor, use `update/<template-name>/ray-<version>`.)
 - **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
 - **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.
+
+## Cursor Cloud specific instructions
+
+- **No local services to run.** This is a content-only repository; the dev loop is `edit → pre-commit run --all-files → push`. All template execution happens remotely on Anyscale infrastructure.
+- **Preflight may hang on `anyscale cloud list`:** The preflight script calls `anyscale cloud list` which defaults to `--mode=interactive` and blocks waiting for pager input. Wrap with `timeout 30` or pipe to `head` to avoid hanging. A timeout exit (124) is acceptable as long as the underlying anyscale auth is valid (check `~/.anyscale/credentials.json` exists with a valid token).
+- **Lint/validate commands** (run before every commit):
+  - `pre-commit run --all-files` — all hooks (trailing whitespace, large files, README auto-gen, BUILD.yaml schema)
+  - `python3 ci/validate_build_yaml.py --no-network` — standalone BUILD.yaml validation
+  - `bash ./update_deps.sh --check` — dependency lockfile freshness
+  - `rayapp build all` — mirrors CI's build job locally (notebook → markdown conversion for all templates)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with non-obvious gotchas discovered during environment setup:

- Preflight may hang on `anyscale cloud list` due to interactive pager mode — document workaround (wrap with `timeout 30`)
- Clarify no local services are needed (content-only repo)
- Quick reference summary of lint/validate commands for future agents
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57f1c35b-315a-4986-a932-e1da4309b5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57f1c35b-315a-4986-a932-e1da4309b5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

