### PR TITLE
feat(skill/template): add create.md for new-template flow

### DIFF
--- a/.claude/skills/template/SKILL.md
+++ b/.claude/skills/template/SKILL.md
@@ -7,6 +7,7 @@ description: Work with Anyscale console templates. Covers maintenance (Ray versi
 
 Read the reference matching your task:
 
+- **How to create** a new template (defers authoring to anyscale-template-agent, then walks repo integration) → `references/create.md`
 - **How to update** a template to a specific Ray release → `references/update.md`
 - **How to format** a template to repo conventions → `references/format.md`
 - **How to publish** a template to dev/staging/production (S3 via Buildkite) → `references/publish.md`

--- a/.claude/skills/template/SKILL.md
+++ b/.claude/skills/template/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: template
-description: Work with Anyscale console templates. Covers maintenance (Ray version bumps), formatting (repo conventions), and publishing (S3 via Buildkite). Use for any BUILD.yaml edit, image bump, or template lifecycle task.
+description: Create, maintain, format, and publish Anyscale console templates. Use for making a new template, bumping a template's Ray version, BUILD.yaml edits, image bumps, repo conventions, or publishing to dev/staging/prod.
 ---
 
 # Template skill

--- a/.claude/skills/template/references/compute-config-schema.yaml
+++ b/.claude/skills/template/references/compute-config-schema.yaml
@@ -7,8 +7,7 @@
 # actually need to override. This keeps configs minimal and avoids confusion
 # about which values are intentional vs just restating defaults.
 #
-# NOT included in the template config (these are operational, not template-shipped):
-# idle_termination_minutes, maximum_uptime_minutes, region, cloud.
+# NOT included in the template config: `cloud` (operational reference, not a per-template setting).
 
 # --- Full schema (with defaults noted) ---
 

--- a/.claude/skills/template/references/compute-config-schema.yaml
+++ b/.claude/skills/template/references/compute-config-schema.yaml
@@ -8,7 +8,7 @@
 # about which values are intentional vs just restating defaults.
 #
 # NOT included in the template config (these are operational, not template-shipped):
-# idle_termination_minutes, maximum_uptime_minutes, region, cloud, allowed_azs.
+# idle_termination_minutes, maximum_uptime_minutes, region, cloud.
 
 # --- Full schema (with defaults noted) ---
 

--- a/.claude/skills/template/references/compute-config-schema.yaml
+++ b/.claude/skills/template/references/compute-config-schema.yaml
@@ -6,6 +6,9 @@
 # IMPORTANT: Omit fields that match their default value. Only include what you
 # actually need to override. This keeps configs minimal and avoids confusion
 # about which values are intentional vs just restating defaults.
+#
+# NOT included in the template config (these are operational, not template-shipped):
+# idle_termination_minutes, maximum_uptime_minutes, region, cloud, allowed_azs.
 
 # --- Full schema (with defaults noted) ---
 

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -1,5 +1,7 @@
 # Create a new template
 
+Read `format.md` first — it owns repo conventions, schemas, and the legacy-API warning. This file is the generation workflow.
+
 `<name>` below is the template's identifier — used in `BUILD.yaml`, `configs/<name>/`, `tests/<name>/`.
 
 ## Source the content
@@ -17,11 +19,7 @@ Wait for its deliverable, drop it in `templates/<dir>/`, then continue.
 
 Append a list item per `build-yaml-schema.yaml`. Pick the image case per SKILL.md "Image URI cases" — set `cluster_env.image_uri` (stock) or `cluster_env.byod.{docker_image,ray_version}` (custom or third-party). For custom GCP, publish the image first (script in SKILL.md) and use the printed URI.
 
-Cross-field rules (validator-enforced) live at the bottom of `build-yaml-schema.yaml`.
-
 ## Step 2: Compute configs
-
-Legacy schema, per `compute-config-schema.yaml`. NOT the new ComputeConfig API.
 
 **Preferred — translate from a tested workspace.** Ask the user for the Anyscale console URL of the workspace they validated the template on. Extract the workspace ID (`expwrk_*` from `/workspaces/<id>`) and fetch its config:
 

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -33,8 +33,6 @@ The CLI returns the new ComputeConfig API shape; translate fields into the legac
 
 **Fallback — guided Q&A.** When no tested workspace exists, walk the user through the schema fields (`compute-config-schema.yaml`) — head/worker instance types, autoscaler bounds, spot, cross-zone autoscaling.
 
-Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU example).
-
 ## Step 3: Test script
 
 Write `tests/<name>/tests.sh`. Two shapes — pick by template type:

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -25,15 +25,21 @@ Cross-field rules (validator-enforced) live at the bottom of `build-yaml-schema.
 
 Legacy schema, per `compute-config-schema.yaml`. NOT the new ComputeConfig API.
 
-**Preferred — translate from a tested workspace.** Ask the user for the Anyscale console URL of the workspace they validated the template on. Pull the workspace's compute config (head node type, worker node types, autoscaler bounds, spot, flags) and translate into `configs/<name>/aws.yaml` + `configs/<name>/gce.yaml`.
+**Preferred — translate from a tested workspace.** Ask the user for the Anyscale console URL of the workspace they validated the template on. Extract the workspace ID (`expwrk_*` from `/workspaces/<id>`) and fetch its config:
 
-**Fallback — guided Q&A.** Ask:
+```
+anyscale workspace_v2 get --id expwrk_<id> --json | jq '.config.compute_config'
+```
+
+The CLI returns the new ComputeConfig API shape; translate fields into the legacy schema per `compute-config-schema.yaml`. Pick `configs/<name>/aws.yaml` or `configs/<name>/gce.yaml` by instance-type family — AWS uses `m5.*` / `g5.*` / `g6.*` / `p4d.*`; GCP uses `n2-standard-*` / `g2-standard-*-nvidia-l4-*` / `a2-highgpu-*-nvidia-a100-*`. If the template should support both clouds, mirror the same GPU class on the other side. `idle_termination_minutes`, `region`, and cloud metadata don't go in the template config — they're operational.
+
+**Fallback — guided Q&A.** When no tested workspace exists, ask:
 - GPU or CPU? Head + worker instance type?
 - `min_workers` / `max_workers`?
 - Spot or on-demand (`use_spot`)?
 - Cross-zone autoscaling (`flags.allow-cross-zone-autoscaling: true`)?
 
-Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU single-node — shared across intro and serve templates). AWS uses `m5.*` / `g5.*` / `g6.*` / `p4d.*`; GCP uses `n2-standard-*` / `g2-standard-*-nvidia-l4-*` / `a2-highgpu-*-nvidia-a100-*`. Pair AWS and GCP at the same GPU class.
+Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU single-node — shared across intro and serve templates).
 
 ## Step 3: Test script
 

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -1,0 +1,58 @@
+# Create a new template
+
+Author the content via the dedicated agent, then integrate into this repo (BUILD.yaml + compute configs + tests + validation), then hand off to `publish.md`.
+
+`<name>` below is the template's identifier (used in `BUILD.yaml`, `configs/`, `tests/`). Must match `^[a-z0-9_-]+$`.
+
+## Authoring (defer)
+
+Authoring lives in **anyscale/anyscale-template-agent** (https://github.com/anyscale/anyscale-template-agent) — a 4-phase pipeline: Author → Debug → Diagram → Finalize. Two starting points:
+
+- **Bootstrap from scratch** (prompt-only) — describe what the template should demonstrate; the agent generates it.
+- **Wrap existing work** — Jupyter notebook, Python files, markdown, URL, or GitHub repo.
+
+Wait for the deliverable (typically a `.ipynb` + supporting files). Move it into `templates/<dir>/` and continue below.
+
+## Step 1: BUILD.yaml entry
+
+Append a list item per `build-yaml-schema.yaml`. Pick the image case per SKILL.md "Image URI cases":
+
+- **Stock Anyscale** — `cluster_env.image_uri: anyscale/ray:<tag>` (or `anyscale/ray-llm:<tag>`).
+- **Anyscale custom on GCP** — publish via `.claude/skills/template/scripts/publish-custom-image.sh <dockerfile-dir> <name> <ray-version>`, then set `cluster_env.byod.docker_image` to the printed URI and `byod.ray_version` to the matching Ray version.
+- **Third-party** — set `cluster_env.byod.docker_image` to the upstream tag; infer `byod.ray_version` from the image.
+
+Cross-field rules (validator-enforced) live at the bottom of `build-yaml-schema.yaml`. The common ones: `configs/<name>/` and `tests/<name>/` directory basenames must equal `<name>`.
+
+## Step 2: Compute configs
+
+Legacy schema, per `compute-config-schema.yaml`. NOT the new ComputeConfig API.
+
+**Preferred — translate from a tested workspace.** Ask the user for the Anyscale console URL of the workspace they validated the template on. Pull the workspace's compute config (head node type, worker node types, autoscaler bounds, spot, flags) and translate into `configs/<name>/aws.yaml` + `configs/<name>/gce.yaml`.
+
+**Fallback — guided Q&A.** Ask:
+- GPU or CPU? Head + worker instance type?
+- `min_workers` / `max_workers`?
+- Spot or on-demand (`use_spot`)?
+- Cross-zone autoscaling (`flags.allow-cross-zone-autoscaling: true`)?
+
+Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU single-node — used by intro templates). AWS uses `m5.*` / `g5.*` / `g6.*` / `p4d.*`; GCP uses `n2-standard-*` / `g2-standard-*-nvidia-l4-*` / `a2-highgpu-*-nvidia-a100-*`. Pair AWS and GCP at the same GPU class.
+
+## Step 3: Test script
+
+Write `tests/<name>/tests.sh`. Three shapes — pick by template type:
+
+- **Notebook via nb2py** (most common) — convert `README.ipynb` to Python and execute. Copy `tests/distributing-pytorch/tests.sh` + `tests/distributing-pytorch/nb2py.py` as the starting point.
+- **Notebook via papermill** — for notebooks that don't translate cleanly via nb2py. See `tests/audio-dataset-curation-llm-judge/tests.sh`.
+- **Custom script** — for templates shipping a `.py` entrypoint or service. See `tests/asynchronous_inference/tests.sh`.
+
+## Step 4: Validate
+
+```
+python3 ci/validate_build_yaml.py --no-network
+```
+
+Fix anything it reports — schema errors, missing paths, name mismatches.
+
+## Handoff
+
+Now run the publish flow per `publish.md`.

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -27,7 +27,7 @@ Append a list item per `build-yaml-schema.yaml`. Pick the image case per SKILL.m
 anyscale workspace_v2 get --id expwrk_<id> --json | jq '.config.compute_config'
 ```
 
