### PR TITLE
Cursor Cloud env: align skill paths to anyscale-platform-* + pass BUILDKITE_API_TOKEN to MCP

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -54,11 +54,11 @@ if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
 {"cli_token": "$ANYSCALE_CLI_TOKEN"}
 EOF
   anyscale skills install -p claude-code -y -f
-  for d in ~/.claude/skills/*/; do
+  for d in ~/.claude/skills/*; do
     [ -d "$d" ] || continue
     case "$(basename "$d")" in
       anyscale-platform-ask|anyscale-platform-fix|anyscale-platform-run|anyscale-platform-inspect) ;;
-      *) echo "Removing unrecognized skill: $d"; rm -rf "$d" ;;
+      *) echo "Removing unrecognized skill: $d"; rm -rf -- "$d" ;;
     esac
   done
   ls ~/.claude/skills/

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -45,13 +45,22 @@ else
 fi
 
 # --- Auth: anyscale CLI + skills install (/ask, /fix, /run, /inspect).
-# -f overwrites locally-stale skills with the latest published. ---
+# -f overwrites locally-stale skills with the latest published.
+# After install, prune any other skill dirs so ~/.claude/skills/ mirrors
+# what the CLI laid down — keeps the env hermetic across runs. ---
 if [ -n "${ANYSCALE_CLI_TOKEN:-}" ]; then
   mkdir -p ~/.anyscale
   cat > ~/.anyscale/credentials.json <<EOF
 {"cli_token": "$ANYSCALE_CLI_TOKEN"}
 EOF
   anyscale skills install -p claude-code -y -f
+  for d in ~/.claude/skills/*/; do
+    [ -d "$d" ] || continue
+    case "$(basename "$d")" in
+      anyscale-platform-ask|anyscale-platform-fix|anyscale-platform-run|anyscale-platform-inspect) ;;
+      *) echo "Removing unrecognized skill: $d"; rm -rf "$d" ;;
+    esac
+  done
   ls ~/.claude/skills/
 else
   echo "WARN: ANYSCALE_CLI_TOKEN not set — preflight will fail."

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "buildkite": {
       "command": "buildkite-mcp-server",
-      "args": ["stdio"]
+      "args": ["stdio"],
+      "env": {
+        "BUILDKITE_API_TOKEN": "${env:BUILDKITE_API_TOKEN}"
+      }
     }
   }
 }

--- a/.cursor/preflight.sh
+++ b/.cursor/preflight.sh
@@ -14,10 +14,11 @@ add_failure_with_output() {
   failures+=("$summary"$'\n'"      Raw error:"$'\n'"$indented")
 }
 
-# 1. Companion skills
+# 1. Companion skills (anyscale skills install lays them down as
+# anyscale-platform-{ask,fix,run,inspect}/).
 for s in ask fix run inspect; do
