### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,4 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **pip installs land in `~/.local/bin`:** The base image runs as non-root, so `pip install --break-system-packages` puts binaries (e.g. `pre-commit`, `anyscale`) in `~/.local/bin`. Ensure this is on `$PATH`.
 - **gcloud SDK lives at `/opt/google-cloud-sdk/bin`:** Must be on `$PATH` for `gcloud auth` and `gcloud auth configure-docker` to work.
 - **`ANYSCALE_HOST` must be `https://console.anyscale-staging.com`:** The CLI is pinned to staging; preflight validates this.
+- **Secret casing gotcha:** Cursor Secrets may lowercase token values. If `ANYSCALE_GH_TOKEN` returns 401, check `echo -n "$ANYSCALE_GH_TOKEN" | od -c | head` — GitHub PATs are case-sensitive.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,11 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **Branch naming:** Cursor auto-assigns `cursor/...`. (Outside Cursor, use `update/<template-name>/ray-<version>`.)
 - **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
 - **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.
+
+## Cursor Cloud specific instructions
+
+- **No services to run.** This repo manages template definitions (BUILD.yaml). The dev loop is: edit templates → `pre-commit run --all-files` → push. `rayapp build all` mirrors CI's build job.
+- **Docker in nested container:** dockerd must be started with `sudo dockerd &` (not `service docker start`). The Dockerfile configures `fuse-overlayfs` as the storage driver and `iptables-legacy`; these are already set up by the image/install flow.
+- **pip installs land in `~/.local/bin`:** The base image runs as non-root, so `pip install --break-system-packages` puts binaries (e.g. `pre-commit`, `anyscale`) in `~/.local/bin`. Ensure this is on `$PATH`.
+- **gcloud SDK lives at `/opt/google-cloud-sdk/bin`:** Must be on `$PATH` for `gcloud auth` and `gcloud auth configure-docker` to work.
+- **`ANYSCALE_HOST` must be `https://console.anyscale-staging.com`:** The CLI is pinned to staging; preflight validates this.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious operational notes for future cloud agents:

- No services to run — dev loop is edit → pre-commit → push
- Docker nested-container startup (dockerd, not service docker start)
- pip binary path (`~/.local/bin`) must be on `$PATH`
- gcloud SDK path at `/opt/google-cloud-sdk/bin`
- `ANYSCALE_HOST` must point to staging

These notes capture gotchas discovered during environment setup so future agents don't need to rediscover them.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2254d7c-8e70-49b6-8195-861901532314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2254d7c-8e70-49b6-8195-861901532314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

