### PR TITLE
fix(templates): repo-level GH link fixes + repo redirects + final dead-link cleanup

### DIFF
--- a/templates/audio-dataset-curation-llm-judge/README.ipynb
+++ b/templates/audio-dataset-curation-llm-judge/README.ipynb
@@ -10,7 +10,7 @@
         "\n",
         "<div align=\"left\">\n",
         "<a target=\"_blank\" href=\"https://console.anyscale.com/\"><img src=\"https://img.shields.io/badge/🚀 Run_on-Anyscale-9hf\"></a>&nbsp;\n",
-        "<a href=\"https://github.com/anyscale/e2e-audio\" role=\"button\"><img src=\"https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d\"></a>&nbsp;\n",
+        "<a href=\"https://github.com/anyscale/templates/tree/main/templates/audio-dataset-curation-llm-judge\" role=\"button\"><img src=\"https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d\"></a>&nbsp;\n",
         "</div>\n",
         "\n",
         "\n",

--- a/templates/audio-dataset-curation-llm-judge/README.md
+++ b/templates/audio-dataset-curation-llm-judge/README.md
@@ -4,7 +4,7 @@
 
 <div align="left">
 <a target="_blank" href="https://console.anyscale.com/"><img src="https://img.shields.io/badge/🚀 Run_on-Anyscale-9hf"></a>&nbsp;
-<a href="https://github.com/anyscale/e2e-audio" role="button"><img src="https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d"></a>&nbsp;
+<a href="https://github.com/anyscale/templates/tree/main/templates/audio-dataset-curation-llm-judge" role="button"><img src="https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d"></a>&nbsp;
 </div>
 
 

--- a/templates/e2e-dspy-workflow/README.ipynb
+++ b/templates/e2e-dspy-workflow/README.ipynb
@@ -621,7 +621,7 @@
     "6. Wait for the finetuning job to complete\n",
     "7. Return the finetuned `dspy.LM` object\n",
     "\n",