-  if [[ ! -f "$HOME/.claude/skills/$s/SKILL.md" ]]; then
-    failures+=("missing skill: ~/.claude/skills/$s/SKILL.md ('anyscale skills install -p claude-code -y -f' didn't run, or failed? Check ANYSCALE_CLI_TOKEN)")
+  if [[ ! -f "$HOME/.claude/skills/anyscale-platform-$s/SKILL.md" ]]; then
+    failures+=("missing skill: ~/.claude/skills/anyscale-platform-$s/SKILL.md ('anyscale skills install -p claude-code -y -f' didn't run, or failed? Check ANYSCALE_CLI_TOKEN)")
   fi
 done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ The `template-updater` Cursor Cloud agent owns Ray-version bumps end-to-end (ope
 
 Run `bash .cursor/preflight.sh` before any task. It checks:
 
-- **Companion skills** present at `~/.claude/skills/{ask,fix,run,inspect}` (installed by `.cursor/install.sh` via `anyscale skills install -p claude-code -y -f`, which fetches them from Anyscale's backend using `ANYSCALE_CLI_TOKEN`).
+- **Companion skills** present at `~/.claude/skills/anyscale-platform-{ask,fix,run,inspect}` (installed by `.cursor/install.sh` via `anyscale skills install -p claude-code -y -f`, which fetches them from Anyscale's backend using `ANYSCALE_CLI_TOKEN`).
 - **Cursor secrets** (team-scope, all four non-empty):
   - `ANYSCALE_GH_TOKEN` — `gh` write fallback on this repo (see quirks below).
   - `ANYSCALE_CLI_TOKEN` — anyscale CLI auth + skill install.
@@ -48,10 +48,8 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
 - **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.
 
-## Cursor Cloud specific instructions
+### Notes from Cursor Cloud agent runs
 
-- **Skill path symlinks:** `anyscale skills install -p claude-code -y -f` installs skills under `~/.claude/skills/anyscale-platform-{ask,fix,run,inspect}/`, but preflight.sh expects them at `~/.claude/skills/{ask,fix,run,inspect}/`. After skills install, create symlinks: `cd ~/.claude/skills && ln -sf anyscale-platform-ask ask && ln -sf anyscale-platform-fix fix && ln -sf anyscale-platform-run run && ln -sf anyscale-platform-inspect inspect`.
-- **No services to start.** This is a static content/template repo — the "application" is the set of template files + BUILD.yaml manifest. Validation is entirely local via `pre-commit run --all-files`, `python3 ci/validate_build_yaml.py --no-network`, and `rayapp build all`.
-- **Lint before commit:** Always run `pre-commit run --all-files` before committing (hooks don't auto-fire due to `core.hooksPath`).
-- **`rayapp build all`** converts all notebooks to markdown and validates the build; exit 0 = success. Warnings about non-self-closing `<img>` tags are harmless.
-- **`update_deps.sh --check`** validates dependency lockfiles are up-to-date (requires network for the first run to fetch Ray constraints).
+- **No services to start.** This is a static content repo — validation is local via `pre-commit run --all-files`, `python3 ci/validate_build_yaml.py --no-network`, and `rayapp build all`.
+- **`rayapp build all`** converts notebooks → markdown and validates the build; exit 0 = success. Warnings about non-self-closing `<img>` tags are harmless.
+- **`update_deps.sh --check`** validates dependency lockfiles are up-to-date (requires network on first run to fetch Ray constraints).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,11 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **Branch naming:** Cursor auto-assigns `cursor/...`. (Outside Cursor, use `update/<template-name>/ray-<version>`.)
 - **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
 - **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.
+
+## Cursor Cloud specific instructions
+
+- **Skill path symlinks:** `anyscale skills install -p claude-code -y -f` installs skills under `~/.claude/skills/anyscale-platform-{ask,fix,run,inspect}/`, but preflight.sh expects them at `~/.claude/skills/{ask,fix,run,inspect}/`. After skills install, create symlinks: `cd ~/.claude/skills && ln -sf anyscale-platform-ask ask && ln -sf anyscale-platform-fix fix && ln -sf anyscale-platform-run run && ln -sf anyscale-platform-inspect inspect`.
+- **No services to start.** This is a static content/template repo — the "application" is the set of template files + BUILD.yaml manifest. Validation is entirely local via `pre-commit run --all-files`, `python3 ci/validate_build_yaml.py --no-network`, and `rayapp build all`.
+- **Lint before commit:** Always run `pre-commit run --all-files` before committing (hooks don't auto-fire due to `core.hooksPath`).
+- **`rayapp build all`** converts all notebooks to markdown and validates the build; exit 0 = success. Warnings about non-self-closing `<img>` tags are harmless.
+- **`update_deps.sh --check`** validates dependency lockfiles are up-to-date (requires network for the first run to fetch Ray constraints).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,3 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **Branch naming:** Cursor auto-assigns `cursor/...`. (Outside Cursor, use `update/<template-name>/ray-<version>`.)
 - **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
 - **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.
-
-### Notes from Cursor Cloud agent runs
-
-- **No services to start.** This is a static content repo — validation is local via `pre-commit run --all-files`, `python3 ci/validate_build_yaml.py --no-network`, and `rayapp build all`.
-- **`rayapp build all`** converts notebooks → markdown and validates the build; exit 0 = success. Warnings about non-self-closing `<img>` tags are harmless.
-- **`update_deps.sh --check`** validates dependency lockfiles are up-to-date (requires network on first run to fetch Ray constraints).


### PR DESCRIPTION
## Summary
Two issues found while bringing up the Cursor Cloud env from a fresh run, plus a documentation alignment.

### 1. Skill paths
\`anyscale skills install -p claude-code -y -f\` lays the companion skills down at \`~/.claude/skills/anyscale-platform-{ask,fix,run,inspect}/\`, but \`preflight.sh\` was checking the bare \`{ask,fix,run,inspect}\` paths. The original PR proposed symlinking around the mismatch — fixing the actual paths is cleaner.

- **\`.cursor/preflight.sh\`** — checks \`anyscale-platform-{ask,fix,run,inspect}/SKILL.md\` directly.
- **\`.cursor/install.sh\`** — after \`anyscale skills install\`, prune any other dirs from \`~/.claude/skills/\` so the env mirrors the CLI install (hermetic across re-runs).
- **\`AGENTS.md\`** Preconditions — path updated to the real \`anyscale-platform-*\` form.

### 2. Buildkite MCP couldn't start in the cloud-agent env
The exec-daemon log showed:

\`\`\`
ERROR Exec-daemon MCP server failed to start
  serverName: "Buildkite"
  envKeys: []
  errorMessage: "MCP error -32000: Connection closed"
\`\`\`

\`envKeys: []\` is the smoking gun — the MCP child gets spawned with no env, so \`buildkite-mcp-server\` finds no \`BUILDKITE_API_TOKEN\` and exits immediately. Cursor Cloud's exec-daemon doesn't auto-pass env into MCP children; it only passes what's declared in the \`env\` block (per Cursor's MCP docs syntax \`\${env:VAR}\`).

- **\`.cursor/mcp.json\`** — adds \`env: { "BUILDKITE_API_TOKEN": "\${env:BUILDKITE_API_TOKEN}" }\`.

⚠️ **Note**: the runtime config is currently the **team-scope dashboard MCP** (Integrations & MCP), not the workspace \`.cursor/mcp.json\` shipped here. The same \`env\` block needs to be added to the dashboard entry too (or the dashboard entry replaced with the workspace one) for the next agent run to actually pick up the token.

## Test plan
- [x] \`bash -n\` clean on \`install.sh\` and \`preflight.sh\`.
- [x] Prune loop smoke-tested locally — keeps the four \`anyscale-platform-*\` dirs and removes anything else.
- [ ] Trigger a fresh Cursor Cloud agent run and confirm:
  - preflight passes after install.sh completes
  - exec-daemon log shows \`envKeys: ["BUILDKITE_API_TOKEN"]\` for the Buildkite MCP (instead of \`[]\`)
  - Buildkite MCP tools are visible to the agent