### PR TITLE
chore(codeowners): own /BUILD.yaml and /.cursor/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,7 @@
 
 # to make sure people are using serverless
 /configs @shomilj @sofianhnaide @scottsun94
+
+# Template infra
+/BUILD.yaml @anyscale/template-infra
+/.cursor/   @anyscale/cloud-agents


### PR DESCRIPTION
Add CODEOWNERS entries for shared template infra:

- `/BUILD.yaml` → `@anyscale/template-infra`
- `/.cursor/` → `@anyscale/cloud-agents`

Routed to teams (not individuals) so membership changes don't churn this file. Root-anchored — per-template `BUILD.yaml` stays with its author. Opening as **draft**; teams are being created in parallel.

Test plan: post-merge, open a no-op PR touching each path and confirm the right team is auto-requested.