-The CLI returns the new ComputeConfig API shape; translate fields into the legacy schema per `compute-config-schema.yaml`. Pick `configs/<name>/aws.yaml` or `configs/<name>/gce.yaml` by instance family. For dual-cloud support, mirror the same GPU class across both files. `idle_termination_minutes`, `region`, and cloud metadata don't go in the template config — they're operational.
+The CLI returns the new ComputeConfig API shape; translate fields into the legacy schema per `compute-config-schema.yaml`. Pick `configs/<name>/aws.yaml` or `configs/<name>/gce.yaml` by instance family.
 
 **Fallback — guided Q&A.** When no tested workspace exists, walk the user through the schema fields (`compute-config-schema.yaml`) — head/worker instance types, autoscaler bounds, spot, cross-zone autoscaling.
 
@@ -38,14 +38,16 @@ Write `tests/<name>/tests.sh`. Two shapes — pick by template type:
 - **Notebook via papermill** (most common) — for `.ipynb` templates. See `tests/audio-dataset-curation-llm-judge/tests.sh`.
 - **Custom script** — for templates shipping a `.py` entrypoint or service. See `tests/asynchronous_inference/tests.sh`.
 
+Design the test to mirror the user flow, with minimal-impact shortcuts to keep CI fast:
+
+- **Skip redundant paths.** If two code paths exercise the same logic (e.g., a local Ray Serve deployment and the same app deployed as an Anyscale Service), test only one.
+- **Prefer cheap GPUs.** A10 (`g5.*`) or L4 (`g6.*` / `g2-*-nvidia-l4-*`) over A100/H100 — faster to provision, cheaper to run.
+- **Shrink work via env vars.** Lower dataset size, epochs, or warmup through environment variables read in the notebook. Keep the user-facing code path clean (e.g., `epochs = int(os.getenv("EPOCHS", 100))` reads as real config, not test scaffolding).
+
 ## Step 4: Validate
 
