### PR TITLE
Bump anyscale CLI from 0.26.87 to 0.26.99

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@
 # / CI run / contributor pull.
 pre-commit==3.8.0
 nbconvert==7.17.1
-anyscale==0.26.87
+anyscale==0.26.99
 pyyaml==6.0.3
 pydantic==2.13.3


### PR DESCRIPTION
## Summary
Bumps \`anyscale\` in \`requirements-dev.txt\` from 0.26.87 → 0.26.99 (latest on PyPI).

## Why
Unlocks \`anyscale skills install\` in the cursor cloud agent setup. Today the agent gets a GitHub PAT scoped to clone the skills repo; with 0.26.99 we can install skills via the Anyscale backend (using the existing \`ANYSCALE_CLI_TOKEN\`) and drop the GitHub PAT dependency for that path. See follow-up #643 for the actual install.sh switch.

## Out of scope
\`ci/render-template-pipeline.sh\` has its own \`anyscale==0.26.87\` install for the forge-image rayapp test runner — left at 0.26.87 here. Will be picked up automatically once #638 lands (which switches that script to read the pin from \`requirements-dev.txt\`).

## Test plan
- [ ] CI green on this PR.
- [ ] After merge, verify cloud-agent image rebuild picks up the new version.