### PR TITLE
install.sh: fetch skills via 'anyscale skills install' instead of git clone

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -6,7 +6,7 @@
 #     triggers an automatic image rebuild on the next agent run.
 #   - install.sh: runtime auth (per-run secrets) + repo-tree-dependent
 #     setup (pre-commit hook, rayapp pinned via repo's download_rayapp.sh,
-#     skills clone). Runs on every VM start.
+#     skills install via 'anyscale skills install'). Runs on every VM start.
 #
 # This Dockerfile also puts environment.json into "Manual Dockerfile" mode
 # so Cursor honors the install command instead of its agent-driven setup.

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -10,10 +10,10 @@
 #     download_rayapp.sh, pre-commit hook, sideloaded skills).
 #
 # Required secrets (set in Cursor → My Secrets, exposed as env vars):
-#   ANYSCALE_GH_TOKEN  GitHub PAT — needs read on anyscale/anyscale-debug-agent
-#                                   (skills clone) AND push/PR/comment/label on anyscale/templates
-#                                   (gh fallback when Cursor's default auth lacks PR permissions).
-#   ANYSCALE_CLI_TOKEN             For the anyscale CLI
+#   ANYSCALE_GH_TOKEN  GitHub PAT — needs push/PR/comment/label on anyscale/templates
+#                                   (gh fallback; Cursor's default GH App auth lacks PR permissions).
+#   ANYSCALE_CLI_TOKEN             anyscale CLI auth — also used by `anyscale skills install`
+#                                   to fetch /ask, /fix, /run, /inspect from Anyscale's backend.
 #   GCP_TEMPLATE_REGISTRY_SA_KEY   GCP SA JSON for docker push to us-docker.pkg.dev
 #   BUILDKITE_API_TOKEN            Read by the Buildkite MCP server (Dockerfile-baked).
 set -euo pipefail
@@ -46,43 +46,23 @@ else
   echo "WARN: GCP_TEMPLATE_REGISTRY_SA_KEY not set — custom-image rebuild + push to GCP will fail."
 fi
 
-# --- Auth: anyscale CLI (soft — only needed for templates that invoke the anyscale CLI) ---
+# --- Auth: anyscale CLI + sideload required skills (/ask, /fix, /run,
+# /inspect) via the CLI. The skills are required for the /template update
+# flow — without /fix the agent cannot iterate on CI failures.
+# `anyscale skills install` pulls them from Anyscale's skills backend using
+# ANYSCALE_CLI_TOKEN (no GitHub PAT needed). `-f` overwrites locally-stale
+# files so we always get the latest published skills. ---
 if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
   mkdir -p ~/.anyscale
   cat > ~/.anyscale/credentials.json <<EOF
 {"cli_token": "$ANYSCALE_CLI_TOKEN"}
 EOF
+  anyscale skills install -p claude-code -y -f
+  echo "User-scope skills:"
+  ls ~/.claude/skills/
 else
-  echo "WARN: ANYSCALE_CLI_TOKEN not set — rayapp and anyscale CLI commands will fail."
+  echo "WARN: ANYSCALE_CLI_TOKEN not set — anyscale CLI commands and skill install will fail. preflight will catch this."
 fi