-    "You can see what DSPy is doing under the hood [here](https://github.com/stanfordnlp/dspy/blob/main/dspy/clients/anyscale.py)"
+    "You can see what DSPy is doing under the hood [here](https://dspy.ai/learn/programming/language_models/)"
    ]
   },
   {

--- a/templates/e2e-dspy-workflow/README.md
+++ b/templates/e2e-dspy-workflow/README.md
@@ -410,7 +410,7 @@ When you call `LM.finetune()`, DSPy will:
 6. Wait for the finetuning job to complete
 7. Return the finetuned `dspy.LM` object
 
-You can see what DSPy is doing under the hood [here](https://github.com/stanfordnlp/dspy/blob/main/dspy/clients/anyscale.py)
+You can see what DSPy is doing under the hood [here](https://dspy.ai/learn/programming/language_models/)
 
 
 ```python

--- a/templates/endpoints/README.md
+++ b/templates/endpoints/README.md
@@ -14,7 +14,7 @@ You can also find more advanced tutorials in the `examples/` folder, including t
 
 ## Step 1 - Run the model locally in the Workspace
 
-We provide a starter command to run Llama and Mistral-family models via Ray Serve. You can specify the arguments, such as Lora, GPU type and tensor parallelism via the command. You can also follow the [guide](examples/CustomModels.ipynb) to bring your own models.
+We provide a starter command to run Llama and Mistral-family models via Ray Serve. You can specify the arguments, such as Lora, GPU type and tensor parallelism via the command. You can also follow the [guide](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/CustomModels.ipynb) to bring your own models.
 
 The command will generate 2 files - a model config file (saved in `model_config/`) and a serve config file (`serve_TIMESTAMP.yaml`) that you can reference and re-run in the future.
 
@@ -132,12 +132,12 @@ As well as operational features for efficient scaling of LLM apps:
 - Native multi-GPU & multi-node model deployments.
 
 Look at the following guides for more advanced use-cases:
-* [Deploy models for embedding generation](examples/embedding/EmbeddingModels.ipynb)
-* [Learn how to bring your own models](examples/CustomModels.ipynb)
-* [Deploy multiple LoRA fine-tuned models](examples/lora/DeployLora.ipynb)
-* [Deploy Function calling models](examples/function_calling/DeployFunctionCalling.ipynb)
-* [Learn how to leverage different configurations that can optimize the latency and throughput of your models](examples/OptimizeModels.ipynb)
-* [Learn how to fully configure your deployment including auto-scaling, optimization parameters and tensor-parallelism](examples/AdvancedModelConfigs.ipynb)
+* [Deploy models for embedding generation](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/embedding/EmbeddingModels.ipynb)
+* [Learn how to bring your own models](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/CustomModels.ipynb)
+* [Deploy multiple LoRA fine-tuned models](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/lora/DeployLora.ipynb)
+* [Deploy Function calling models](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/function_calling/DeployFunctionCalling.ipynb)
+* [Learn how to leverage different configurations that can optimize the latency and throughput of your models](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/OptimizeModels.ipynb)
+* [Learn how to fully configure your deployment including auto-scaling, optimization parameters and tensor-parallelism](https://github.com/anyscale/templates/blob/main/templates/endpoints/examples/AdvancedModelConfigs.ipynb)
 
 ## Application Examples
 

--- a/templates/endpoints/examples/AdvancedModelConfigs.ipynb
+++ b/templates/endpoints/examples/AdvancedModelConfigs.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "The `engine_config` section specifies the Hugging Face model ID (`model_id`), how to initialize it and what parameters to use when generating tokens with an LLM.\n",
     "\n",
-    "RayLLM supports continuous batching, meaning incoming requests are processed as soon as they arrive, and can be added to batches that are already being processed. This means that the model is not slowed down by certain sentences taking longer to generate than others. RayLLM also supports quantization, meaning compressed models can be deployed with cheaper hardware requirements. For more details on using quantized models in RayLLM, see the [quantization guide](models/quantization/README.md).\n",
+    "RayLLM supports continuous batching, meaning incoming requests are processed as soon as they arrive, and can be added to batches that are already being processed. This means that the model is not slowed down by certain sentences taking longer to generate than others. RayLLM also supports quantization, meaning compressed models can be deployed with cheaper hardware requirements. For more details on using quantized models in RayLLM, see the [quantization guide](https://github.com/anyscale/templates/blob/main/templates/endpoints/models/quantization/README.md).\n",
     "\n",
     "* `model_id` is the ID that refers to the model in the RayLLM or OpenAI API.\n",
     "* `type` is the type of  inference engine. Only `VLLMEngine` is currently supported.\n",

--- a/templates/endpoints/examples/CustomModels.ipynb
+++ b/templates/endpoints/examples/CustomModels.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "The string template should include the `{instruction}` keyword, which will be replaced with message content from the ChatCompletions API.\n",
     "\n",
-    "For example, if a user sends the following message for llama2-7b-chat-hf ([prompt format](models/llama/meta-llama--Llama-2-7b-chat-hf_a10g_tp1.yaml#L30-L36)):\n",
+    "For example, if a user sends the following message for llama2-7b-chat-hf (prompt format):\n",
     "```json\n",
     "{\n",
     "  \"messages\": [\n",

--- a/templates/endpoints_v2/README.ipynb
+++ b/templates/endpoints_v2/README.ipynb
@@ -227,7 +227,7 @@
    "source": [
     "## End-to-end examples\n",
     "\n",
-    "* [Build Tool Calling Feature for Any LLM via JSON Mode](./end-to-end-examples/function_calling/README.ipynb): This example demonstrates how to build a tool calling feature for any LLM via JSON mode.\n"
+    "* [Build Tool Calling Feature for Any LLM via JSON Mode](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/README.ipynb): This example demonstrates how to build a tool calling feature for any LLM via JSON mode.\n"
    ]
   },
   {

--- a/templates/endpoints_v2/README.md
+++ b/templates/endpoints_v2/README.md
@@ -150,7 +150,7 @@ query(service_url, service_bearer_token)
 
 ## End-to-end examples
 
-* [Build Tool Calling Feature for Any LLM via JSON Mode](./end-to-end-examples/function_calling/README.ipynb): This example demonstrates how to build a tool calling feature for any LLM via JSON mode.
+* [Build Tool Calling Feature for Any LLM via JSON Mode](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/README.ipynb): This example demonstrates how to build a tool calling feature for any LLM via JSON mode.
 
 
 ## What's next?

--- a/templates/endpoints_v2/end-to-end-examples/function_calling/README.ipynb
+++ b/templates/endpoints_v2/end-to-end-examples/function_calling/README.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Tool calling** (aka **Function calling**) allows you to hook up external tools to an LLM, enabling it to use APIs and other functions to perform tasks. This feature is particularly useful when you want to extend the capabilities of an LLM beyond its internal knowledge base.\n",
     "\n",
-    "This example explains how to use [JSON Mode](docs.anyscale.com/llms/serving/guides/json_mode) to enable this capability for *any* LLM. "
+    "This example explains how to use [JSON Mode](https://docs.anyscale.com/llms/serving/guides/json_mode) to enable this capability for *any* LLM. "
    ]
   },
   {
@@ -33,7 +33,7 @@
     "\n",
     "1. **Fine-tuning**: You can fine-tune an LLM to use tools when prompted in a specific way. Many recently released open-weight models have gone through some stages of post-training and come out-of-the-box with the capability to use tools. For examples, `mistralai/Mixtral-8x22B-Instruct-v0.1` and `meta-llama/Meta-Llama-3.1-8B-Instruct` natively support tool calling. They have been fine-tuned to do so when given a special prompt format. To use these models, you must specify the tool-compatible prompt format in your LLM config YAML. \n",
     "\n",
-    "For example, for `mistralai/Mixtral-8x22B-Instruct-v0.1`, here is the prompt format used to enable tool calling (see the full config [here](./llm_configs/mistralai--Mixtral-8x22B-Instruct-v0_1.yaml)):\n",
+    "For example, for `mistralai/Mixtral-8x22B-Instruct-v0.1`, here is the prompt format used to enable tool calling (see the full config [here](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/llm_configs/mistralai--Mixtral-8x22B-Instruct-v0_1.yaml)):\n",
     "\n",
     "```yaml\n",
     "    prompt_format:\n",
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then use the corresponding tool's schema to guarantee that the output matches the desired schema of the tool. An example of this implementation is done in this [client module](./client/client.py)."
+    "We then use the corresponding tool's schema to guarantee that the output matches the desired schema of the tool. An example of this implementation is done in this [client module](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/client/client.py)."
    ]
   },
   {
@@ -182,7 +182,7 @@
    "source": [
     "The pre-requisite for the following code is to have a self-deployed model (e.g. `meta-llama/Meta-Llama-3.1-8B-Instruct`). To do so, you can follow the instructions in the [RayLLM documentation](https://docs.anyscale.com/llms/serving/intro).\n",
     "\n",
-    "Alternatively, you can do `serve run serve_llama_3p1.yaml --non-blocking` to deploy a service locally on a 1xA10 GPU. Make sure to add your HuggingFace token to the [LLM config](./llm_configs/meta-llama--Meta-Llama-3_1-8B-Instruct.yaml) first."
+    "Alternatively, you can do `serve run serve_llama_3p1.yaml --non-blocking` to deploy a service locally on a 1xA10 GPU. Make sure to add your HuggingFace token to the [LLM config](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/llm_configs/meta-llama--Meta-Llama-3_1-8B-Instruct.yaml) first."
    ]
   },
   {
@@ -313,7 +313,7 @@
     "\n",
     "In this example, we have shown how you can use JSON Mode to create a simple client that is capable of tool calling on Any Open-weight LLM, even if the LLM is not fine-tuned to natively support tool calling. \n",
     "\n",
-    "The implementation in [client.py](./client/client.py) is complete and you can read the code to cover all the details."
+    "The implementation in [client.py](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/client/client.py) is complete and you can read the code to cover all the details."
    ]
   },
   {

--- a/templates/endpoints_v2/end-to-end-examples/function_calling/README.md
+++ b/templates/endpoints_v2/end-to-end-examples/function_calling/README.md
@@ -3,7 +3,7 @@
 
 **Tool calling** (aka **Function calling**) allows you to hook up external tools to an LLM, enabling it to use APIs and other functions to perform tasks. This feature is particularly useful when you want to extend the capabilities of an LLM beyond its internal knowledge base.
 
-This example explains how to use [JSON Mode](docs.anyscale.com/llms/serving/guides/json_mode) to enable this capability for *any* LLM. 
+This example explains how to use [JSON Mode](https://docs.anyscale.com/llms/serving/guides/json_mode) to enable this capability for *any* LLM. 
 
 
 ## How does tool calling work?
@@ -22,7 +22,7 @@ Tool calling can be enabled with one of the two following approaches:
 
 1. **Fine-tuning**: You can fine-tune an LLM to use tools when prompted in a specific way. Many recently released open-weight models have gone through some stages of post-training and come out-of-the-box with the capability to use tools. For examples, `mistralai/Mixtral-8x22B-Instruct-v0.1` and `meta-llama/Meta-Llama-3.1-8B-Instruct` natively support tool calling. They have been fine-tuned to do so when given a special prompt format. To use these models, you must specify the tool-compatible prompt format in your LLM config YAML. 
 
-For example, for `mistralai/Mixtral-8x22B-Instruct-v0.1`, here is the prompt format used to enable tool calling (see the full config [here](./llm_configs/mistralai--Mixtral-8x22B-Instruct-v0_1.yaml)):
+For example, for `mistralai/Mixtral-8x22B-Instruct-v0.1`, here is the prompt format used to enable tool calling (see the full config [here](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/llm_configs/mistralai--Mixtral-8x22B-Instruct-v0_1.yaml)):
 
 ```yaml
     prompt_format:
@@ -118,13 +118,13 @@ text = "\n\nTo help answer, you have access to the following tool:\n{tool}.\n\n 
 print(text)
 ```
 
-We then use the corresponding tool's schema to guarantee that the output matches the desired schema of the tool. An example of this implementation is done in this [client module](./client/client.py).
+We then use the corresponding tool's schema to guarantee that the output matches the desired schema of the tool. An example of this implementation is done in this [client module](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/client/client.py).
 
 ## Example usage
 
 The pre-requisite for the following code is to have a self-deployed model (e.g. `meta-llama/Meta-Llama-3.1-8B-Instruct`). To do so, you can follow the instructions in the [RayLLM documentation](https://docs.anyscale.com/llms/serving/intro).
 
-Alternatively, you can do `serve run serve_llama_3p1.yaml --non-blocking` to deploy a service locally on a 1xA10 GPU. Make sure to add your HuggingFace token to the [LLM config](./llm_configs/meta-llama--Meta-Llama-3_1-8B-Instruct.yaml) first.
+Alternatively, you can do `serve run serve_llama_3p1.yaml --non-blocking` to deploy a service locally on a 1xA10 GPU. Make sure to add your HuggingFace token to the [LLM config](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/llm_configs/meta-llama--Meta-Llama-3_1-8B-Instruct.yaml) first.
 
 
 ```python
@@ -228,6 +228,6 @@ for chunk in completion:
 
 In this example, we have shown how you can use JSON Mode to create a simple client that is capable of tool calling on Any Open-weight LLM, even if the LLM is not fine-tuned to natively support tool calling. 
 
-The implementation in [client.py](./client/client.py) is complete and you can read the code to cover all the details.
+The implementation in [client.py](https://github.com/anyscale/templates/blob/main/templates/endpoints_v2/end-to-end-examples/function_calling/client/client.py) is complete and you can read the code to cover all the details.
 
 

--- a/templates/entity-recognition-with-llms/README.ipynb
+++ b/templates/entity-recognition-with-llms/README.ipynb
@@ -71,7 +71,7 @@
     "    \"pynvml==12.0.0\" \\\n",
     "    \"hf_transfer==0.1.9\" \\\n",
     "    \"tensorboard==2.19.0\" \\\n",
-    "    \"llamafactory@git+https://github.com/hiyouga/LLaMA-Factory.git\" \\\n",
+    "    \"llamafactory@git+https://github.com/hiyouga/LlamaFactory.git\" \\\n",
     "    \"transformers>=4.56.0,<5\" \\\n",
     "    \"peft>=0.18\" \\\n",
     "    \"trl>=0.18\" \\\n",
@@ -169,7 +169,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LLaMA-Factory/tree/main/examples).\n",
+    "Use [LLaMA-Factory](https://github.com/hiyouga/LlamaFactory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples).\n",
     "\n",
     "**Note**: Ray also supports using other tools like [axolotl](https://axolotl-ai-cloud.github.io/axolotl/docs/ray-integration.html) or even [Ray Train + HF Accelerate + FSDP/DeepSpeed](https://docs.ray.io/en/latest/train/huggingface-accelerate.html) directly for complete control of your post-training workloads."
    ]

--- a/templates/entity-recognition-with-llms/README.md
+++ b/templates/entity-recognition-with-llms/README.md
@@ -51,7 +51,7 @@ pip install -q \
     "pynvml==12.0.0" \
     "hf_transfer==0.1.9" \
     "tensorboard==2.19.0" \
-    "llamafactory@git+https://github.com/hiyouga/LLaMA-Factory.git" \
+    "llamafactory@git+https://github.com/hiyouga/LlamaFactory.git" \
     "transformers>=4.56.0,<5" \
     "peft>=0.18" \
     "trl>=0.18" \
@@ -105,7 +105,7 @@ display(Code(filename="/mnt/cluster_storage/viggo/dataset_info.json", language="
 
 ## Fine-tuning
 
-Use [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LLaMA-Factory/tree/main/examples).
+Use [LLaMA-Factory](https://github.com/hiyouga/LlamaFactory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples).
 
 **Note**: Ray also supports using other tools like [axolotl](https://axolotl-ai-cloud.github.io/axolotl/docs/ray-integration.html) or even [Ray Train + HF Accelerate + FSDP/DeepSpeed](https://docs.ray.io/en/latest/train/huggingface-accelerate.html) directly for complete control of your post-training workloads.
 

--- a/templates/entity-recognition-with-llms/containerfile
+++ b/templates/entity-recognition-with-llms/containerfile
@@ -4,7 +4,7 @@ RUN python3 -m pip install --no-cache-dir \
     "pynvml==12.0.0" \
     "hf_transfer==0.1.9" \
     "tensorboard==2.19.0" \
-    "llamafactory@git+https://github.com/hiyouga/LLaMA-Factory.git" \
+    "llamafactory@git+https://github.com/hiyouga/LlamaFactory.git" \
     "transformers>=4.56.0,<5" \
     "peft>=0.18" \
     "trl>=0.18" \

--- a/templates/fine-tune-llm-oss/README.ipynb
+++ b/templates/fine-tune-llm-oss/README.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "**⏱️ Time to complete**: ~20 mins, which includes the time to train the model\n",
     "\n",
-    "Looking to get the most out of your LLM workloads? Fine-tuning pretrained LLMs can often be the most cost effective way to improve model performance on the tasks that you care about. This template walks through how to use the popular open source library [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) to fine-tune LLMs on Anyscale. LLaMA-Factory comes with a [Ray](https://www.ray.io/) integration for scaling training to multiple GPUs and nodes."
+    "Looking to get the most out of your LLM workloads? Fine-tuning pretrained LLMs can often be the most cost effective way to improve model performance on the tasks that you care about. This template walks through how to use the popular open source library [LLaMA-Factory](https://github.com/hiyouga/LlamaFactory) to fine-tune LLMs on Anyscale. LLaMA-Factory comes with a [Ray](https://www.ray.io/) integration for scaling training to multiple GPUs and nodes."
    ]
   },
   {
@@ -20,10 +20,10 @@
    },
    "source": [
     "## Getting started with LLaMA-Factory \n",
-    "First, you need to install the LLaMA-Factory code. You can view the latest changes from the [LLaMA-Factory GitHub](https://github.com/hiyouga/LLaMA-Factory.git). \n",
+    "First, you need to install the LLaMA-Factory code. You can view the latest changes from the [LLaMA-Factory GitHub](https://github.com/hiyouga/LlamaFactory.git). \n",
     "\n",
     "```bash\n",
-    "git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LLaMA-Factory.git\n",
+    "git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LlamaFactory.git\n",
     "cd LLaMA-Factory\n",
     "# Install extras separately so Anyscale can track the dependencies on worker nodes.\n",
     "pip install torch==2.5.0 torchvision==0.20.0 torchaudio==2.5.0 --index-url https://download.pytorch.org/whl/cu121\n",
@@ -37,7 +37,7 @@
     "\n",
     "<img src=\"https://raw.githubusercontent.com/anyscale/templates/main/templates/fine-tune-llm-oss/assets/env_vars.png\" width=1500px />\n",
     "\n",
-    "You can find some example configs that use Ray with LLaMA-Factory for pretraining and SFT (instruction tuning) in the `llamafactory_config` directory. Find a full set of examples with various models, tasks, and datasets on the [LLaMA-Factory GitHub](https://github.com/hiyouga/LLaMA-Factory/tree/main/examples). \n",
+    "You can find some example configs that use Ray with LLaMA-Factory for pretraining and SFT (instruction tuning) in the `llamafactory_config` directory. Find a full set of examples with various models, tasks, and datasets on the [LLaMA-Factory GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples). \n",
     "\n",
     "LLaMA-Factory provides a CLI `llamafactory-cli` that allows you to launch training with a config YAML file. For example, you can launch a supervised fine-tuning job with Ray by running the following command:\n",
     "```bash\n",
@@ -112,7 +112,7 @@
     "# Start with an Anyscale base image.\n",
     "FROM anyscale/ray-ml:2.42.0-py310-gpu\n",
     "WORKDIR /app\n",
-    "RUN git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LLaMA-Factory.git && \\\n",
+    "RUN git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LlamaFactory.git && \\\n",
     "    cd LLaMA-Factory && \\\n",
     "    pip install torch==2.5.0 torchvision==0.20.0 torchaudio==2.5.0 --index-url https://download.pytorch.org/whl/cu121 && \\\n",
     "    pip install --no-cache-dir deepspeed==0.16.4 transformers==4.51.3 jieba nltk rouge-chinese && \\\n",

--- a/templates/fine-tune-llm-oss/README.md
+++ b/templates/fine-tune-llm-oss/README.md
@@ -2,13 +2,13 @@
 
 **⏱️ Time to complete**: ~20 mins, which includes the time to train the model
 
-Looking to get the most out of your LLM workloads? Fine-tuning pretrained LLMs can often be the most cost effective way to improve model performance on the tasks that you care about. This template walks through how to use the popular open source library [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) to fine-tune LLMs on Anyscale. LLaMA-Factory comes with a [Ray](https://www.ray.io/) integration for scaling training to multiple GPUs and nodes.
+Looking to get the most out of your LLM workloads? Fine-tuning pretrained LLMs can often be the most cost effective way to improve model performance on the tasks that you care about. This template walks through how to use the popular open source library [LLaMA-Factory](https://github.com/hiyouga/LlamaFactory) to fine-tune LLMs on Anyscale. LLaMA-Factory comes with a [Ray](https://www.ray.io/) integration for scaling training to multiple GPUs and nodes.
 
 ## Getting started with LLaMA-Factory 
-First, you need to install the LLaMA-Factory code. You can view the latest changes from the [LLaMA-Factory GitHub](https://github.com/hiyouga/LLaMA-Factory.git). 
+First, you need to install the LLaMA-Factory code. You can view the latest changes from the [LLaMA-Factory GitHub](https://github.com/hiyouga/LlamaFactory.git). 
 
 ```bash
-git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
+git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LlamaFactory.git
 cd LLaMA-Factory
 # Install extras separately so Anyscale can track the dependencies on worker nodes.
 pip install torch==2.5.0 torchvision==0.20.0 torchaudio==2.5.0 --index-url https://download.pytorch.org/whl/cu121
@@ -22,7 +22,7 @@ Additionally it's recommended to use `hf_transfer` for fast model downloading by
 
 <img src="https://raw.githubusercontent.com/anyscale/templates/main/templates/fine-tune-llm-oss/assets/env_vars.png" width=1500px />
 
-You can find some example configs that use Ray with LLaMA-Factory for pretraining and SFT (instruction tuning) in the `llamafactory_config` directory. Find a full set of examples with various models, tasks, and datasets on the [LLaMA-Factory GitHub](https://github.com/hiyouga/LLaMA-Factory/tree/main/examples). 
+You can find some example configs that use Ray with LLaMA-Factory for pretraining and SFT (instruction tuning) in the `llamafactory_config` directory. Find a full set of examples with various models, tasks, and datasets on the [LLaMA-Factory GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples). 
 
 LLaMA-Factory provides a CLI `llamafactory-cli` that allows you to launch training with a config YAML file. For example, you can launch a supervised fine-tuning job with Ray by running the following command:
 ```bash
@@ -87,7 +87,7 @@ To run LLaMA-Factory as an Anyscale job, create a [custom container image](https
 # Start with an Anyscale base image.
 FROM anyscale/ray-ml:2.42.0-py310-gpu
 WORKDIR /app
-RUN git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LLaMA-Factory.git && \
+RUN git clone --branch v0.9.3 --depth 1 https://github.com/hiyouga/LlamaFactory.git && \
     cd LLaMA-Factory && \
     pip install torch==2.5.0 torchvision==0.20.0 torchaudio==2.5.0 --index-url https://download.pytorch.org/whl/cu121 && \
     pip install --no-cache-dir deepspeed==0.16.4 transformers==4.51.3 jieba nltk rouge-chinese && \

--- a/templates/image-search-and-classification/README.ipynb
+++ b/templates/image-search-and-classification/README.ipynb
@@ -20,7 +20,7 @@
     "</div>\n",
     "\n",
     "\ud83d\udcbb Run this entire tutorial on [Anyscale](https://www.anyscale.com/) for free:\n",
-    "**https://console.anyscale.com/template-preview/image-search-and-classification** or access the repository [here](https://github.com/ray-project/ray/tree/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads).\n",
+    "**https://console.anyscale.com/template-preview/image-search-and-classification** or access the repository [here](https://github.com/anyscale/templates/tree/main/templates/image-search-and-classification).\n",
     "\n",
     "This tutorial focuses on the fundamental challenges of multimodal AI workloads at scale:\n",
     "\n",

--- a/templates/image-search-and-classification/README.md
+++ b/templates/image-search-and-classification/README.md
@@ -9,7 +9,7 @@
 </div>
 
 💻 Run this entire tutorial on [Anyscale](https://www.anyscale.com/) for free:
-**https://console.anyscale.com/template-preview/image-search-and-classification** or access the repository [here](https://github.com/ray-project/ray/tree/master/doc/source/ray-overview/examples/e2e-multimodal-ai-workloads).
+**https://console.anyscale.com/template-preview/image-search-and-classification** or access the repository [here](https://github.com/anyscale/templates/tree/main/templates/image-search-and-classification).
 
 This tutorial focuses on the fundamental challenges of multimodal AI workloads at scale:
 


### PR DESCRIPTION
Three classes of small cleanup:

1. **Repo-level (A).** `audio-dataset-curation-llm-judge`'s "View On GitHub" button → `anyscale/templates/.../audio-dataset-curation-llm-judge` (was pointing to a private repo). Added missing `https://` scheme to a `docs.anyscale.com` link in `endpoints_v2`.

2. **Dead-link cleanup (D).** `e2e-dspy-workflow`'s dspy `clients/anyscale.py` link (404'd when dspy moved to LiteLLM) → `https://dspy.ai/learn/programming/language_models/` (HEAD-verified). `endpoints/examples/CustomModels.ipynb` internal dead yaml link → removed. `image-search-and-classification` ray-doc link → local (kept `anyscale/multimodal-ai` mirror unchanged).

3. **Repo redirects (D).** `hiyouga/LLaMA-Factory` → `hiyouga/LlamaFactory` (15 refs across templates incl. pip pins in containerfile); `microsoft/DeepSpeed` → `deepspeedai/DeepSpeed`. Repos renamed upstream; updating to canonical avoids redirect dependency.

Left as-is (out of scope): archived `ray-project/llmperf` (no canonical replacement); 18 `docs.anyscale.com/examples/<old-slug>` links (resolve via redirects; #626 explicitly deferred them).
