### PR TITLE
Cursor Cloud agent setup for template-updater automation

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,18 +1,68 @@
 # Cursor Cloud Agent base image for anyscale/templates.
-# Provides the minimum prerequisites .cursor/install.sh needs to bootstrap
-# at every VM startup (curl, sudo, apt, python/pip, git). Heavier deps
-# (gh, anyscale, gcloud, docker) are installed by install.sh idempotently.
 #
-# This Dockerfile's primary job is to put environment.json into "Manual
-# Dockerfile" mode so Cursor honors the install command instead of falling
-# back to its agent-driven setup which ignores it.
-FROM ubuntu:22.04
+# Split between this Dockerfile and .cursor/install.sh:
+#   - Dockerfile: deterministic, version-pinned, secret-free tooling. Built
+#     once by Cursor, cached as image layers. Adding/bumping tools here
+#     triggers an automatic image rebuild on the next agent run.
+#   - install.sh: runtime auth (per-run secrets) + repo-tree-dependent
+#     setup (pre-commit hook, rayapp pinned via repo's download_rayapp.sh,
+#     skills clone). Runs on every VM start.
+#
+# This Dockerfile also puts environment.json into "Manual Dockerfile" mode
+# so Cursor honors the install command instead of its agent-driven setup.
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# --- Base OS packages ---
+# rsync + openssh-client are needed by `anyscale workspace push` (which
+# `rayapp test` calls). python-is-python3 makes `python` resolve, which
+# `update_deps.sh` and the depset/raydepsets scripts need.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl wget ca-certificates sudo gnupg lsb-release \
-      git python3 python3-pip \
+      git python3 python3-pip python-is-python3 \
+      rsync openssh-client \
  && rm -rf /var/lib/apt/lists/*
+
+# --- gh CLI ---
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update -qq && apt-get install -y gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# --- docker.io (for byod custom image flow via publish-custom-image.sh) ---
+RUN apt-get update -qq && apt-get install -y docker.io fuse-overlayfs iptables \
+ && rm -rf /var/lib/apt/lists/*
+
+# --- Python tooling (pinned via requirements-dev.txt, the single source of
+# truth shared with CI and human contributors). System-wide install so
+# binaries land in /usr/local/bin (already on PATH). --break-system-packages:
+# Ubuntu 24.04's Python 3.12 enforces PEP 668; safe in this single-purpose
+# container. ---
+COPY requirements-dev.txt /tmp/requirements-dev.txt
+RUN python3 -m pip install --no-warn-script-location --break-system-packages \
+      -r /tmp/requirements-dev.txt \
+ && rm /tmp/requirements-dev.txt
+
+# --- gcloud SDK (installed at /opt/google-cloud-sdk; bin added to PATH below) ---
+RUN curl -sSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh \
+ && bash /tmp/gcloud-install.sh --disable-prompts --install-dir=/opt \
+ && rm /tmp/gcloud-install.sh
+
+# --- Buildkite MCP server (pinned; the cursor cloud automation's MCP config
+# invokes `buildkite-mcp-server stdio` and the binary reads BUILDKITE_API_TOKEN
+# from the agent's env, populated by the Cursor secret). ---
+ARG BK_MCP_VER=v1.0.0
+RUN curl -fsSL "https://github.com/buildkite/buildkite-mcp-server/releases/download/${BK_MCP_VER}/buildkite-mcp-server_Linux_x86_64.tar.gz" \
+      | tar -xz -C /usr/local/bin buildkite-mcp-server \
+ && chmod +x /usr/local/bin/buildkite-mcp-server
+
+# --- Bake env into the image so ALL processes see it (login, non-login,
+# interactive, non-interactive). Replaces the prior /etc/profile.d/ + ~/.bashrc
+# dance, which depended on shell mode. ---
+ENV PATH=/opt/google-cloud-sdk/bin:$PATH
+ENV ANYSCALE_HOST=https://console.anyscale-staging.com
 
 WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,8 @@
 {
+  "name": "anyscale-templates-environment-dev",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "context": ".."
   },
   "install": "bash .cursor/install.sh",
   "start": "sudo service docker start"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,59 +1,41 @@
 #!/usr/bin/env bash
-# Cursor Cloud Agent install script.
-# Idempotent: runs on every VM startup. Cached via Cursor's snapshot.
+# Cursor Cloud Agent install script — runtime auth + repo-tree wiring.
+#
+# Split between this script and .cursor/Dockerfile:
+#   - Dockerfile (image build, cached): all deterministic, version-pinned,
+#     secret-free tooling — gh, docker, gcloud, anyscale CLI, pre-commit,
+#     buildkite-mcp-server, ANYSCALE_HOST, etc.
+#   - install.sh (every VM start): per-run auth using Cursor secrets, plus
+#     setup that depends on the mounted repo (rayapp pinned by
+#     download_rayapp.sh, pre-commit hook, sideloaded skills).
+#
 # Required secrets (set in Cursor → My Secrets, exposed as env vars):
-#   ANYSCALE_DEBUG_AGENT_GH_TOKEN  GitHub PAT with read on anyscale/anyscale-debug-agent
+#   ANYSCALE_GH_TOKEN  GitHub PAT — needs read on anyscale/anyscale-debug-agent
+#                                   (skills clone) AND push/PR/comment/label on anyscale/templates
+#                                   (gh fallback when Cursor's default auth lacks PR permissions).
 #   ANYSCALE_CLI_TOKEN             For the anyscale CLI
 #   GCP_TEMPLATE_REGISTRY_SA_KEY   GCP SA JSON for docker push to us-docker.pkg.dev
+#   BUILDKITE_API_TOKEN            Read by the Buildkite MCP server (Dockerfile-baked).
 set -euo pipefail
 
-# --- CLIs ---
-if ! command -v gh &>/dev/null; then
-  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
-  sudo apt-get update -qq
-  sudo apt-get install -y gh
+# --- pre-commit hooks (auto-fire on git commit; idempotent) ---
+# Non-fatal: pre-commit refuses if core.hooksPath is set (Cursor sets it).
+# The agent can still run `pre-commit run --all-files` by hand.
+if [ -f .pre-commit-config.yaml ] && [ -d .git ]; then
+  pre-commit install \
+    || echo "WARN: pre-commit install skipped — run 'pre-commit run --all-files' manually before committing."
 fi
 
-# --- Python tooling (versions pinned to match this repo's CI) ---
-python3 -m pip install --user --no-warn-script-location \
-  pre-commit==3.8.0 jupyter==1.1.1 anyscale==0.26.87
-export PATH="$HOME/.local/bin:$PATH"
-grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' ~/.bashrc 2>/dev/null \
-  || echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-
-# --- rayapp (version pinned via repo's download_rayapp.sh) ---
+# --- rayapp (version pinned via repo's download_rayapp.sh; lives in the
+# repo so kept here rather than baked into the image) ---
 if [ -f download_rayapp.sh ] && ! command -v rayapp &>/dev/null; then
   bash download_rayapp.sh
-  mkdir -p "$HOME/.local/bin"
-  mv rayapp "$HOME/.local/bin/rayapp"
+  mv rayapp /usr/local/bin/rayapp
 fi
 
-if ! command -v gcloud &>/dev/null; then
-  curl -sSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh
-  bash /tmp/gcloud-install.sh --disable-prompts --install-dir="$HOME"
-  echo 'export PATH=$PATH:$HOME/google-cloud-sdk/bin' >> ~/.bashrc
-fi
-export PATH=$PATH:$HOME/google-cloud-sdk/bin
-
-if ! command -v docker &>/dev/null; then
-  sudo apt-get update -qq
-  sudo apt-get install -y docker.io fuse-overlayfs iptables
-fi
-
-# --- Auth: gh (hard requirement — used to clone debug-agent skills) ---
-: "${ANYSCALE_DEBUG_AGENT_GH_TOKEN:?secret ANYSCALE_DEBUG_AGENT_GH_TOKEN is empty/unset; add it in Cursor → Cloud Agents → My Secrets}"
-echo "$ANYSCALE_DEBUG_AGENT_GH_TOKEN" | gh auth login --with-token
-
-# --- Sideload private skills from anyscale-debug-agent ---
-rm -rf /tmp/debug-agent
-GH_TOKEN="$ANYSCALE_DEBUG_AGENT_GH_TOKEN" gh repo clone anyscale/anyscale-debug-agent /tmp/debug-agent
-mkdir -p ~/.claude/skills
-cp -r /tmp/debug-agent/skills/* ~/.claude/skills/
-echo "User-scope skills:"
-ls ~/.claude/skills/
+# --- Auth: gh ---
+: "${ANYSCALE_GH_TOKEN:?secret ANYSCALE_GH_TOKEN is empty/unset; add it in Cursor → Cloud Agents → My Secrets}"
+echo "$ANYSCALE_GH_TOKEN" | gh auth login --with-token
 
 # --- Auth: gcloud (for docker push to GCP artifact registry; soft — only needed for custom images) ---
 if [ -n "${GCP_TEMPLATE_REGISTRY_SA_KEY:-}" ]; then
@@ -71,5 +53,66 @@ if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
 {"cli_token": "$ANYSCALE_CLI_TOKEN"}
 EOF
 else
-  echo "WARN: ANYSCALE_CLI_TOKEN not set — anyscale CLI commands will fail."
+  echo "WARN: ANYSCALE_CLI_TOKEN not set — rayapp and anyscale CLI commands will fail."
 fi
+
+# --- Sideload required skills (/ask, /fix, /run, /inspect) from
+# anyscale-debug-agent. Required for the /template update flow — without
+# /fix the agent cannot iterate on CI failures. Last in the script so a
+# clone failure can't cascade into losing earlier auth/creds setup; the
+# script still exits non-zero on failure. Sparse + shallow + blobless:
+# fetches only .claude/skills/ (~1.4M) instead of the full 210M repo.
+#
+# Direct `git clone` with the token in the URL, not `gh repo clone`:
+# newer `gh` doesn't auto-configure git's credential helper on
+# `gh auth login --with-token`, so the underlying git clone fires
+# anonymously and GitHub returns 404 on private repos. Embedding the
+# token in the URL bypasses that auth chain entirely. ---
+rm -rf /tmp/debug-agent
+git clone --depth 1 --single-branch --no-checkout --filter=blob:none \
+  "https://x-access-token:${ANYSCALE_GH_TOKEN}@github.com/anyscale/anyscale-debug-agent.git" \
+  /tmp/debug-agent
+git -C /tmp/debug-agent sparse-checkout set .claude/skills
+git -C /tmp/debug-agent checkout
+mkdir -p ~/.claude/skills
+# rsync --delete keeps ~/.claude/skills/ exactly mirrored to upstream — drops
+# any locally-stale skill that was removed from anyscale-debug-agent.
+rsync -a --delete /tmp/debug-agent/.claude/skills/ ~/.claude/skills/
+echo "User-scope skills:"
+ls ~/.claude/skills/
+# Clean up the cloned dir — the .git/config has the token embedded and
+# we've already extracted what we need.
+rm -rf /tmp/debug-agent
+
+# --- Cloud-agent MCP config: merge workspace .cursor/mcp.json into user-scope
+# ~/.cursor/mcp.json. Workspace-scope is read by Cursor IDE only; cloud agents
+# read user-scope at session boot. Merge rather than overwrite so any
+# pre-existing MCPs (e.g. ones Cursor itself populates) survive — workspace
+# entries win on key collision. ---
+if [ -f .cursor/mcp.json ]; then
+  mkdir -p ~/.cursor
+  python3 - <<'PY'
+import json, pathlib
+
+home = pathlib.Path.home() / ".cursor" / "mcp.json"
+ws = pathlib.Path(".cursor") / "mcp.json"
+
+merged = {}
+if home.exists():
+    try:
+        merged = json.loads(home.read_text())
+    except json.JSONDecodeError:
+        merged = {}
+
+ws_cfg = json.loads(ws.read_text())
+merged.setdefault("mcpServers", {})
+merged["mcpServers"].update(ws_cfg.get("mcpServers", {}))
+
+home.write_text(json.dumps(merged, indent=2) + "\n")
+print(f"Merged MCP servers from {ws} into {home}")
+PY
+fi
+
+# --- Preflight: validate the env this script just set up. Same script the
+# agent re-runs at task start (see AGENTS.md → Cursor Cloud → Preconditions). ---
+bash .cursor/preflight.sh

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "buildkite": {
+      "command": "buildkite-mcp-server",
+      "args": ["stdio"]
+    }
+  }
+}

--- a/.cursor/preflight.sh
+++ b/.cursor/preflight.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Cursor Cloud preflight — see AGENTS.md → Cursor Cloud → Preconditions.
+
+set -uo pipefail
+
+failures=()
+
+# Append a failure entry consisting of a summary line and an indented block of
+# captured stderr/stdout output, so summaries and their underlying errors stay
+# paired in the final report.
+add_failure_with_output() {
+  local summary="$1" output="$2" indented
+  indented=$(printf '%s\n' "$output" | sed 's/^/        /')
+  failures+=("$summary"$'\n'"      Raw error:"$'\n'"$indented")
+}
+
+# 1. Companion skills
+for s in ask fix run inspect; do
+  if [[ ! -f "$HOME/.claude/skills/$s/SKILL.md" ]]; then
+    failures+=("missing skill: ~/.claude/skills/$s/SKILL.md (clone of anyscale/anyscale-debug-agent failed? Check ANYSCALE_GH_TOKEN)")
+  fi
+done
+
+# 2. Environment variables
+for var in ANYSCALE_GH_TOKEN ANYSCALE_CLI_TOKEN GCP_TEMPLATE_REGISTRY_SA_KEY BUILDKITE_API_TOKEN; do
+  if [[ -z "${!var:-}" ]]; then
+    failures+=("missing env var: $var (team-scope, non-empty)")
+  fi
+done
+
+# 3. Auth verified
+if out=$(GH_TOKEN="${ANYSCALE_GH_TOKEN:-}" gh auth status 2>&1); then :; else
+  add_failure_with_output \
+    "gh auth: 'gh auth status' failed with ANYSCALE_GH_TOKEN — check token validity/scopes" \
+    "$out"
+fi
+
+# `gh auth status` validates the token but won't flag tokens that are valid
+# yet not SSO-authorized for the org — every PR write would 404.
+if out=$(GH_TOKEN="${ANYSCALE_GH_TOKEN:-}" gh api /repos/anyscale/templates 2>&1); then :; else
+  add_failure_with_output \
+    "gh repo access: ANYSCALE_GH_TOKEN can't fetch anyscale/templates — likely missing SSO authorization for the org" \
+    "$out"
+fi
+
+gcloud_out=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>&1)
+if ! echo "$gcloud_out" | grep -q .; then
+  add_failure_with_output \
+    "gcloud auth: no active account — service-account activation failed (check GCP_TEMPLATE_REGISTRY_SA_KEY)" \
+    "$gcloud_out"
+fi
+
+if [[ ! -f "$HOME/.docker/config.json" ]] \
+    || ! grep -q "us-docker.pkg.dev" "$HOME/.docker/config.json" 2>/dev/null; then
+  failures+=("docker auth: us-docker.pkg.dev not configured in ~/.docker/config.json — install.sh's 'gcloud auth configure-docker' step likely failed; custom-image push will fail")
+fi
+
+# Pinned to staging — Cursor Cloud agent must never run against prod.
+# --no-interactive prevents the CLI from prompting (would hang in CI).
+if out=$(ANYSCALE_HOST=https://console.anyscale-staging.com \
+         anyscale cloud list --no-interactive 2>&1); then :; else
+  add_failure_with_output \
+    "anyscale auth: 'anyscale cloud list' against staging failed — check ANYSCALE_CLI_TOKEN is a staging token" \
+    "$out"
+fi
+
+# Buildkite MCP server starts with a stale token and only 401s mid-task —
+# probe the API directly to surface that here.
+if [[ -n "${BUILDKITE_API_TOKEN:-}" ]]; then
+  if out=$(curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+           https://api.buildkite.com/v2/access-token 2>&1); then
+    if ! echo "$out" | grep -q '"uuid"'; then
+      add_failure_with_output \
+        "buildkite auth: BUILDKITE_API_TOKEN rejected by api.buildkite.com — token expired or revoked" \
+        "$out"
+    fi
+  else
+    add_failure_with_output \
+      "buildkite auth: 'curl https://api.buildkite.com/v2/access-token' failed" \
+      "$out"
+  fi
+fi
+
+# 4. Tools
+if ! command -v rayapp >/dev/null 2>&1; then
+  failures+=("rayapp not on PATH — install.sh's download_rayapp.sh step likely failed")
+fi
+
+if ! command -v buildkite-mcp-server >/dev/null 2>&1; then
+  failures+=("buildkite-mcp-server not on PATH — Dockerfile bake step regressed; Buildkite MCP integration will fail to start")
+fi
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  echo "Preflight FAILED:" >&2
+  for f in "${failures[@]}"; do
+    echo "  - $f" >&2
+  done
+  exit 1
+fi
+
+echo "Preflight OK: skills, secrets, and auth verified."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,48 @@
 
 Anyscale console templates. For any template-related work (bump Ray, format, publish, debug a test failure), use the `template` skill (`/template`) — canonical entry point for procedures and references.
 
-For cloud agents, companion skills `/fix`, `/run`, and `/inspect` are loaded at user scope via `.cursor/environment.json` for debugging. Advice: `/fix` is a powerful skill that handles the entire debug loop, you might want to wrap it with a subagent to avoid cluttering your main context too much.
+## Companion skills
 
-**CI invariant** — `.github/workflows/test-template.yaml` only runs when a PR comment matches `/test-template <template-id>`. After any push to a PR, comment to trigger or re-trigger validation.
+The `/template` update flow leans on companion skills `/ask`, `/fix`, `/run`, `/inspect` (from `anyscale/anyscale-debug-agent`). `/fix` in particular drives the CI iteration loop — without it you cannot reliably diagnose and fix a broken template. Strongly recommended for any update work. Tip: wrap `/fix` in a subagent to keep its debug output out of your main context.
 
-**Known automation** — the `template-updater` Cursor automation owns Ray-version bumps end-to-end (open PR → CI → fix-loop) on every major/minor Ray release. Its PRs use label `ray-update` and branches `update/*/ray-*`.
+For Cursor Cloud, these skills are a hard precondition (see Cursor Cloud → Preconditions).
+
+## Dev lifecycle
+
+Manage production templates (BUILD.yaml entries). No services to run.
+
+Local: edit → `pre-commit run --all-files` → push. Pre-commit covers lint, formatting, codebase conventions. `rayapp build all` mirrors CI's build job locally.
+
+Per-template tests — comment `/test-template <id> [<id>...]` (up to 3, parallel) on the PR to dispatch the Buildkite `template-test` pipeline (workspace + actual test run). For local iteration before pushing, `rayapp test <id>` runs the same flow (see `references/rayapp-local-testing.md` in the `/template` skill for setup).
+
+PR labels (apply all that fit):
+- `cursor-cloud` — origin: Cursor Cloud agent.
+- `ray-update` — content: Ray version bump.
+
+## Cursor Cloud
+
+The `template-updater` Cursor Cloud agent owns Ray-version bumps end-to-end (open PR → CI → fix-loop) on every major/minor Ray release.
+
+### Preconditions (HARD EXIT IF MISSING)
+
+Run `bash .cursor/preflight.sh` before any task. It checks:
+
+- **Companion skills** present at `~/.claude/skills/{ask,fix,run,inspect}` (cloned from `anyscale/anyscale-debug-agent` by `.cursor/install.sh`).
+- **Cursor secrets** (team-scope, all four non-empty):
+  - `ANYSCALE_GH_TOKEN` — skills clone + `gh` write fallback on this repo (see quirks below).
+  - `ANYSCALE_CLI_TOKEN`
+  - `GCP_TEMPLATE_REGISTRY_SA_KEY`
+  - `BUILDKITE_API_TOKEN`
+- **Auth verified:** `gh auth status` (with the token above), `gcloud auth list`, and `anyscale cloud list` all succeed.
+
+**If preflight exits non-zero, post its stderr as a PR comment and stop — don't attempt the task.**
+
+### Setup
+
+Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment setup. Run `bash .cursor/install.sh`. If anything fails, read the files and reproduce their steps yourself.
+
+### Cursor-specific quirks
+
+- **Branch naming:** Cursor auto-assigns `cursor/...`. (Outside Cursor, use `update/<template-name>/ray-<version>`.)
+- **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
+- **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,62 @@
-# Anyscale Starter Templates
+# Anyscale console templates
 
-These templates are a set of minimal examples & tutorials for customers to run on the anyscale platform.
+Reference templates that ship in the Anyscale console — dozens of working examples covering Ray Train, Ray Data, Ray Serve, RayLLM, fine-tuning, RAG, and more. Each one is a runnable notebook or script that a customer can launch end-to-end from the Anyscale UI.
 
-## Contributing Guide
+## Repository layout
 
-If the template is generic to Ray & Ray libraries, please consider adding the template in: https://github.com/ray-project/ray/tree/master/doc/source/templates
+```
+BUILD.yaml                # Manifest of every template (entry point, image, compute, test)
+templates/<name>/         # Template content — notebook or .py + Dockerfile (if custom image)
+tests/<name>/tests.sh     # Per-template smoke test, executed by CI
+configs/<name>/           # Compute configs: aws.yaml + gce.yaml (or reuse basic-single-node/)
+ci/                       # Schema validators + the README auto-generator
+.claude/skills/template/  # Maintenance procedures (Ray bumps, formatting, publishing)
+```
 
-To setup the environment:
-1. Install pre-commit `pip install pre-commit`
-2. Install the git hook scripts `pre-commit install`
+## Recommended workflow: delegate to the `/template` skill
 
+For most tasks — adding a template, bumping Ray, formatting to conventions, publishing a custom image — the fastest path is to ask Claude Code or Cursor to use the [`/template` skill](.claude/skills/template/). It's the canonical entry point for every procedure in this repo, and it knows the schema, image conventions, CI workflow, and validator rules.
 
-To add a template:
+Example prompts:
 
-1. Add your template as a directory under `templates/<your-template-name>`
+- *"Use `/template` to bump `deepspeed_finetune` to Ray 2.55.0."*
+- *"Use `/template` to format my new `my-rag-pipeline` template against repo conventions."*
+- *"Use `/template` to validate the `BUILD.yaml` entry I just added for `foo-bar`."*
+- *"Use `/template` to publish a new custom image for `entity-recognition-with-llms` at Ray 2.54.1."*
 
-    For example:
+The sections below describe what the skill (or you, manually) does under the hood — useful when you want to understand a step or work without an agent.
 
-    ```text
-    templates/my-awesome-template
-        <name-of-your-template>/
-            README.md
-            <name-of-your-template>.ipynb/py
-    ```
+## Contributing a template
 
-    Your template does not need to be a Jupyter notebook. It can also be presented as a
-    Python script.
+> For **Anyscale-platform-specific** content. If your template is generic Ray or a Ray library, please contribute upstream to [ray-project/ray](https://github.com/ray-project/ray/tree/master/doc/source/templates) instead.
 
-    All templates MUST have a `README.md` or a `README.ipynb` file.
+1. **Template content** at `templates/<name>/`:
+   - **Preferred:** a `README.ipynb` notebook — `README.md` is auto-generated from it on every commit via `nbconvert` (don't hand-edit the `.md`)
+   - **Minimum:** a hand-written `README.md` (this is what's rendered in the Anyscale console preview)
+   - A `Dockerfile` only if you need a custom image — otherwise reference a stock `anyscale/ray:...` image
+2. **Test** at `tests/<name>/tests.sh` — runs in CI to confirm the template still works end-to-end
+3. **Compute config:** most templates reuse `configs/basic-single-node/`. If you need custom compute, add `configs/<name>/aws.yaml` + `configs/<name>/gce.yaml`
+4. **`BUILD.yaml` entry** — schema in [`.claude/skills/template/references/build-yaml-schema.yaml`](.claude/skills/template/references/build-yaml-schema.yaml), strictly validated by `ci/validate_build_yaml.py` (also runs as a pre-commit hook)
+5. **Custom image** (only if you set `cluster_env.byod`): build and push with [`.claude/skills/template/scripts/publish-custom-image.sh`](.claude/skills/template/scripts/publish-custom-image.sh)`<dockerfile-dir> <name> <ray-version>`. You need permissions to push to Anyscale's public GCP Artifact registry.
 
-2. Add your compute configuration under `configs/<your-template-name>` (for both AWS and GCE).
+## Local development
 
-3. Update the product repo `backend/workspace-templates.yaml` to point to the new template added here after being merged.
+Requires Python 3.12 (matches CI and cursor cloud — `generate-readme` is byte-deterministic at that version).
+
+```bash
+pip install -r requirements-dev.txt               # pinned dev deps (single source of truth)
+pre-commit install                                # auto-fire hooks on git commit
+pre-commit run --all-files                        # lint + schema + auto-README
+python3 ci/validate_build_yaml.py --no-network    # offline BUILD.yaml validation
+bash ./update_deps.sh --check                     # dependency lockfile up-to-date check
+```
+
+For `rayapp` (the local test runner), GCP/anyscale auth, and the full dev environment, see [`.cursor/install.sh`](.cursor/install.sh) — it's the source of truth.
+
+## CI
+
+Static checks (schema, paths, README generation, build) run on every push. To run a template's actual tests, comment **`/test-template <name>`** on the PR — accepts up to three names, fanned out in parallel.
+
+## Running this repo with an AI agent
+
+If you're using Cursor Cloud or Claude Code, see [`AGENTS.md`](AGENTS.md) for setup, required secrets, and the operational cheatsheet.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,14 @@
+# Pinned dev/contributor deps — single source of truth for Python tooling.
+#
+# Consumers:
+#   - .cursor/Dockerfile (cursor cloud agent base image)
+#   - .github/workflows/premerge.yaml (CI)
+#   - human contributors (see README.md "Local development")
+#
+# Bumping a version here propagates to all three on the next image rebuild
+# / CI run / contributor pull.
+pre-commit==3.8.0
+nbconvert==7.17.1
+anyscale==0.26.87
+pyyaml==6.0.3
+pydantic==2.13.3


### PR DESCRIPTION
## Summary
Third of a 3-PR stack carved out of #619.

Sets up a deterministic, hands-off environment for the \`template-updater\` Cursor Cloud agent to bump templates to new Ray releases end-to-end (open PR → \`/test-template\` → fix loop on failure → mark ready when CI green).

## Changes
- **\`.cursor/Dockerfile\`** — Ubuntu 24.04, bakes \`gh\`, \`docker.io\`, \`gcloud\` SDK, \`buildkite-mcp-server\`, and pinned Python deps from \`requirements-dev.txt\` (PR 1). \`ANYSCALE_HOST\` pinned to staging at the image level.
- **\`.cursor/install.sh\`** — per-VM-start runtime auth (gh PAT, gcloud SA, anyscale CLI), \`rayapp\` install, sparse + blobless clone of skills from \`anyscale-debug-agent\`, MCP config merge into \`~/.cursor/mcp.json\`.
- **\`.cursor/preflight.sh\`** *(new)* — hard-fail precondition validator: companion skills present, all 4 team-scope secrets non-empty, \`gh\` / \`gcloud\` / \`anyscale\` auth verified (staging-pinned), Buildkite token live, GCP docker auth wired, \`rayapp\` + \`buildkite-mcp-server\` on PATH. Captured stderr is paired with each failure as \`Raw error:\`.
- **\`.cursor/mcp.json\`** *(new)* — workspace MCP config registering \`buildkite-mcp\`.
- **\`.cursor/environment.json\`** — dockerfile + install + start hooks.
- **\`AGENTS.md\`** — Companion skills, Cursor Cloud Preconditions (points at \`preflight.sh\`), Setup, Cursor-specific quirks (branch naming, pre-commit, gh write fallback).
- **\`README.md\`** — rewrite around the Anyscale-console-templates framing, recommend the \`/template\` skill, point local dev at \`requirements-dev.txt\` (PR 1).

## Stack
- PR 1: dev deps + CI Python alignment → \`main\` (#638)
- PR 2: template skill refinements → PR 1 (#639)
- **PR 3 (this):** Cursor Cloud agent setup → PR 2

## Test plan
- [x] Trigger a Cursor Cloud agent on this branch and verify it boots through preflight without failures.
- [ ] Verify \`buildkite-mcp\` registers via \`~/.cursor/mcp.json\` (visible in agent's tool list).
- [x] Trigger an end-to-end Ray-version bump via the automation webhook against \`fix/agents-md-setup\`-style override and confirm the PR opens.