-
-# --- Sideload required skills (/ask, /fix, /run, /inspect) from
-# anyscale-debug-agent. Required for the /template update flow — without
-# /fix the agent cannot iterate on CI failures. Last in the script so a
-# clone failure can't cascade into losing earlier auth/creds setup; the
-# script still exits non-zero on failure. Sparse + shallow + blobless:
-# fetches only .claude/skills/ (~1.4M) instead of the full 210M repo.
-#
-# Direct `git clone` with the token in the URL, not `gh repo clone`:
-# newer `gh` doesn't auto-configure git's credential helper on
-# `gh auth login --with-token`, so the underlying git clone fires
-# anonymously and GitHub returns 404 on private repos. Embedding the
-# token in the URL bypasses that auth chain entirely. ---
-rm -rf /tmp/debug-agent
-git clone --depth 1 --single-branch --no-checkout --filter=blob:none \
-  "https://x-access-token:${ANYSCALE_GH_TOKEN}@github.com/anyscale/anyscale-debug-agent.git" \
-  /tmp/debug-agent
-git -C /tmp/debug-agent sparse-checkout set .claude/skills
-git -C /tmp/debug-agent checkout
-mkdir -p ~/.claude/skills
-# rsync --delete keeps ~/.claude/skills/ exactly mirrored to upstream — drops
-# any locally-stale skill that was removed from anyscale-debug-agent.
-rsync -a --delete /tmp/debug-agent/.claude/skills/ ~/.claude/skills/
-echo "User-scope skills:"
-ls ~/.claude/skills/
-# Clean up the cloned dir — the .git/config has the token embedded and
-# we've already extracted what we need.
-rm -rf /tmp/debug-agent
 
 # --- Cloud-agent MCP config: merge workspace .cursor/mcp.json into user-scope
 # ~/.cursor/mcp.json. Workspace-scope is read by Cursor IDE only; cloud agents

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -9,13 +9,11 @@
 #     setup that depends on the mounted repo (rayapp pinned by
 #     download_rayapp.sh, pre-commit hook, sideloaded skills).
 #
-# Required secrets (set in Cursor → My Secrets, exposed as env vars):
-#   ANYSCALE_GH_TOKEN  GitHub PAT — needs push/PR/comment/label on anyscale/templates
-#                                   (gh fallback; Cursor's default GH App auth lacks PR permissions).
-#   ANYSCALE_CLI_TOKEN             anyscale CLI auth — also used by `anyscale skills install`
-#                                   to fetch /ask, /fix, /run, /inspect from Anyscale's backend.
-#   GCP_TEMPLATE_REGISTRY_SA_KEY   GCP SA JSON for docker push to us-docker.pkg.dev
-#   BUILDKITE_API_TOKEN            Read by the Buildkite MCP server (Dockerfile-baked).
+# Required secrets (Cursor → My Secrets):
+#   ANYSCALE_GH_TOKEN              gh write fallback on anyscale/templates
+#   ANYSCALE_CLI_TOKEN             anyscale CLI auth + skills install
+#   GCP_TEMPLATE_REGISTRY_SA_KEY   docker push to us-docker.pkg.dev
+#   BUILDKITE_API_TOKEN            Buildkite MCP server (Dockerfile-baked)
 set -euo pipefail
 
 # --- pre-commit hooks (auto-fire on git commit; idempotent) ---
@@ -46,22 +44,17 @@ else
   echo "WARN: GCP_TEMPLATE_REGISTRY_SA_KEY not set — custom-image rebuild + push to GCP will fail."
 fi
 
-# --- Auth: anyscale CLI + sideload required skills (/ask, /fix, /run,
-# /inspect) via the CLI. The skills are required for the /template update
-# flow — without /fix the agent cannot iterate on CI failures.
-# `anyscale skills install` pulls them from Anyscale's skills backend using
-# ANYSCALE_CLI_TOKEN (no GitHub PAT needed). `-f` overwrites locally-stale
-# files so we always get the latest published skills. ---
+# --- Auth: anyscale CLI + skills install (/ask, /fix, /run, /inspect).
+# -f overwrites locally-stale skills with the latest published. ---
 if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
   mkdir -p ~/.anyscale
   cat > ~/.anyscale/credentials.json <<EOF
 {"cli_token": "$ANYSCALE_CLI_TOKEN"}
 EOF
   anyscale skills install -p claude-code -y -f
-  echo "User-scope skills:"
   ls ~/.claude/skills/
 else
-  echo "WARN: ANYSCALE_CLI_TOKEN not set — anyscale CLI commands and skill install will fail. preflight will catch this."
+  echo "WARN: ANYSCALE_CLI_TOKEN not set — preflight will fail."
 fi
 
 # --- Cloud-agent MCP config: merge workspace .cursor/mcp.json into user-scope

