### PR TITLE
docs(claude): add CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Claude Code reads `CLAUDE.md` for repo memory; without one, sessions in this repo silently miss the AGENTS.md guidance. The new file is a single `@AGENTS.md` import, keeping AGENTS.md as the single source of truth.