### PR TITLE
fix(templates): replace broken MCP template-preview links with public docs guide

### DIFF
--- a/templates/langchain-agent-ray-serve/README.ipynb
+++ b/templates/langchain-agent-ray-serve/README.ipynb
@@ -151,8 +151,7 @@
     "\n",
     "**Additional resources:**\n",
     "- [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)\n",
-    "- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n",
-    "- [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve)\n"
+    "- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n"
    ]
   },
   {
@@ -629,7 +628,7 @@
     "### Extend your agent\n",
     "\n",
     "**Add more tools**  \n",
-    "Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve).\n",
+    "Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation guidance, see [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).\n",
     "\n",
     "**Swap or upgrade LLMs**  \n",
     "Replace the Qwen model with other tool-calling models such as GPT-4, Claude, or Llama variants. Since the LLM runs as a separate service, you can A/B test different models or perform zero-downtime upgrades. For deployment patterns, see the [Anyscale LLM Serving Template](https://console.anyscale.com/template-preview/deployment-serve-llm).\n",

--- a/templates/langchain-agent-ray-serve/README.md
+++ b/templates/langchain-agent-ray-serve/README.md
@@ -124,8 +124,7 @@ mcp = FastMCP("weather", stateless_http=True)
 
 **Additional resources:**
 - [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)
-- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)
-- [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve)
+- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)
 
 
 ### Step 3: Create the agent logic
@@ -514,7 +513,7 @@ You've successfully built, deployed, and tested a multi-tool agent using Ray Ser
 ### Extend your agent
 
 **Add more tools**  
-Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve).
+Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation guidance, see [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).
 
 **Swap or upgrade LLMs**  
 Replace the Qwen model with other tool-calling models such as GPT-4, Claude, or Llama variants. Since the LLM runs as a separate service, you can A/B test different models or perform zero-downtime upgrades. For deployment patterns, see the [Anyscale LLM Serving Template](https://console.anyscale.com/template-preview/deployment-serve-llm).

--- a/templates/multi_agent_a2a/README.ipynb
+++ b/templates/multi_agent_a2a/README.ipynb
@@ -598,7 +598,7 @@
     "\n",
     "Ray Serve only supports stateless HTTP mode in MCP. Set `stateless_http=True` to prevent \"session not found\" errors when running multiple replicas.\n",
     "\n",
-    "For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [MCP Ray Serve template](https://console.anyscale.com/template-preview/mcp-ray-serve).\n",
+    "For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).\n",
     "\n",
     "#### 5.2.1 Weather MCP server\n",
     "\n",
@@ -1035,7 +1035,7 @@
     "- [Anyscale LLM Serving Documentation](https://docs.anyscale.com/llm/serving) - Detailed guide for deploying and configuring LLM services.\n",
     "- [Deploy LLM Template](https://console.anyscale.com/template-preview/deployment-serve-llm) - Template for deploying LLM services on Anyscale.\n",
     "- [Anyscale MCP Documentation](https://docs.anyscale.com/mcp) - Guide for deploying and configuring MCP servers with Ray Serve.\n",
-    "- [MCP Ray Serve Template](https://console.anyscale.com/template-preview/mcp-ray-serve) - Template for deploying MCP servers on Anyscale."
+    "- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment) - Guide for deploying MCP servers on Anyscale."
    ]
   }
  ],

--- a/templates/multi_agent_a2a/README.md
+++ b/templates/multi_agent_a2a/README.md
@@ -369,7 +369,7 @@ For detailed information on deploying and configuring LLM services, see the [Any
 
 Ray Serve only supports stateless HTTP mode in MCP. Set `stateless_http=True` to prevent "session not found" errors when running multiple replicas.
 
-For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [MCP Ray Serve template](https://console.anyscale.com/template-preview/mcp-ray-serve).
+For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).
 
 #### 5.2.1 Weather MCP server
 
@@ -717,4 +717,4 @@ The system uses Ray Serve's built-in autoscaling to handle variable load. See th
 - [Anyscale LLM Serving Documentation](https://docs.anyscale.com/llm/serving) - Detailed guide for deploying and configuring LLM services.
 - [Deploy LLM Template](https://console.anyscale.com/template-preview/deployment-serve-llm) - Template for deploying LLM services on Anyscale.
 - [Anyscale MCP Documentation](https://docs.anyscale.com/mcp) - Guide for deploying and configuring MCP servers with Ray Serve.
-- [MCP Ray Serve Template](https://console.anyscale.com/template-preview/mcp-ray-serve) - Template for deploying MCP servers on Anyscale.
+- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment) - Guide for deploying MCP servers on Anyscale.


### PR DESCRIPTION
## Summary

The `Anyscale MCP Deployment Template` link (`https://console.anyscale.com/template-preview/mcp-ray-serve`) fails to render in the Anyscale console for users outside the appropriate organization. This PR replaces it with the equivalent public guide, [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment), in both templates that reference it:

- `templates/langchain-agent-ray-serve` (Step 2 resources list and "Extend your agent" section)
- `templates/multi_agent_a2a` (section 5.2 and closing resources list)

In the langchain template's Step 2 resources list, the public guide was already listed one bullet up, so the broken bullet is removed rather than rewritten.

Tracking: DOC-951 (kept open until the fix propagates to the Ray docs copies).

## Why here

This ports ray-project/ray#63439, which was closed unmerged: per Elliot, the Ray docs copies of these notebooks (`doc/source/ray-overview/examples/langchain_agent_ray_serve` and `multi_agent_a2a`) now sync from this repo, so the fix belongs at the source. The original report, ray-project/ray#62943, stays open until the synced copies in the Ray repo pick up this change.

## Changes

- Edited `README.ipynb` in both templates. Link replacements only; no code changes.
- Regenerated both `README.md` files with `jupyter-nbconvert` (verified by the `check-readme` pre-commit hook).

All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