--- a/.cursor/preflight.sh
+++ b/.cursor/preflight.sh
@@ -17,7 +17,7 @@ add_failure_with_output() {
 # 1. Companion skills
 for s in ask fix run inspect; do
   if [[ ! -f "$HOME/.claude/skills/$s/SKILL.md" ]]; then
-    failures+=("missing skill: ~/.claude/skills/$s/SKILL.md (clone of anyscale/anyscale-debug-agent failed? Check ANYSCALE_GH_TOKEN)")
+    failures+=("missing skill: ~/.claude/skills/$s/SKILL.md ('anyscale skills install -p claude-code -y -f' didn't run, or failed? Check ANYSCALE_CLI_TOKEN)")
   fi
 done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Anyscale console templates. For any template-related work (bump Ray, format, pub
 
 ## Companion skills
 
-The `/template` update flow leans on companion skills `/ask`, `/fix`, `/run`, `/inspect` (from `anyscale/anyscale-debug-agent`). `/fix` in particular drives the CI iteration loop — without it you cannot reliably diagnose and fix a broken template. Strongly recommended for any update work. Tip: wrap `/fix` in a subagent to keep its debug output out of your main context.
+The `/template` update flow leans on companion skills `/ask`, `/fix`, `/run`, `/inspect` (install with `anyscale skills install -p claude-code -y -f` — pulls from Anyscale's skills backend; uses `ANYSCALE_CLI_TOKEN`). `/fix` in particular drives the CI iteration loop — without it you cannot reliably diagnose and fix a broken template. Strongly recommended for any update work. Tip: wrap `/fix` in a subagent to keep its debug output out of your main context.
 
 For Cursor Cloud, these skills are a hard precondition (see Cursor Cloud → Preconditions).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,10 @@ The `template-updater` Cursor Cloud agent owns Ray-version bumps end-to-end (ope
 
 Run `bash .cursor/preflight.sh` before any task. It checks:
 
-- **Companion skills** present at `~/.claude/skills/{ask,fix,run,inspect}` (cloned from `anyscale/anyscale-debug-agent` by `.cursor/install.sh`).
+- **Companion skills** present at `~/.claude/skills/{ask,fix,run,inspect}` (installed by `.cursor/install.sh` via `anyscale skills install -p claude-code -y -f`, which fetches them from Anyscale's backend using `ANYSCALE_CLI_TOKEN`).
 - **Cursor secrets** (team-scope, all four non-empty):
-  - `ANYSCALE_GH_TOKEN` — skills clone + `gh` write fallback on this repo (see quirks below).
-  - `ANYSCALE_CLI_TOKEN`
+  - `ANYSCALE_GH_TOKEN` — `gh` write fallback on this repo (see quirks below).
+  - `ANYSCALE_CLI_TOKEN` — anyscale CLI auth + skill install.
   - `GCP_TEMPLATE_REGISTRY_SA_KEY`
   - `BUILDKITE_API_TOKEN`
 - **Auth verified:** `gh auth status` (with the token above), `gcloud auth list`, and `anyscale cloud list` all succeed.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@
 # / CI run / contributor pull.
 pre-commit==3.8.0
 nbconvert==7.17.1
-anyscale==0.26.87
+anyscale==0.26.99
 pyyaml==6.0.3
 pydantic==2.13.3


### PR DESCRIPTION
## Summary
Replaces the sparse + blobless git clone of \`anyscale/anyscale-debug-agent\` in \`.cursor/install.sh\` with a single CLI call:

\`\`\`bash
anyscale skills install -p claude-code -y -f
\`\`\`

The CLI pulls from Anyscale's skills backend using \`ANYSCALE_CLI_TOKEN\`, so \`ANYSCALE_GH_TOKEN\` is no longer needed for the skills sideload (still required for the \`gh\` PR-write fallback). Net: ~30 lines of git/rsync plumbing → one command.

Also bumps anyscale CLI from \`0.26.87\` → \`0.26.99\` in \`requirements-dev.txt\` (the version that ships \`anyscale skills install\`). This absorbs what was #641 — closing that PR.

\`AGENTS.md\` Preconditions updated to describe the new install path and tighten the \`ANYSCALE_GH_TOKEN\` purpose blurb.

## Test plan
- [ ] CI green (premerge installs from the bumped requirements-dev.txt).
- [ ] After merge, retrigger a Cursor Cloud agent run and verify \`~/.claude/skills/{ask,fix,run,inspect}/SKILL.md\` exist after install.sh.