-```
-python3 ci/validate_build_yaml.py --no-network
-```
-
-Fix anything it reports.
+Apply `format.md` to the new template.
 
 ## Handoff
 
-Now run the publish flow per `publish.md`.
+Open a PR with the new template, then have the user comment `/test-template` on it to trigger CI. After merge, publish per `publish.md`.

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -2,18 +2,18 @@
 
 Read `format.md` first — it owns repo conventions, schemas, and the legacy-API warning. This file is the generation workflow.
 
-`<name>` below is the template's identifier — used in `BUILD.yaml`, `configs/<name>/`, `tests/<name>/`.
+`<name>` below is the template's identifier — used in `BUILD.yaml`, `templates/<name>/`, `configs/<name>/`, `tests/<name>/`.
 
 ## Source the content
 
-Move the template's content (notebook / Python files / partial draft) into `templates/<dir>/`. Most users arrive with something partial-to-done already — just integrate what they have.
+Move the template's content (notebook / Python files / partial draft) into `templates/<name>/`. Most users arrive with something partial-to-done already — just integrate what they have.
 
 If nothing exists yet, or the user wants existing work agent-polished, defer to **anyscale/anyscale-template-agent** (https://github.com/anyscale/anyscale-template-agent) first:
 
 - **Bootstrap from scratch** (prompt-only) — when there's no starting content.
 - **Wrap or improve existing work** — for adding diagrams, debugging, or finalizing.
 
-Wait for its deliverable, drop it in `templates/<dir>/`, then continue.
+Wait for its deliverable, drop it in `templates/<name>/`, then continue.
 
 ## Step 1: BUILD.yaml entry
 
@@ -50,4 +50,7 @@ Apply `format.md` to the new template.
 
 ## Handoff
 
-Open a PR with the new template, then have the user comment `/test-template` on it to trigger CI. After merge, publish per `publish.md`.
+1. **Open a PR** with the new template.
+2. **Run CI** — have the user comment `/test-template` on the PR.
+3. **After merge, publish to dev / staging / prod** via the Buildkite tmpl-publish pipeline. Offer to run it for the user (see `publish.md`), or point them at it to run themselves.
+4. **Reference the template in `anyscale/product`** so it surfaces in the Anyscale console frontend.

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -2,14 +2,16 @@
 
 `<name>` below is the template's identifier — used in `BUILD.yaml`, `configs/<name>/`, `tests/<name>/`.
 
-## Authoring (defer)
+## Source the content
 
-Authoring lives in **anyscale/anyscale-template-agent** (https://github.com/anyscale/anyscale-template-agent). Two starting points:
+Move the template's content (notebook / Python files / partial draft) into `templates/<dir>/`. Most users arrive with something partial-to-done already — just integrate what they have.
 
-- **Bootstrap from scratch** (prompt-only) — describe what the template should demonstrate; the agent generates it.
-- **Wrap existing work** — Jupyter notebook, Python files, markdown, URL, or GitHub repo.
+If nothing exists yet, or the user wants existing work agent-polished, defer to **anyscale/anyscale-template-agent** (https://github.com/anyscale/anyscale-template-agent) first:
 
-Wait for the deliverable (typically a `.ipynb` + supporting files). Move it into `templates/<dir>/` and continue below.
+- **Bootstrap from scratch** (prompt-only) — when there's no starting content.
+- **Wrap or improve existing work** — for adding diagrams, debugging, or finalizing.
+
+Wait for its deliverable, drop it in `templates/<dir>/`, then continue.
 
 ## Step 1: BUILD.yaml entry
 

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -1,10 +1,10 @@
 # Create a new template
 
-`<name>` below is the template's identifier (used in `BUILD.yaml`, `configs/`, `tests/`). Must match `^[a-z0-9_-]+$`.
+`<name>` below is the template's identifier — used in `BUILD.yaml`, `configs/<name>/`, `tests/<name>/`.
 
 ## Authoring (defer)
 
-Authoring lives in **anyscale/anyscale-template-agent** (https://github.com/anyscale/anyscale-template-agent) — a 4-phase pipeline: Author → Debug → Diagram → Finalize. Two starting points:
+Authoring lives in **anyscale/anyscale-template-agent** (https://github.com/anyscale/anyscale-template-agent). Two starting points:
 
 - **Bootstrap from scratch** (prompt-only) — describe what the template should demonstrate; the agent generates it.
 - **Wrap existing work** — Jupyter notebook, Python files, markdown, URL, or GitHub repo.
@@ -13,13 +13,9 @@ Wait for the deliverable (typically a `.ipynb` + supporting files). Move it into
 
 ## Step 1: BUILD.yaml entry
 
-Append a list item per `build-yaml-schema.yaml`. Pick the image case per SKILL.md "Image URI cases":
+Append a list item per `build-yaml-schema.yaml`. Pick the image case per SKILL.md "Image URI cases" — set `cluster_env.image_uri` (stock) or `cluster_env.byod.{docker_image,ray_version}` (custom or third-party). For custom GCP, publish the image first (script in SKILL.md) and use the printed URI.
 
-- **Stock Anyscale** — `cluster_env.image_uri: anyscale/ray:<tag>` (or `anyscale/ray-llm:<tag>`).
-- **Anyscale custom on GCP** — publish via `.claude/skills/template/scripts/publish-custom-image.sh <dockerfile-dir> <name> <ray-version>`, then set `cluster_env.byod.docker_image` to the printed URI and `byod.ray_version` to the matching Ray version.
-- **Third-party** — set `cluster_env.byod.docker_image` to the upstream tag; infer `byod.ray_version` from the image.
-
-Cross-field rules (validator-enforced) live at the bottom of `build-yaml-schema.yaml`. The common ones: `configs/<name>/` and `tests/<name>/` directory basenames must equal `<name>`.
+Cross-field rules (validator-enforced) live at the bottom of `build-yaml-schema.yaml`.
 
 ## Step 2: Compute configs
 
@@ -31,22 +27,17 @@ Legacy schema, per `compute-config-schema.yaml`. NOT the new ComputeConfig API.
 anyscale workspace_v2 get --id expwrk_<id> --json | jq '.config.compute_config'
 ```
 
-The CLI returns the new ComputeConfig API shape; translate fields into the legacy schema per `compute-config-schema.yaml`. Pick `configs/<name>/aws.yaml` or `configs/<name>/gce.yaml` by instance-type family — AWS uses `m5.*` / `g5.*` / `g6.*` / `p4d.*`; GCP uses `n2-standard-*` / `g2-standard-*-nvidia-l4-*` / `a2-highgpu-*-nvidia-a100-*`. If the template should support both clouds, mirror the same GPU class on the other side. `idle_termination_minutes`, `region`, and cloud metadata don't go in the template config — they're operational.
+The CLI returns the new ComputeConfig API shape; translate fields into the legacy schema per `compute-config-schema.yaml`. Pick `configs/<name>/aws.yaml` or `configs/<name>/gce.yaml` by instance family. For dual-cloud support, mirror the same GPU class across both files. `idle_termination_minutes`, `region`, and cloud metadata don't go in the template config — they're operational.
 
-**Fallback — guided Q&A.** When no tested workspace exists, ask:
-- GPU or CPU? Head + worker instance type?
-- `min_workers` / `max_workers`?
-- Spot or on-demand (`use_spot`)?
-- Cross-zone autoscaling (`flags.allow-cross-zone-autoscaling: true`)?
+**Fallback — guided Q&A.** When no tested workspace exists, walk the user through the schema fields (`compute-config-schema.yaml`) — head/worker instance types, autoscaler bounds, spot, cross-zone autoscaling.
 
-Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU single-node — shared across intro and serve templates).
+Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU example).
 
 ## Step 3: Test script
 
-Write `tests/<name>/tests.sh`. Three shapes — pick by template type:
+Write `tests/<name>/tests.sh`. Two shapes — pick by template type:
 
-- **Notebook via nb2py** (most common) — convert `README.ipynb` to Python and execute. Copy `tests/distributing-pytorch/tests.sh` + `tests/distributing-pytorch/nb2py.py` as the starting point.
-- **Notebook via papermill** — for notebooks that don't translate cleanly via nb2py. See `tests/audio-dataset-curation-llm-judge/tests.sh`.
+- **Notebook via papermill** (most common) — for `.ipynb` templates. See `tests/audio-dataset-curation-llm-judge/tests.sh`.
 - **Custom script** — for templates shipping a `.py` entrypoint or service. See `tests/asynchronous_inference/tests.sh`.
 
 ## Step 4: Validate
@@ -55,7 +46,7 @@ Write `tests/<name>/tests.sh`. Three shapes — pick by template type:
 python3 ci/validate_build_yaml.py --no-network
 ```
 
-Fix anything it reports — schema errors, missing paths, name mismatches.
+Fix anything it reports.
 
 ## Handoff
 

--- a/.claude/skills/template/references/create.md
+++ b/.claude/skills/template/references/create.md
@@ -1,7 +1,5 @@
 # Create a new template
 
-Author the content via the dedicated agent, then integrate into this repo (BUILD.yaml + compute configs + tests + validation), then hand off to `publish.md`.
-
 `<name>` below is the template's identifier (used in `BUILD.yaml`, `configs/`, `tests/`). Must match `^[a-z0-9_-]+$`.
 
 ## Authoring (defer)
@@ -35,7 +33,7 @@ Legacy schema, per `compute-config-schema.yaml`. NOT the new ComputeConfig API.
 - Spot or on-demand (`use_spot`)?
 - Cross-zone autoscaling (`flags.allow-cross-zone-autoscaling: true`)?
 
-Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU single-node — used by intro templates). AWS uses `m5.*` / `g5.*` / `g6.*` / `p4d.*`; GCP uses `n2-standard-*` / `g2-standard-*-nvidia-l4-*` / `a2-highgpu-*-nvidia-a100-*`. Pair AWS and GCP at the same GPU class.
+Cross-check shape against `configs/distributing-pytorch/{aws,gce}.yaml` (GPU example) or `configs/basic-single-node/{aws,gce}.yaml` (CPU single-node — shared across intro and serve templates). AWS uses `m5.*` / `g5.*` / `g6.*` / `p4d.*`; GCP uses `n2-standard-*` / `g2-standard-*-nvidia-l4-*` / `a2-highgpu-*-nvidia-a100-*`. Pair AWS and GCP at the same GPU class.
 
 ## Step 3: Test script
 

--- a/.claude/skills/template/references/format.md
+++ b/.claude/skills/template/references/format.md
@@ -4,7 +4,7 @@ Validate the specified template against the conventions below. If the template d
 
 ## Rules
 
-- **Only validate and format existing files.** If required files are missing (compute configs, test scripts, etc.), report what's missing and ask the user to add them — do NOT generate them yourself.
+- **Only validate and format existing files.** If required files are missing (compute configs, test scripts, etc.), report what's missing and ask the user to add them — do NOT generate them yourself. Direct them to `references/create.md` to scaffold missing files.
 - **Do not run tests.** This guide only checks formatting, not functionality.
 - **Minimal changes.** Only fix what doesn't follow conventions. Don't refactor or "improve" code.
 
@@ -37,4 +37,4 @@ Run `python3 ci/validate_build_yaml.py --no-network` first — covers schema, pa
 - WorkerNodeType:        https://docs.anyscale.com/ref/0.26.64/other#workernodetype-legacy
 - Resources:             https://docs.anyscale.com/ref/0.26.64/other#resources-legacy
 
-**If anything is missing**: report to the user, do NOT generate from scratch unless explicitly requested.
+**If anything is missing**: report to the user and point them at `references/create.md`. Do NOT generate from scratch unless explicitly requested.


### PR DESCRIPTION
Adds `references/create.md` to the `/template` skill — an entry point for new-template authoring that defers content generation to [anyscale-template-agent](https://github.com/anyscale/anyscale-template-agent) and owns the repo-integration phase (BUILD.yaml, compute configs, tests, validation, handoff to publish.md). Updates SKILL.md to list the new reference and cross-references create.md from format.md so the existing "don't generate inside format" rule has a path forward.

Validator passes (`python3 ci/validate_build_yaml.py --no-network`, 48 entries).