### PR TITLE
[ray-update-2.55.1] Update job-intro to Ray 2.55.1

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -4,7 +4,7 @@
 - name: job-intro
   dir: templates/intro-jobs
   cluster_env:
-    image_uri: anyscale/ray:2.54.1-py311
+    image_uri: anyscale/ray:2.55.1-py311
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml


### PR DESCRIPTION
## Summary
Bump job-intro to Ray 2.55.1.

## Changes
- `BUILD.yaml`: `job-intro` entry `image_uri` → `anyscale/ray:2.55.1-py311`.
- No in-template version strings to update.

## Tests / validation
- **CI:** Buildkite build [#142](https://buildkite.com/anyscale/template-test/builds/142) — passed. All GitHub Actions checks green (`build`, `check-depsets`, `pre-commit`, `validate-build-yaml`).
