### PR TITLE
test: harden the final 3 nb2py templates → papermill (batch 13)

### DIFF
--- a/templates/llm_batch_inference_text/README.ipynb
+++ b/templates/llm_batch_inference_text/README.ipynb
@@ -329,7 +329,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "skip-in-ci"
+    ]
+   },
    "outputs": [],
    "source": [
     "# The dataset has ~2M rows\n",
@@ -353,7 +357,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "skip-in-ci"
+    ]
+   },
    "outputs": [],
    "source": [
     "processor_config_large = vLLMEngineProcessorConfig(\n",
@@ -384,7 +392,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "skip-in-ci"
+    ]
+   },
    "outputs": [],
    "source": [
     "# Run the same processor on the larger dataset.\n",

--- a/templates/model-composition-recsys/README.ipynb
+++ b/templates/model-composition-recsys/README.ipynb
@@ -320,7 +320,8 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "skip-execution"
+     "skip-execution",
+     "skip-in-ci"
     ]
    },
    "outputs": [],

--- a/templates/model-composition-recsys/README.ipynb
+++ b/templates/model-composition-recsys/README.ipynb
@@ -320,7 +320,6 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "skip-execution",
      "skip-in-ci"
     ]
    },

--- a/templates/object-detection-video-processing/4.object_detection_serve.ipynb
+++ b/templates/object-detection-video-processing/4.object_detection_serve.ipynb
@@ -222,7 +222,11 @@
     },
     {
       "cell_type": "code",
-      "metadata": {},
+      "metadata": {
+        "tags": [
+          "skip-in-ci"
+        ]
+      },
       "source": [
         "!anyscale service deploy object_detection:entrypoint --name=face_mask_detection_service"
       ],
@@ -243,7 +247,11 @@
     },
     {
       "cell_type": "code",
-      "metadata": {},
+      "metadata": {
+        "tags": [
+          "skip-in-ci"
+        ]
+      },
       "source": [
         "\n",
         "!anyscale service status --name=face_mask_detection_service"
@@ -276,7 +284,9 @@
     {
       "cell_type": "code",
       "metadata": {
-        "tags": []
+        "tags": [
+          "skip-in-ci"
+        ]
       },
       "source": [
         "import requests\n",

--- a/tests/llm_batch_inference_text/tests.sh
+++ b/tests/llm_batch_inference_text/tests.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
-
-set -exo pipefail
-
-python nb2py.py "README.ipynb" "README.py" --ignore-cmds
-python "README.py"
-rm "README.py"
+#!/usr/bin/env bash
+set -euxo pipefail
+pip install -q papermill nbconvert==7.16.6
+jupyter nbconvert --to notebook README.ipynb \
+  --TagRemovePreprocessor.enabled=True \
+  --TagRemovePreprocessor.remove_cell_tags='["skip-in-ci"]' \
+  --output /tmp/llm_batch_inference_text.ci.ipynb
+papermill /tmp/llm_batch_inference_text.ci.ipynb /tmp/llm_batch_inference_text.out.ipynb --log-output --kernel python3 --cwd .

--- a/tests/model-composition-recsys/tests.sh
+++ b/tests/model-composition-recsys/tests.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
-python nb2py.py "README.ipynb" "README.py"
-python "README.py"
-rm "README.py"
+pip install -q papermill nbconvert==7.16.6
+
+# Strip the `# client_anyscale_service.py` cell (tagged skip-in-ci) — it requires a
+# real prod endpoint + auth token from `anyscale service deploy`, not the localhost
+# serve.run path the test exercises.
+jupyter nbconvert --to notebook README.ipynb \
+  --TagRemovePreprocessor.enabled=True \
+  --TagRemovePreprocessor.remove_cell_tags='["skip-in-ci"]' \
+  --output /tmp/model-composition-recsys.ci.ipynb
+papermill /tmp/model-composition-recsys.ci.ipynb /tmp/model-composition-recsys.out.ipynb --log-output --kernel python3 --cwd .

--- a/tests/object-detection-video-processing/tests.sh
+++ b/tests/object-detection-video-processing/tests.sh
@@ -1,16 +1,15 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -euxo pipefail
 
-# don't use nbcovert or jupytext unless you're willing
-# to check each subprocess unit and validate that errors
-# aren't being consumed/hidden
+pip install -q papermill nbconvert==7.16.6
 
+# NB4 cells 13/15/17 (`anyscale service deploy/status` + the leaked-token prod
+# query) are tagged skip-in-ci. The local `serve run` test path (cells 7/9/11)
+# still runs.
 for nb in 1.object_detection_train 2.object_detection_batch_inference_eval 3.video_processing_batch_inference 4.object_detection_serve; do
-  # Convert .ipynb → .py (in the current dir)
-  python nb2py.py "${nb}.ipynb" "${nb}.py"
-  # Run the generated script (also in the current dir)
-  python "${nb}.py"
-  # Remove the generated .py
-  rm "${nb}.py"
+  jupyter nbconvert --to notebook "${nb}.ipynb" \
+    --TagRemovePreprocessor.enabled=True \
+    --TagRemovePreprocessor.remove_cell_tags='["skip-in-ci"]' \
+    --output "/tmp/${nb}.ci.ipynb"
+  papermill "/tmp/${nb}.ci.ipynb" "/tmp/${nb}.out.ipynb" --log-output --kernel python3 --cwd .
 done


### PR DESCRIPTION
Final batch — the last 3 templates on `main` still using `nb2py.py`. Each switches to nbconvert+papermill with surgical `skip-in-ci` tags.

- **llm_batch_inference_text**: cells 17/19/21 (the 1M-row "scaled demonstration" — `ds_large = ds.limit(1_000_000)` + `concurrency=10`) tagged skip-in-ci. The smaller demo (cells 2-13: 10k × L4 × Llama-3.1-8B) still runs end-to-end and covers the real workflow. Coverage trade vs. prior nb2py: that script sed-rewrote `1M → 10k` so the scaled-section code paths ran with a small dataset; the scaled section is now skipped entirely, which is showcase-only.
- **model-composition-recsys**: cell 11 (`# client_anyscale_service.py` with `ENDPOINT = "<YOUR-ENDPOINT>"` placeholder) tagged skip-in-ci — same MissingSchema fix as batch-12 model-multiplexing.
- **object-detection-video-processing**: 4-notebook loop. NB4 cells 13/15/17 tagged skip-in-ci — `!anyscale service deploy/status` and the cell with hardcoded `API_KEY = "xkRQv_..."` + prod URL `face-mask-detection-service-bxauk....anyscaleuserdata.com`. The local `serve run` test path (NB4 cells 7/9/11) still runs. Per prior directive the leaked-looking token in cell 17 is not scrubbed here.

Test-only changes plus `skip-in-ci` metadata tags. `tests/*/nb2py.py` left in place.

## Test plan
- [ ] `/test-template llm_batch_inference_text model-composition-recsys object-detection-video-processing`