### PR TITLE
[ray-update-2.55.1] Update workspace-intro to Ray 2.55.1

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -17,7 +17,7 @@
 - name: workspace-intro
   dir: templates/intro-workspaces
   cluster_env:
-    image_uri: anyscale/ray:2.54.1-py311
+    image_uri: anyscale/ray:2.55.1-py311
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml


### PR DESCRIPTION
## Summary
Bump workspace-intro to Ray 2.55.1.

## Changes
- BUILD.yaml: `workspace-intro` `image_uri` → `anyscale/ray:2.55.1-py311`.

## Tests / validation
- **CI:** Buildkite `template-test` build [#143](https://buildkite.com/anyscale/template-test/builds/143) — passed.
