### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,13 @@ Use `.cursor/Dockerfile` and `.cursor/install.sh` as the canonical environment s
 - **Branch naming:** Cursor auto-assigns `cursor/...`. (Outside Cursor, use `update/<template-name>/ray-<version>`.)
 - **`pre-commit install` doesn't auto-fire:** Cursor sets `core.hooksPath`, which causes pre-commit to skip its hook install. Run `pre-commit run --all-files` manually before committing.
 - **GitHub write operations:** Cursor's default GitHub App auth can't write to this repo. **Always prefix `gh` write commands** (`gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue comment`, `gh pr review`) with `GH_TOKEN=$ANYSCALE_GH_TOKEN`. Read-only `gh` calls work without the prefix.
+
+## Cursor Cloud specific instructions
+
+This section captures non-obvious runtime caveats for future cloud agents. The canonical setup is `.cursor/Dockerfile` (image build) + `.cursor/install.sh` (per-run auth); see those files for the full picture.
+
+- **No services to run.** This is a content-only template repository. The dev loop is: edit files → `pre-commit run --all-files` → push. `rayapp build all` mirrors CI locally.
+- **Validation commands:** `python3 ci/validate_build_yaml.py --no-network` (offline schema check) and `bash ./update_deps.sh --check` (depset lockfile freshness). Both should pass on a clean checkout.
+- **Docker in Cursor VM:** If Docker is needed (custom image flows), start with `sudo dockerd &` and fix socket permissions with `sudo chmod 666 /var/run/docker.sock`. The daemon config at `/etc/docker/daemon.json` already sets `fuse-overlayfs`; do not pass `--storage-driver` as a flag too, or dockerd will refuse to start.
+- **PATH:** When the environment is built from the Dockerfile, all binaries are on PATH. If running `install.sh` manually in a fresh VM, pip packages (pre-commit, anyscale, nbconvert) land in `~/.local/bin` — ensure it is on PATH. `gcloud` lives at `/opt/google-cloud-sdk/bin`.
+- **`install.sh` needs sudo for rayapp:** `download_rayapp.sh` writes the binary to `$PWD`; the `mv` to `/usr/local/bin/` requires sudo in non-root environments.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious runtime caveats discovered during environment setup:

- Docker startup in Cursor VM (daemon flags vs config file conflict)
- PATH gotchas when running `install.sh` manually vs from pre-built Dockerfile image
- `rayapp` sudo requirement for `/usr/local/bin` install
- Quick reference to validation commands

**Validation evidence:**

[preflight_and_validation.log](https://cursor.com/agents/bc-71b78e17-92ad-4bbf-bb22-f19c54dafff7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreflight_and_validation.log)

All checks pass:
- `bash .cursor/preflight.sh` → Preflight OK
- `pre-commit run --all-files` → 5/5 Passed
- `python3 ci/validate_build_yaml.py --no-network` → 48 entries validated
- `bash ./update_deps.sh --check` → Lock files up to date
- `rayapp build all` → All templates built successfully

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71b78e17-92ad-4bbf-bb22-f19c54dafff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71b78e17-92ad-4bbf-bb22-f19c54dafff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

