### PR TITLE
refactor(configs): migrate compute configs to ComputeConfig schema

### DIFF
--- a/ci/validate_build_yaml.py
+++ b/ci/validate_build_yaml.py
@@ -80,14 +80,12 @@ class Entry(Strict):
     test: Test
 
 
-# Schema for the new user-facing ComputeConfig, applied to BUILD.yaml-referenced
-# files. All fields are optional (lax) but extra keys are rejected (strict) — extra
-# keys (e.g. head_node_type, worker_node_types) usually indicate the file is still
-# using the legacy compute-config schema.
+# ComputeConfig schema, applied to BUILD.yaml-referenced files.
+# All fields are optional (lax) but extra keys are rejected (strict).
 #   ComputeConfig: https://docs.anyscale.com/reference/compute-config-api#computeconfig
 
-class NewHeadNode(Strict):
-    """Used for head_node. Note: the new schema has no per-node `name` on the head."""
+class HeadNode(Strict):
+    """Used for head_node (the head has no `name` field)."""
     instance_type: Optional[Any] = None
     resources: Optional[Any] = None
     required_resources: Optional[Any] = None
@@ -98,7 +96,7 @@ class NewHeadNode(Strict):
     cloud_deployment: Optional[Any] = None
 
 
-class NewWorkerNode(NewHeadNode):
+class WorkerNode(HeadNode):
     """Used for worker_nodes entries: head fields plus a name and worker scaling / market fields."""
     name: Optional[Any] = None
     min_nodes: Optional[Any] = None
@@ -106,11 +104,11 @@ class NewWorkerNode(NewHeadNode):
     market_type: Optional[Any] = None
 
 
-class NewComputeConfig(Strict):
+class ComputeConfigFile(Strict):
     cloud: Optional[Any] = None
     cloud_resource: Optional[Any] = None
-    head_node: Optional[NewHeadNode] = None
-    worker_nodes: Optional[List[NewWorkerNode]] = None
+    head_node: Optional[HeadNode] = None
+    worker_nodes: Optional[List[WorkerNode]] = None
     min_resources: Optional[Any] = None
     max_resources: Optional[Any] = None
     zones: Optional[Any] = None
@@ -122,9 +120,9 @@ class NewComputeConfig(Strict):
     @model_validator(mode="after")
     def _auto_select_xor_worker_nodes(self):
         # Mirror the SDK constraint (anyscale compute_config/models.py
-        # _validate_auto_select_worker_config): the new schema forbids
-        # auto_select_worker_config together with an explicit worker_nodes list
-        # (note `[]` is not None, so it is also forbidden).
+        # _validate_auto_select_worker_config): auto_select_worker_config cannot
+        # be combined with an explicit worker_nodes list (note `[]` is not None,
+        # so it is also forbidden).
         if self.auto_select_worker_config and self.worker_nodes is not None:
             raise ValueError(
                 "'auto_select_worker_config: true' cannot be combined with 'worker_nodes'; "
@@ -260,8 +258,8 @@ COMPUTE_CONFIG_DOCS = (
 
 
 def check_compute_configs(entries: list[Entry]) -> list[str]:
-    """Each compute config file must follow the new user-facing ComputeConfig
-    schema. Top-level keys are checked (nested keys are lightly validated)."""
+    """Each compute config file must follow the ComputeConfig schema.
+    Top-level keys are checked (nested keys are lightly validated)."""
     errors: list[str] = []
     paths: set[str] = set()
     for e in entries:
@@ -273,7 +271,7 @@ def check_compute_configs(entries: list[Entry]) -> list[str]:
             continue  # already reported by check_filesystem_and_uniqueness
         try:
             data = yaml.safe_load(full.read_text()) or {}
-            NewComputeConfig.model_validate(data)
+            ComputeConfigFile.model_validate(data)
         except ValidationError as e:
             extras = [
                 ".".join(str(p) for p in err["loc"]) for err in e.errors()
@@ -281,9 +279,8 @@ def check_compute_configs(entries: list[Entry]) -> list[str]:
             ]
             if extras:
                 errors.append(
-                    f"{path}: unknown keys {extras} — this config likely uses "
-                    f"the legacy compute-config schema. This repo now requires the "
-                    f"new ComputeConfig schema: {COMPUTE_CONFIG_DOCS}"
+                    f"{path}: unknown keys {extras} — compute configs must follow "
+                    f"the ComputeConfig schema: {COMPUTE_CONFIG_DOCS}"
                 )
             else:
                 errors.append(f"{path}: {e.errors()}")

--- a/ci/validate_build_yaml.py
+++ b/ci/validate_build_yaml.py
@@ -80,58 +80,57 @@ class Entry(Strict):
     test: Test
 
 
-# Schemas for the legacy compute config, applied to BUILD.yaml-referenced
-# files. All fields are optional (lax) but extra keys are rejected (strict)
-# — extra keys usually indicate the file is using the new schema.
-#   ComputeTemplateConfig: https://docs.anyscale.com/ref/0.26.64/compute-config-api#computetemplateconfig-legacy
-#   ComputeNodeType:       https://docs.anyscale.com/ref/0.26.64/compute-config-api#computenodetype-legacy
-#   WorkerNodeType:        https://docs.anyscale.com/ref/0.26.64/other#workernodetype-legacy
-#   Resources:             https://docs.anyscale.com/ref/0.26.64/other#resources-legacy
+# Schema for the new user-facing ComputeConfig, applied to BUILD.yaml-referenced
+# files. All fields are optional (lax) but extra keys are rejected (strict) — extra
+# keys (e.g. head_node_type, worker_node_types) usually indicate the file is still
+# using the legacy compute-config schema.
+#   ComputeConfig: https://docs.anyscale.com/reference/compute-config-api#computeconfig
 
-class LegacyResources(Strict):
-    cpu: Optional[Any] = None
-    gpu: Optional[Any] = None
-    memory: Optional[Any] = None
-    object_store_memory: Optional[Any] = None
-    custom_resources: Optional[Any] = None
-
-
-class LegacyComputeNodeType(Strict):
-    """Used for head_node_type."""
-    name: Optional[Any] = None
+class NewHeadNode(Strict):
+    """Used for head_node. Note: the new schema has no per-node `name` on the head."""
     instance_type: Optional[Any] = None
-    resources: Optional[LegacyResources] = None
+    resources: Optional[Any] = None
+    required_resources: Optional[Any] = None
     labels: Optional[Any] = None
-    aws_advanced_configurations_json: Optional[Any] = None
-    gcp_advanced_configurations_json: Optional[Any] = None
-    advanced_configurations_json: Optional[Any] = None
+    required_labels: Optional[Any] = None
+    advanced_instance_config: Optional[Any] = None
     flags: Optional[Any] = None
+    cloud_deployment: Optional[Any] = None
 
 
-class LegacyWorkerNodeType(LegacyComputeNodeType):
-    """Used for worker_node_types entries. Same as ComputeNodeType plus
-    worker-specific scaling / spot fields."""
-    min_workers: Optional[Any] = None
-    max_workers: Optional[Any] = None
-    use_spot: Optional[Any] = None
-    fallback_to_ondemand: Optional[Any] = None
+class NewWorkerNode(NewHeadNode):
+    """Used for worker_nodes entries: head fields plus a name and worker scaling / market fields."""
+    name: Optional[Any] = None
+    min_nodes: Optional[Any] = None
+    max_nodes: Optional[Any] = None
+    market_type: Optional[Any] = None
 
 
-class LegacyComputeTemplateConfig(Strict):
-    cloud_id: Optional[Any] = None
-    maximum_uptime_minutes: Optional[Any] = None
-    deployment_configs: Optional[Any] = None
-    max_workers: Optional[Any] = None
-    region: Optional[Any] = None
-    allowed_azs: Optional[Any] = None
-    head_node_type: Optional[LegacyComputeNodeType] = None
-    worker_node_types: Optional[List[LegacyWorkerNodeType]] = None
-    aws_advanced_configurations_json: Optional[Any] = None
-    gcp_advanced_configurations_json: Optional[Any] = None
-    advanced_configurations_json: Optional[Any] = None
+class NewComputeConfig(Strict):
+    cloud: Optional[Any] = None
+    cloud_resource: Optional[Any] = None
+    head_node: Optional[NewHeadNode] = None
+    worker_nodes: Optional[List[NewWorkerNode]] = None
+    min_resources: Optional[Any] = None
+    max_resources: Optional[Any] = None
+    zones: Optional[Any] = None
+    enable_cross_zone_scaling: Optional[Any] = None
+    advanced_instance_config: Optional[Any] = None
+    flags: Optional[Any] = None
     auto_select_worker_config: Optional[Any] = None
-    flags: Optional[Any] = None
-    idle_termination_minutes: Optional[Any] = None
+
+    @model_validator(mode="after")
+    def _auto_select_xor_worker_nodes(self):
+        # Mirror the SDK constraint (anyscale compute_config/models.py
+        # _validate_auto_select_worker_config): the new schema forbids
+        # auto_select_worker_config together with an explicit worker_nodes list
+        # (note `[]` is not None, so it is also forbidden).
+        if self.auto_select_worker_config and self.worker_nodes is not None:
+            raise ValueError(
+                "'auto_select_worker_config: true' cannot be combined with 'worker_nodes'; "
+                "omit 'worker_nodes' when auto-selecting"
+            )
+        return self
 
 
 # ------------------------------------------- filesystem + name uniqueness
@@ -253,17 +252,16 @@ def check_redundant_compute_configs(entries: list[Entry]) -> list[str]:
     return warnings
 
 
-# ----------------------------------------- compute config legacy schema
+# -------------------------------------- compute config schema (ComputeConfig)
 
-LEGACY_DOCS = (
-    "https://docs.anyscale.com/ref/0.26.64/compute-config-api"
-    "#computetemplateconfig-legacy"
+COMPUTE_CONFIG_DOCS = (
+    "https://docs.anyscale.com/reference/compute-config-api#computeconfig"
 )
 
 
-def check_compute_configs_legacy(entries: list[Entry]) -> list[str]:
-    """Each compute config file must follow the legacy ComputeTemplateConfig
-    schema. Top-level keys are checked (nested keys are not validated)."""
+def check_compute_configs(entries: list[Entry]) -> list[str]:
+    """Each compute config file must follow the new user-facing ComputeConfig
+    schema. Top-level keys are checked (nested keys are lightly validated)."""
     errors: list[str] = []
     paths: set[str] = set()
     for e in entries:
@@ -275,7 +273,7 @@ def check_compute_configs_legacy(entries: list[Entry]) -> list[str]:
             continue  # already reported by check_filesystem_and_uniqueness
         try:
             data = yaml.safe_load(full.read_text()) or {}
-            LegacyComputeTemplateConfig.model_validate(data)
+            NewComputeConfig.model_validate(data)
         except ValidationError as e:
             extras = [
                 ".".join(str(p) for p in err["loc"]) for err in e.errors()
@@ -284,8 +282,8 @@ def check_compute_configs_legacy(entries: list[Entry]) -> list[str]:
             if extras:
                 errors.append(
                     f"{path}: unknown keys {extras} — this config likely uses "
-                    f"the new compute-config schema. This repo requires the "
-                    f"legacy ComputeTemplateConfig API: {LEGACY_DOCS}"
+                    f"the legacy compute-config schema. This repo now requires the "
+                    f"new ComputeConfig schema: {COMPUTE_CONFIG_DOCS}"
                 )
             else:
                 errors.append(f"{path}: {e.errors()}")
@@ -388,7 +386,7 @@ def main() -> int:
         print(f"::warning::{w}", file=sys.stderr)
 
     errors = check_filesystem_and_uniqueness(entries)
-    errors.extend(check_compute_configs_legacy(entries))
+    errors.extend(check_compute_configs(entries))
     errors.extend(check_gcp_byod_images(entries, network=not args.no_network))
 
     if errors:

--- a/configs/anyscale-ray-101/aws.yaml
+++ b/configs/anyscale-ray-101/aws.yaml
@@ -1,10 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
+worker_nodes:
 - name: cpu_worker
   instance_type: m5.2xlarge
-  min_workers: 0
-  max_workers: 2
-  use_spot: false
+  max_nodes: 2

--- a/configs/anyscale-ray-101/gce.yaml
+++ b/configs/anyscale-ray-101/gce.yaml
@@ -1,10 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: cpu_worker
   instance_type: n2-standard-8
-  min_workers: 0
-  max_workers: 2
-  use_spot: false
+  max_nodes: 2

--- a/configs/audio-dataset-curation-llm-judge/aws.yaml
+++ b/configs/audio-dataset-curation-llm-judge/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types:
-  - name: "gpu-workers"
-    instance_type: "g6.4xlarge"
-    min_workers: 5
-    max_workers: 5
-auto_select_worker_config: false
+worker_nodes:
+- name: gpu-workers
+  instance_type: g6.4xlarge
+  min_nodes: 5
+  max_nodes: 5

--- a/configs/audio-dataset-curation-llm-judge/gce.yaml
+++ b/configs/audio-dataset-curation-llm-judge/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-worker_node_types:
-  - name: "gpu-workers"
-    instance_type: "g2-standard-16"
-    min_workers: 5
-    max_workers: 5
-auto_select_worker_config: false
+worker_nodes:
+- name: gpu-workers
+  instance_type: g2-standard-16
+  min_nodes: 5
+  max_nodes: 5

--- a/configs/basic-serverless-config/aws.yaml
+++ b/configs/basic-serverless-config/aws.yaml
@@ -1,5 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types: []
 auto_select_worker_config: true

--- a/configs/basic-serverless-config/gce.yaml
+++ b/configs/basic-serverless-config/gce.yaml
@@ -1,5 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-worker_node_types: []
 auto_select_worker_config: true

--- a/configs/basic-single-node/aws.yaml
+++ b/configs/basic-single-node/aws.yaml
@@ -1,5 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types: []
 auto_select_worker_config: true

--- a/configs/basic-single-node/gce.yaml
+++ b/configs/basic-single-node/gce.yaml
@@ -1,5 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-worker_node_types: []
 auto_select_worker_config: true

--- a/configs/batch-llm/aws-l4.yaml
+++ b/configs/batch-llm/aws-l4.yaml
@@ -1,11 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: worker
   instance_type: g6.2xlarge
-  min_workers: 1
-  max_workers: 4
+  min_nodes: 1
+  max_nodes: 4

--- a/configs/batch-llm/aws.yaml
+++ b/configs/batch-llm/aws.yaml
@@ -1,4 +1,3 @@
-head_node_type:
-  name: head
-    # TODO(ricky): We need head node to have CUDA due to eager import from rayllm_batch now.
+head_node:
   instance_type: g5.xlarge
+worker_nodes: []

--- a/configs/batch-llm/gce.yaml
+++ b/configs/batch-llm/gce.yaml
@@ -1,11 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: worker
   instance_type: g2-standard-8-nvidia-l4-1
-  min_workers: 1
-  max_workers: 4
+  min_nodes: 1
+  max_nodes: 4

--- a/configs/biotech_boltz_screening/aws.yaml
+++ b/configs/biotech_boltz_screening/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g5.2xlarge   # A10G 24GB — Boltz-1 inference
-    min_workers: 1
-    max_workers: 4
+worker_nodes:
+- name: gpu-worker
+  instance_type: g5.2xlarge
+  min_nodes: 1
+  max_nodes: 4

--- a/configs/biotech_boltz_screening/gce.yaml
+++ b/configs/biotech_boltz_screening/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g2-standard-8-nvidia-l4-1   # L4 24GB — Boltz-1 inference
-    min_workers: 1
-    max_workers: 4
+worker_nodes:
+- name: gpu-worker
+  instance_type: g2-standard-8-nvidia-l4-1
+  min_nodes: 1
+  max_nodes: 4

--- a/configs/biotech_protein_embeddings/aws.yaml
+++ b/configs/biotech_protein_embeddings/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g5.xlarge   # A10G 24GB — ESM-2 inference
-    min_workers: 1
-    max_workers: 2
+worker_nodes:
+- name: gpu-worker
+  instance_type: g5.xlarge
+  min_nodes: 1
+  max_nodes: 2

--- a/configs/biotech_protein_embeddings/gce.yaml
+++ b/configs/biotech_protein_embeddings/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g2-standard-8-nvidia-l4-1   # L4 24GB — ESM-2 inference
-    min_workers: 1
-    max_workers: 2
+worker_nodes:
+- name: gpu-worker
+  instance_type: g2-standard-8-nvidia-l4-1
+  min_nodes: 1
+  max_nodes: 2

--- a/configs/creatives_diffusion_finetuning/aws.yaml
+++ b/configs/creatives_diffusion_finetuning/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g4dn.xlarge   # T4 16GB — one per training worker
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: gpu-worker
+  instance_type: g4dn.xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/creatives_diffusion_finetuning/gce.yaml
+++ b/configs/creatives_diffusion_finetuning/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: n1-standard-8-nvidia-t4-16gb-1   # T4 16GB — LoRA fine-tuning
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: gpu-worker
+  instance_type: n1-standard-8-nvidia-t4-16gb-1
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/deepspeed_finetune/aws.yaml
+++ b/configs/deepspeed_finetune/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g6.2xlarge
-    name: '1xL4:8CPU-32GB'
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: 1xL4:8CPU-32GB
+  instance_type: g6.2xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/deepspeed_finetune/gce.yaml
+++ b/configs/deepspeed_finetune/gce.yaml
@@ -1,10 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: g2-standard-8-nvidia-l4-1
-  min_workers: 2
-  max_workers: 2
-  use_spot: false
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/distributing-pytorch/aws.yaml
+++ b/configs/distributing-pytorch/aws.yaml
@@ -1,15 +1,7 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: g4dn.xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-
-# Worker nodes
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g4dn.12xlarge  # 4x T4 GPUs
-    min_workers: 2
-    max_workers: 2
-    use_spot: false
+worker_nodes:
+- name: gpu-worker
+  instance_type: g4dn.12xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/distributing-pytorch/gce.yaml
+++ b/configs/distributing-pytorch/gce.yaml
@@ -1,15 +1,7 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8-nvidia-tesla-t4-1
-  resources:
-    cpu: 0
-    gpu: 0
-
-# Worker nodes
-worker_node_types:
-  - name: gpu_worker
-    instance_type: n1-standard-8-nvidia-tesla-t4-4
-    min_workers: 2
-    max_workers: 2
-    use_spot: false
+worker_nodes:
+- name: gpu_worker
+  instance_type: n1-standard-8-nvidia-tesla-t4-4
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/e2e-llm-workflows/aws.yaml
+++ b/configs/e2e-llm-workflows/aws.yaml
@@ -1,18 +1,12 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 8
-
-worker_node_types:
+    CPU: 8
+worker_nodes:
 - name: cpu-worker
   instance_type: m5.2xlarge
-  min_workers: 0
-  max_workers: 1
+  max_nodes: 1
 - name: gpu-worker
   instance_type: g5.12xlarge
-  min_workers: 0
-  max_workers: 2
-
-flags:
-  allow-cross-zone-autoscaling: true
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/e2e-llm-workflows/gcp.yaml
+++ b/configs/e2e-llm-workflows/gcp.yaml
@@ -1,20 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 8
-
+    CPU: 8
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-
-# This will be ignored since auto_select_worker_config is enabled,
-# but must be present to pass backend validation.
-# TODO (shomilj): Remove once validation is fixed.
-worker_node_types:
-- name: cpu-worker
-  instance_type: n2-standard-8
-  min_workers: 0
-  max_workers: 1
-  use_spot: false
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/e2e-rag-deepdive/aws.yaml
+++ b/configs/e2e-rag-deepdive/aws.yaml
@@ -1,9 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-worker_node_types: []
+    CPU: 0
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/e2e-rag-deepdive/gce.yaml
+++ b/configs/e2e-rag-deepdive/gce.yaml
@@ -1,9 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-worker_node_types: []
+    CPU: 0
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/e2e-timeseries-forecasting/aws.yaml
+++ b/configs/e2e-timeseries-forecasting/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.12xlarge
-    name: '4xT4:48CPU-192GB'
-    min_workers: 1
-    max_workers: 1
+worker_nodes:
+- name: 4xT4:48CPU-192GB
+  instance_type: g4dn.12xlarge
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/e2e-timeseries-forecasting/gce.yaml
+++ b/configs/e2e-timeseries-forecasting/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-
-worker_node_types:
-  - instance_type: n1-standard-16-nvidia-t4-16gb-4
-    name: '4xT4:16CPU-60GB'
-    min_workers: 1
-    max_workers: 1
+worker_nodes:
+- name: 4xT4:16CPU-60GB
+  instance_type: n1-standard-16-nvidia-t4-16gb-4
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/ecommerce_batch_embeddings/aws.yaml
+++ b/configs/ecommerce_batch_embeddings/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g4dn.xlarge   # T4 16GB — sentence embedding inference
-    min_workers: 1
-    max_workers: 2
+worker_nodes:
+- name: gpu-worker
+  instance_type: g4dn.xlarge
+  min_nodes: 1
+  max_nodes: 2

--- a/configs/ecommerce_batch_embeddings/gce.yaml
+++ b/configs/ecommerce_batch_embeddings/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: n1-standard-8-nvidia-t4-16gb-1   # T4 16GB — sentence embedding inference
-    min_workers: 1
-    max_workers: 2
+worker_nodes:
+- name: gpu-worker
+  instance_type: n1-standard-8-nvidia-t4-16gb-1
+  min_nodes: 1
+  max_nodes: 2

--- a/configs/ecommerce_multi_model_serving/aws.yaml
+++ b/configs/ecommerce_multi_model_serving/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g4dn.xlarge   # T4 16GB — Ray Serve replicas
-    min_workers: 1
-    max_workers: 4
+worker_nodes:
+- name: gpu-worker
+  instance_type: g4dn.xlarge
+  min_nodes: 1
+  max_nodes: 4

--- a/configs/ecommerce_multi_model_serving/gce.yaml
+++ b/configs/ecommerce_multi_model_serving/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
-  - name: gpu-worker
-    instance_type: n1-standard-8-nvidia-t4-16gb-1   # T4 16GB — Ray Serve replicas
-    min_workers: 1
-    max_workers: 4
+worker_nodes:
+- name: gpu-worker
+  instance_type: n1-standard-8-nvidia-t4-16gb-1
+  min_nodes: 1
+  max_nodes: 4

--- a/configs/endpoints/aws.yaml
+++ b/configs/endpoints/aws.yaml
@@ -1,122 +1,65 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: cpu-worker
   instance_type: m5.2xlarge
-  min_workers: 0
-  max_workers: 100
-  use_spot: false
+  max_nodes: 100
 - name: gpu-worker-t4-1
   instance_type: g4dn.2xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:T4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:T4: 1
+  max_nodes: 100
 - name: gpu-worker-t4-4
   instance_type: g4dn.12xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:T4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:T4: 1
+  max_nodes: 100
 - name: gpu-worker-a10g-1
   instance_type: g5.4xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A10G": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:A10G: 1
+  max_nodes: 100
 - name: gpu-worker-a10g-4
   instance_type: g5.12xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A10G": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:A10G: 1
+  max_nodes: 100
 - name: gpu-worker-a10g-8
   instance_type: g5.48xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A10G": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:A10G: 1
+  max_nodes: 100
 - name: gpu-worker-v100-1
   instance_type: p3.2xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:V100": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:V100: 1
+  max_nodes: 100
 - name: gpu-worker-v100-4
   instance_type: p3.8xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:V100": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:V100: 1
+  max_nodes: 100
 - name: gpu-worker-a100-40g-8
   instance_type: p4d.24xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A100-40G": 1
-  aws_advanced_configurations_json:
+    accelerator_type:A100-40G: 1
+  max_nodes: 100
+  advanced_instance_config:
     BlockDeviceMappings:
     - DeviceName: /dev/sda1
       Ebs:
         DeleteOnTermination: true
         VolumeSize: 1000
-  min_workers: 0
-  max_workers: 100
 - name: gpu-worker-a100-80g-8
   instance_type: p4de.24xlarge
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A100-80G": 1
-  aws_advanced_configurations_json:
+    accelerator_type:A100-80G: 1
+  max_nodes: 100
+  advanced_instance_config:
     BlockDeviceMappings:
     - DeviceName: /dev/sda1
       Ebs:
         DeleteOnTermination: true
         VolumeSize: 1000
-  min_workers: 0
-  max_workers: 100

--- a/configs/endpoints/gcp.yaml
+++ b/configs/endpoints/gcp.yaml
@@ -1,124 +1,62 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: cpu-worker
   instance_type: n2-standard-8
-  min_workers: 0
-  max_workers: 100
+  max_nodes: 100
 - name: gpu-worker-t4-1
   instance_type: n1-standard-8-nvidia-t4-16gb-1
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:T4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:T4: 1
+  max_nodes: 100
 - name: gpu-worker-l4-1
   instance_type: g2-standard-12-nvidia-l4-1
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:L4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:L4: 1
+  max_nodes: 100
 - name: gpu-worker-l4-2
   instance_type: g2-standard-24-nvidia-l4-2
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:L4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:L4: 1
+  max_nodes: 100
 - name: gpu-worker-l4-4
   instance_type: g2-standard-48-nvidia-l4-4
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:L4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:L4: 1
+  max_nodes: 100
 - name: gpu-worker-l4-8
   instance_type: g2-standard-96-nvidia-l4-8
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:L4": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:L4: 1
+  max_nodes: 100
 - name: gpu-worker-v100-1
   instance_type: n1-standard-32-nvidia-v100-16gb-4
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:V100": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:V100: 1
+  max_nodes: 100
 - name: gpu-worker-a100-40g-1
   instance_type: a2-highgpu-1g-nvidia-a100-40gb-1
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A100-40G": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:A100-40G: 1
+  max_nodes: 100
 - name: gpu-worker-a100-40g-2
   instance_type: a2-highgpu-2g-nvidia-a100-40gb-2
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A100-40G": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:A100-40G: 1
+  max_nodes: 100
 - name: gpu-worker-a100-40g-4
   instance_type: a2-highgpu-4g-nvidia-a100-40gb-4
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A100-40G": 1
-  min_workers: 0
-  max_workers: 100
+    accelerator_type:A100-40G: 1
+  max_nodes: 100
 - name: gpu-worker-a100-40g-8
   instance_type: a2-highgpu-8g-nvidia-a100-40gb-8
   resources:
-    cpu:
-    gpu:
-    memory:
-    object_store_memory:
-    custom_resources:
-      "accelerator_type:A100-40G": 1
-  min_workers: 0
-  max_workers: 100
-gcp_advanced_configurations_json:
+    accelerator_type:A100-40G: 1
+  max_nodes: 100
+advanced_instance_config:
   instance_properties:
     labels:
       as-feature-multi-zone: 'true'

--- a/configs/endpoints_v2/aws.yaml
+++ b/configs/endpoints_v2/aws.yaml
@@ -1,19 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-
+    CPU: 0
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-
-# This will be ignored since auto_select_worker_config is enabled,
-# but must be present to pass backend validation.
-# TODO (shomilj): Remove once validation is fixed.
-worker_node_types:
-- name: cpu-worker
-  instance_type: m5.2xlarge
-  min_workers: 0
-  max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/endpoints_v2/aws_no_cross_zone.yaml
+++ b/configs/endpoints_v2/aws_no_cross_zone.yaml
@@ -1,19 +1,5 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-
+    CPU: 0
 auto_select_worker_config: true
-
-# This will be ignored since auto_select_worker_config is enabled,
-# but must be present to pass backend validation.
-# TODO (shomilj): Remove once validation is fixed.
-worker_node_types:
-- name: cpu-worker
-  instance_type: m5.2xlarge
-  min_workers: 0
-  max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: false

--- a/configs/endpoints_v2/gcp.yaml
+++ b/configs/endpoints_v2/gcp.yaml
@@ -1,20 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-
+    CPU: 0
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-
-# This will be ignored since auto_select_worker_config is enabled,
-# but must be present to pass backend validation.
-# TODO (shomilj): Remove once validation is fixed.
-worker_node_types:
-- name: cpu-worker
-  instance_type: n2-standard-8
-  min_workers: 0
-  max_workers: 1
-  use_spot: false
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/endpoints_v2/gcp_no_cross_zone.yaml
+++ b/configs/endpoints_v2/gcp_no_cross_zone.yaml
@@ -1,20 +1,5 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-
+    CPU: 0
 auto_select_worker_config: true
-
-# This will be ignored since auto_select_worker_config is enabled,
-# but must be present to pass backend validation.
-# TODO (shomilj): Remove once validation is fixed.
-worker_node_types:
-- name: cpu-worker
-  instance_type: n2-standard-8
-  min_workers: 0
-  max_workers: 1
-  use_spot: false
-
-flags:
-  allow-cross-zone-autoscaling: false

--- a/configs/entity-recognition-with-llms/aws.yaml
+++ b/configs/entity-recognition-with-llms/aws.yaml
@@ -1,15 +1,6 @@
-# Head node (CPU only)
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-
-# Worker nodes with L4 GPUs
-worker_node_types:
-  - name: gpu-worker-4xL4
-    instance_type: g6.12xlarge  # 4x L4 GPUs
-    min_workers: 0
-    max_workers: 2
-    use_spot: false
+worker_nodes:
+- name: gpu-worker-4xL4
+  instance_type: g6.12xlarge
+  max_nodes: 2

--- a/configs/entity-recognition-with-llms/gce.yaml
+++ b/configs/entity-recognition-with-llms/gce.yaml
@@ -1,15 +1,6 @@
-# Head node (CPU only)
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-  resources:
-    cpu: 0
-    gpu: 0
-
-# Worker nodes with L4 GPUs
-worker_node_types:
-  - name: gpu-worker-4xL4
-    instance_type: g2-standard-48  # 4x L4 GPUs
-    min_workers: 0
-    max_workers: 2
-    use_spot: false
+worker_nodes:
+- name: gpu-worker-4xL4
+  instance_type: g2-standard-48
+  max_nodes: 2

--- a/configs/fine-tune-llm_v2/gce.yaml
+++ b/configs/fine-tune-llm_v2/gce.yaml
@@ -1,13 +1,10 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-auto_select_worker_config: true
-worker_node_types: []
-
-gcp_advanced_configurations_json:
+advanced_instance_config:
   instance_properties:
     disks:
-      - boot: true
-        auto_delete: true
-        initialize_params:
-          disk_size_gb: 250
+    - boot: true
+      auto_delete: true
+      initialize_params:
+        disk_size_gb: 250
+auto_select_worker_config: true

--- a/configs/finetune-stable-diffusion/aws.yaml
+++ b/configs/finetune-stable-diffusion/aws.yaml
@@ -1,8 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g5.2xlarge
-    min_workers: 0
-    max_workers: 4
+worker_nodes:
+- name: gpu-worker
+  instance_type: g5.2xlarge
+  max_nodes: 4

--- a/configs/finetune-stable-diffusion/gce.yaml
+++ b/configs/finetune-stable-diffusion/gce.yaml
@@ -1,8 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-worker_node_types:
-  - name: gpu-worker
-    instance_type: g2-standard-8
-    min_workers: 0
-    max_workers: 4
+worker_nodes:
+- name: gpu-worker
+  instance_type: g2-standard-8
+  max_nodes: 4

--- a/configs/fintech_fraud_risk/aws.yaml
+++ b/configs/fintech_fraud_risk/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.4xlarge
-
-worker_node_types:
-  - name: cpu-worker
-    instance_type: m5.4xlarge   # 16 vCPU, 64GB RAM — feature engineering + scoring
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: cpu-worker
+  instance_type: m5.4xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/fintech_fraud_risk/gce.yaml
+++ b/configs/fintech_fraud_risk/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-16
-
-worker_node_types:
-  - name: cpu-worker
-    instance_type: n2-standard-16   # 16 vCPU, 64GB RAM — feature engineering + scoring
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: cpu-worker
+  instance_type: n2-standard-16
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/fintech_quant/aws.yaml
+++ b/configs/fintech_quant/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: cpu-worker
-    instance_type: m5.2xlarge   # 8 vCPU, 32GB RAM — Ray Core task parallelism
-    min_workers: 2
-    max_workers: 4
+worker_nodes:
+- name: cpu-worker
+  instance_type: m5.2xlarge
+  min_nodes: 2
+  max_nodes: 4

--- a/configs/fintech_quant/gce.yaml
+++ b/configs/fintech_quant/gce.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
-  - name: cpu-worker
-    instance_type: n2-standard-8   # 8 vCPU, 32GB RAM — Ray Core task parallelism
-    min_workers: 2
-    max_workers: 4
+worker_nodes:
+- name: cpu-worker
+  instance_type: n2-standard-8
+  min_nodes: 2
+  max_nodes: 4

--- a/configs/getting-started/aws.yaml
+++ b/configs/getting-started/aws.yaml
@@ -1,10 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
+worker_nodes:
 - name: cpu_worker
   instance_type: m5.2xlarge
-  min_workers: 0
-  max_workers: 2
-  use_spot: false
+  max_nodes: 2

--- a/configs/getting-started/gce.yaml
+++ b/configs/getting-started/gce.yaml
@@ -1,10 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: cpu_worker
   instance_type: n2-standard-8
-  min_workers: 0
-  max_workers: 2
-  use_spot: false
+  max_nodes: 2

--- a/configs/groot-ray-serve/aws.yaml
+++ b/configs/groot-ray-serve/aws.yaml
@@ -1,15 +1,10 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-
-worker_node_types:
-# 8 vCPU, 1 NVIDIA L4 GPU, 32 GiB memory
+    CPU: 0
+worker_nodes:
 - name: gpu-worker
   instance_type: g6.2xlarge
-  min_workers: 2
-  max_workers: 4
-
-flags:
-  allow-cross-zone-autoscaling: true
+  min_nodes: 2
+  max_nodes: 4
+enable_cross_zone_scaling: true

--- a/configs/groot-ray-serve/gce.yaml
+++ b/configs/groot-ray-serve/gce.yaml
@@ -1,15 +1,10 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-
-worker_node_types:
-# 8 vCPU, 1 NVIDIA L4 GPU, 32 GiB memory
+    CPU: 0
+worker_nodes:
 - name: gpu-worker
   instance_type: g2-standard-8-nvidia-l4-1
-  min_workers: 2
-  max_workers: 4
-
-flags:
-  allow-cross-zone-autoscaling: true
+  min_nodes: 2
+  max_nodes: 4
+enable_cross_zone_scaling: true

--- a/configs/image-classification-service/aws.yaml
+++ b/configs/image-classification-service/aws.yaml
@@ -1,8 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: g5.xlarge
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: g5.xlarge
-  min_workers: 1
-  max_workers: 3
+  min_nodes: 1
+  max_nodes: 3

--- a/configs/image-classification-service/gce.yaml
+++ b/configs/image-classification-service/gce.yaml
@@ -1,8 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-4-nvidia-t4-16gb-1
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-4-nvidia-t4-16gb-1
-  min_workers: 1
-  max_workers: 3
+  min_nodes: 1
+  max_nodes: 3

--- a/configs/image-search-and-classification/aws.yaml
+++ b/configs/image-search-and-classification/aws.yaml
@@ -1,7 +1,4 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types: []
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/image-search-and-classification/gce.yaml
+++ b/configs/image-search-and-classification/gce.yaml
@@ -1,7 +1,4 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-worker_node_types: []
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/inferentia-llama/aws.yaml
+++ b/configs/inferentia-llama/aws.yaml
@@ -1,12 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: inf2.8xlarge
-worker_node_types:
+worker_nodes:
 - name: inf_worker
   instance_type: inf2.8xlarge
-  min_workers: 0
-  max_workers: 3
+  max_nodes: 3
 - name: inf_worker_2
   instance_type: inf2.48xlarge
-  min_workers: 0
-  max_workers: 3
+  max_nodes: 3

--- a/configs/inferentia-llama/gce.yaml
+++ b/configs/inferentia-llama/gce.yaml
@@ -1,3 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
+worker_nodes: []

--- a/configs/inferentia-stable-diffusion/aws.yaml
+++ b/configs/inferentia-stable-diffusion/aws.yaml
@@ -1,8 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: inf2.8xlarge
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: inf2.8xlarge
-  min_workers: 0
-  max_workers: 3
+  max_nodes: 3

--- a/configs/inferentia-stable-diffusion/gce.yaml
+++ b/configs/inferentia-stable-diffusion/gce.yaml
@@ -1,3 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
+worker_nodes: []

--- a/configs/intro-ray-libraries/aws.yaml
+++ b/configs/intro-ray-libraries/aws.yaml
@@ -1,12 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.12xlarge
-    name: '4xT4:48CPU-192GB'
-    min_workers: 1
-    max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 4xT4:48CPU-192GB
+  instance_type: g4dn.12xlarge
+  min_nodes: 1
+  max_nodes: 1
+enable_cross_zone_scaling: true

--- a/configs/intro-ray-libraries/gce.yaml
+++ b/configs/intro-ray-libraries/gce.yaml
@@ -1,12 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-
-worker_node_types:
-  - instance_type: n1-standard-16-nvidia-t4-16gb-4
-    name: '4xT4:16CPU-60GB'
-    min_workers: 1
-    max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 4xT4:16CPU-60GB
+  instance_type: n1-standard-16-nvidia-t4-16gb-4
+  min_nodes: 1
+  max_nodes: 1
+enable_cross_zone_scaling: true

--- a/configs/intro-workspaces/aws.yaml
+++ b/configs/intro-workspaces/aws.yaml
@@ -1,4 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types: []
+worker_nodes: []

--- a/configs/intro-workspaces/gce.yaml
+++ b/configs/intro-workspaces/gce.yaml
@@ -1,4 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-worker_node_types: []
+worker_nodes: []

--- a/configs/llm-router/aws.yaml
+++ b/configs/llm-router/aws.yaml
@@ -1,3 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: g5.48xlarge
+worker_nodes: []

--- a/configs/llm-router/gcp.yaml
+++ b/configs/llm-router/gcp.yaml
@@ -1,3 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: g2-standard-48
+worker_nodes: []

--- a/configs/llm_batch_inference_text/aws.yaml
+++ b/configs/llm_batch_inference_text/aws.yaml
@@ -1,14 +1,7 @@
-# Head node
-head_node_type:
-  name: 8CPU-32GB
+head_node:
   instance_type: m5.2xlarge
-
-# Worker nodes
-worker_node_types:
-  - name: 1xL4:8CPU-32GB
-    instance_type: g6.2xlarge
-    min_workers: 0
-    max_workers: 10
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:8CPU-32GB
+  instance_type: g6.2xlarge
+  max_nodes: 10
+enable_cross_zone_scaling: true

--- a/configs/llm_batch_inference_text/gce.yaml
+++ b/configs/llm_batch_inference_text/gce.yaml
@@ -1,14 +1,7 @@
-# Head node
-head_node_type:
-  name: 8CPU-32GB
+head_node:
   instance_type: n2-standard-8
-
-# Worker nodes
-worker_node_types:
-  - name: 1xL4:8CPU-32GB
-    instance_type: g2-standard-8-nvidia-l4-1
-    min_workers: 0
-    max_workers: 10
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:8CPU-32GB
+  instance_type: g2-standard-8-nvidia-l4-1
+  max_nodes: 10
+enable_cross_zone_scaling: true

--- a/configs/llm_batch_inference_vision/aws.yaml
+++ b/configs/llm_batch_inference_vision/aws.yaml
@@ -1,14 +1,7 @@
-# Head node
-head_node_type:
-  name: 8CPU-32GB
+head_node:
   instance_type: m5.2xlarge
-
-# Worker nodes
-worker_node_types:
-  - name: 1xL4:8CPU-32GB
-    instance_type: g6.2xlarge
-    min_workers: 0
-    max_workers: 10
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:8CPU-32GB
+  instance_type: g6.2xlarge
+  max_nodes: 10
+enable_cross_zone_scaling: true

--- a/configs/llm_batch_inference_vision/gce.yaml
+++ b/configs/llm_batch_inference_vision/gce.yaml
@@ -1,14 +1,7 @@
-# Head node
-head_node_type:
-  name: 8CPU-32GB
+head_node:
   instance_type: n2-standard-8
-
-# Worker nodes
-worker_node_types:
-  - name: 1xL4:8CPU-32GB
-    instance_type: g2-standard-8-nvidia-l4-1
-    min_workers: 0
-    max_workers: 10
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:8CPU-32GB
+  instance_type: g2-standard-8-nvidia-l4-1
+  max_nodes: 10
+enable_cross_zone_scaling: true

--- a/configs/multi_agent_a2a/aws.yaml
+++ b/configs/multi_agent_a2a/aws.yaml
@@ -1,14 +1,8 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-# Worker nodes
-worker_node_types:
-  - name: 1xL4:16CPU-64GB
-    instance_type: g6.4xlarge
-    min_workers: 1
-    max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g6.4xlarge
+  min_nodes: 1
+  max_nodes: 1
+enable_cross_zone_scaling: true

--- a/configs/multi_agent_a2a/gce.yaml
+++ b/configs/multi_agent_a2a/gce.yaml
@@ -1,14 +1,8 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-# Worker nodes
-worker_node_types:
-  - name: 1xL4:16CPU-64GB
-    instance_type: g2-standard-16-nvidia-l4-1
-    min_workers: 1
-    max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g2-standard-16-nvidia-l4-1
+  min_nodes: 1
+  max_nodes: 1
+enable_cross_zone_scaling: true

--- a/configs/object-detection-video-processing/aws.yaml
+++ b/configs/object-detection-video-processing/aws.yaml
@@ -1,14 +1,8 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 8
-
-# Worker nodes
-worker_node_types:
-  - name: "gpu-workers"
-    instance_type: "g4dn.xlarge"
-    min_workers: 0
-    max_workers: 10
-auto_select_worker_config: false
+    CPU: 8
+worker_nodes:
+- name: gpu-workers
+  instance_type: g4dn.xlarge
+  max_nodes: 10

--- a/configs/object-detection-video-processing/gce.yaml
+++ b/configs/object-detection-video-processing/gce.yaml
@@ -1,15 +1,8 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 8
-
-
-# Worker nodes
-worker_node_types:
-  - name: "gpu-workers"
-    instance_type: "n1-highcpu-4-nvidia-t4-16gb-1"
-    min_workers: 0
-    max_workers: 10
-auto_select_worker_config: false
+    CPU: 8
+worker_nodes:
+- name: gpu-workers
+  instance_type: n1-highcpu-4-nvidia-t4-16gb-1
+  max_nodes: 10

--- a/configs/pytorch-fsdp/aws.yaml
+++ b/configs/pytorch-fsdp/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.xlarge
-    name: '1xT4:4CPU-16GB'
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: 1xT4:4CPU-16GB
+  instance_type: g4dn.xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/pytorch-fsdp/gce.yaml
+++ b/configs/pytorch-fsdp/gce.yaml
@@ -1,10 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1
-  min_workers: 2
-  max_workers: 2
-  use_spot: false
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/pytorch-profiling/aws.yaml
+++ b/configs/pytorch-profiling/aws.yaml
@@ -1,10 +1,7 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.xlarge
-    name: '1xT4:4CPU-16GB'
-    min_workers: 2
-    max_workers: 2
-    use_spot: false
+worker_nodes:
+- name: 1xT4:4CPU-16GB
+  instance_type: g4dn.xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/pytorch-profiling/gce.yaml
+++ b/configs/pytorch-profiling/gce.yaml
@@ -1,10 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1
-  min_workers: 2
-  max_workers: 2
-  use_spot: false
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/rag-dev-bootcamp-mar2024/aws.yaml
+++ b/configs/rag-dev-bootcamp-mar2024/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: g5.4xlarge
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: g5.4xlarge
-  min_workers: 1
-  max_workers: 1
-  use_spot: false
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/rag-dev-bootcamp-mar2024/gce.yaml
+++ b/configs/rag-dev-bootcamp-mar2024/gce.yaml
@@ -1,10 +1,7 @@
-# n1-standard-8-nvidia-t4-16gb-1  --> 8 CPUs, 1 GPU
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8-nvidia-t4-16gb-1
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1
-  min_workers: 1
-  max_workers: 1
-  use_spot: false
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/ray-summit-ai-libraries/aws.yaml
+++ b/configs/ray-summit-ai-libraries/aws.yaml
@@ -1,12 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: g4dn.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.2xlarge
-    name: '1xT4:8CPU-32GB'
-    min_workers: 1
-    max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xT4:8CPU-32GB
+  instance_type: g4dn.2xlarge
+  min_nodes: 1
+  max_nodes: 1
+enable_cross_zone_scaling: true

--- a/configs/ray-summit-core-masterclass/aws.yaml
+++ b/configs/ray-summit-core-masterclass/aws.yaml
@@ -1,14 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.4xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - instance_type: g6.4xlarge
-    name: '1xL4:16CPU-64GB'
-    min_workers: 2
-    max_workers: 2
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g6.4xlarge
+  min_nodes: 2
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/ray-summit-core-masterclass/gce.yaml
+++ b/configs/ray-summit-core-masterclass/gce.yaml
@@ -1,14 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-16
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - instance_type: g2-standard-16-nvidia-l4-1
-    name: '1xL4:16CPU-64GB'
-    min_workers: 2
-    max_workers: 2
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g2-standard-16-nvidia-l4-1
+  min_nodes: 2
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/ray-summit-end-to-end-llms/aws.yaml
+++ b/configs/ray-summit-end-to-end-llms/aws.yaml
@@ -1,19 +1,11 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.4xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-
-worker_node_types:
-  - instance_type: m5.4xlarge
-    name: 16CPU-64GB
-    min_workers: 1
-    max_workers: 1
-  - instance_type: g6.4xlarge
-    name: '1xL4:16CPU-64GB'
-    min_workers: 0
-    max_workers: 2
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 16CPU-64GB
+  instance_type: m5.4xlarge
+  min_nodes: 1
+  max_nodes: 1
+- name: 1xL4:16CPU-64GB
+  instance_type: g6.4xlarge
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/ray-summit-multi-modal-search/aws.yaml
+++ b/configs/ray-summit-multi-modal-search/aws.yaml
@@ -1,14 +1,8 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.4xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - instance_type: g6.4xlarge
-    name: '1xL4:16CPU-64GB'
-    min_workers: 2
-    max_workers: 2
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g6.4xlarge
+  min_nodes: 2
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/ray-summit-rag/aws.yaml
+++ b/configs/ray-summit-rag/aws.yaml
@@ -1,17 +1,12 @@
-head_node_type:
+head_node:
   instance_type: m5.4xlarge
-  name: head_node
   resources:
-    cpu: 0
-    gpu: 0
-    custom_resources:
-      is_head_node: 1
-
-worker_node_types:
-  - instance_type: g6.4xlarge
-    name: '1xL4:16CPU-64GB'
-    min_workers: 2
-    max_workers: 2
-
-flags:
-  allow-cross-zone-autoscaling: true
+    CPU: 0
+    GPU: 0
+    is_head_node: 1
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g6.4xlarge
+  min_nodes: 2
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/ray-summit-stable-diffusion/aws.yaml
+++ b/configs/ray-summit-stable-diffusion/aws.yaml
@@ -1,15 +1,11 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: g6.4xlarge
   resources:
-    cpu: 12
-    gpu: 1
-
-worker_node_types:
-  - instance_type: g6.4xlarge
-    name: '1xL4:16CPU-64GB'
-    min_workers: 1
-    max_workers: 1
-
-flags:
-  allow-cross-zone-autoscaling: true
+    CPU: 12
+    GPU: 1
+worker_nodes:
+- name: 1xL4:16CPU-64GB
+  instance_type: g6.4xlarge
+  min_nodes: 1
+  max_nodes: 1
+enable_cross_zone_scaling: true

--- a/configs/ray-tune-train-integration/aws.yaml
+++ b/configs/ray-tune-train-integration/aws.yaml
@@ -1,15 +1,8 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-# Worker nodes (1× L4 GPU each, autoscale 1-2)
-worker_node_types:
-  - name: gpu-workers
-    instance_type: g6.4xlarge
-    min_workers: 1
-    max_workers: 2
-
-auto_select_worker_config: false
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: gpu-workers
+  instance_type: g6.4xlarge
+  min_nodes: 1
+  max_nodes: 2
+enable_cross_zone_scaling: true

--- a/configs/ray-tune-train-integration/gce.yaml
+++ b/configs/ray-tune-train-integration/gce.yaml
@@ -1,13 +1,7 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-# Worker nodes (1× L4 GPU each, autoscale 1-2)
-worker_node_types:
-  - name: gpu-workers
-    instance_type: g2-standard-16-nvidia-l4-1
-    min_workers: 1
-    max_workers: 2
-
-auto_select_worker_config: false
+worker_nodes:
+- name: gpu-workers
+  instance_type: g2-standard-16-nvidia-l4-1
+  min_nodes: 1
+  max_nodes: 2

--- a/configs/ray_train_workloads/aws.yaml
+++ b/configs/ray_train_workloads/aws.yaml
@@ -1,11 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - name: gpu-workers
-    instance_type: g5.4xlarge
-    min_workers: 8
-    max_workers: 8
-
-auto_select_worker_config: false
+worker_nodes:
+- name: gpu-workers
+  instance_type: g5.4xlarge
+  min_nodes: 8
+  max_nodes: 8

--- a/configs/ray_train_workloads/gce.yaml
+++ b/configs/ray_train_workloads/gce.yaml
@@ -1,13 +1,7 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-# Worker nodes
-worker_node_types:
-  - name: gpu-workers
-    instance_type: a2-highgpu-1g   # 1x NVIDIA A10G, 12 vCPU, 85 GiB
-    min_workers: 8
-    max_workers: 8
-
-auto_select_worker_config: false
+worker_nodes:
+- name: gpu-workers
+  instance_type: a2-highgpu-1g
+  min_nodes: 8
+  max_nodes: 8

--- a/configs/serverless/aws.yaml
+++ b/configs/serverless/aws.yaml
@@ -1,9 +1,6 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 8
-worker_node_types: []
+    CPU: 8
+enable_cross_zone_scaling: true
 auto_select_worker_config: true
-flags:
-  allow-cross-zone-autoscaling: true

--- a/configs/serverless/gcp.yaml
+++ b/configs/serverless/gcp.yaml
@@ -1,5 +1,3 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-worker_node_types: []
 auto_select_worker_config: true

--- a/configs/skyrl/aws.yaml
+++ b/configs/skyrl/aws.yaml
@@ -1,11 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: worker
   instance_type: g6.24xlarge
-  min_workers: 1
-  max_workers: 1
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/skyrl/gce.yaml
+++ b/configs/skyrl/gce.yaml
@@ -1,11 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: worker
   instance_type: g2-standard-48-nvidia-l4-4
-  min_workers: 1
-  max_workers: 1
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/stable-diffusion-pretraining/aws.yaml
+++ b/configs/stable-diffusion-pretraining/aws.yaml
@@ -1,14 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-# TODO - switch to true when slim image is used
-auto_select_worker_config: false
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: 1xA10G:16CPU-64GB
   instance_type: g5.4xlarge
-  min_workers: 1
-  max_workers: 1
-flags:
-  allow-cross-zone-autoscaling: false
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/stable-diffusion-pretraining/gce.yaml
+++ b/configs/stable-diffusion-pretraining/gce.yaml
@@ -1,14 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-# TODO - switch to true when slim image is used
-auto_select_worker_config: false
-worker_node_types:
+    CPU: 0
+worker_nodes:
 - name: 1xT4:8CPU-30GB
   instance_type: n1-standard-8-nvidia-t4-16gb-1
-  min_workers: 1
-  max_workers: 1
-flags:
-  allow-cross-zone-autoscaling: false
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/tensor_parallel_autotp/aws.yaml
+++ b/configs/tensor_parallel_autotp/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.12xlarge  # 4x T4 GPUs
-    name: '4xT4:48CPU-192GB'
-    min_workers: 1
-    max_workers: 1
+worker_nodes:
+- name: 4xT4:48CPU-192GB
+  instance_type: g4dn.12xlarge
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/tensor_parallel_autotp/gce.yaml
+++ b/configs/tensor_parallel_autotp/gce.yaml
@@ -1,10 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-32-nvidia-t4-16gb-4
-  min_workers: 1
-  max_workers: 1
-  use_spot: false
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/tensor_parallel_dtensor/aws.yaml
+++ b/configs/tensor_parallel_dtensor/aws.yaml
@@ -1,9 +1,7 @@
-head_node_type:
-  name: head_node
+head_node:
   instance_type: m5.2xlarge
-
-worker_node_types:
-  - instance_type: g4dn.12xlarge  # 4x T4 GPUs
-    name: '4xT4:48CPU-192GB'
-    min_workers: 1
-    max_workers: 1
+worker_nodes:
+- name: 4xT4:48CPU-192GB
+  instance_type: g4dn.12xlarge
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/tensor_parallel_dtensor/gce.yaml
+++ b/configs/tensor_parallel_dtensor/gce.yaml
@@ -1,10 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-32-nvidia-t4-16gb-4
-  min_workers: 1
-  max_workers: 1
-  use_spot: false
+  min_nodes: 1
+  max_nodes: 1

--- a/configs/text-embeddings/aws.yaml
+++ b/configs/text-embeddings/aws.yaml
@@ -1,14 +1,9 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
   resources:
-    cpu: 0
-
-worker_node_types:
-# 8 vCPU, 1 NVIDIA L4 GPU, 24 GiB memory
+    CPU: 0
+worker_nodes:
 - name: gpu-worker
   instance_type: g6.2xlarge
-  min_workers: 0
-  max_workers: 4
-  use_spot: true
-  fallback_to_ondemand: true
+  max_nodes: 4
+  market_type: PREFER_SPOT

--- a/configs/text-embeddings/gce.yaml
+++ b/configs/text-embeddings/gce.yaml
@@ -1,19 +1,13 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
   resources:
-    cpu: 0
-
-worker_node_types:
-# 8 vCPU, 1 NVIDIA L4 GPU, 32 GiB memory
+    CPU: 0
+worker_nodes:
 - name: gpu-worker
   instance_type: g2-standard-8-nvidia-l4-1
-  min_workers: 0
-  max_workers: 4
-  use_spot: true
-  fallback_to_ondemand: true
-
-gcp_advanced_configurations_json:
+  max_nodes: 4
+  market_type: PREFER_SPOT
+advanced_instance_config:
   instance_properties:
     labels:
       as-feature-multi-zone: 'true'

--- a/configs/text-gen-service/aws.yaml
+++ b/configs/text-gen-service/aws.yaml
@@ -1,8 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m4.2xlarge
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: g4dn.xlarge
-  min_workers: 1
-  max_workers: 3
+  min_nodes: 1
+  max_nodes: 3

--- a/configs/text-gen-service/gce.yaml
+++ b/configs/text-gen-service/gce.yaml
@@ -1,8 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-worker_node_types:
+worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-4-nvidia-t4-16gb-1
-  min_workers: 1
-  max_workers: 3
+  min_nodes: 1
+  max_nodes: 3

--- a/configs/tune_pytorch_asha/aws.yaml
+++ b/configs/tune_pytorch_asha/aws.yaml
@@ -1,15 +1,8 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-
-# Worker nodes
-worker_node_types:
-  - name: gpu-workers
-    instance_type: g5.4xlarge
-    min_workers: 8
-    max_workers: 8
-
-auto_select_worker_config: false
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: gpu-workers
+  instance_type: g5.4xlarge
+  min_nodes: 8
+  max_nodes: 8
+enable_cross_zone_scaling: true

--- a/configs/tune_pytorch_asha/gce.yaml
+++ b/configs/tune_pytorch_asha/gce.yaml
@@ -1,13 +1,7 @@
-# Head node
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-
-# Worker nodes
-worker_node_types:
-  - name: gpu-workers
-    instance_type: a2-highgpu-1g
-    min_workers: 8
-    max_workers: 8
-
-auto_select_worker_config: false
+worker_nodes:
+- name: gpu-workers
+  instance_type: a2-highgpu-1g
+  min_nodes: 8
+  max_nodes: 8

--- a/configs/unstructured_data_ingestion/aws.yaml
+++ b/configs/unstructured_data_ingestion/aws.yaml
@@ -1,14 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - name: 8CPU-32GB
-    instance_type: m5.2xlarge
-    min_workers: 10
-    max_workers: 10
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 8CPU-32GB
+  instance_type: m5.2xlarge
+  min_nodes: 10
+  max_nodes: 10
+enable_cross_zone_scaling: true

--- a/configs/unstructured_data_ingestion/gce.yaml
+++ b/configs/unstructured_data_ingestion/gce.yaml
@@ -1,14 +1,8 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n1-standard-8
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - name: 8CPU-32GB
-    instance_type: n1-standard-8
-    min_workers: 10
-    max_workers: 10
-
-flags:
-  allow-cross-zone-autoscaling: true
+worker_nodes:
+- name: 8CPU-32GB
+  instance_type: n1-standard-8
+  min_nodes: 10
+  max_nodes: 10
+enable_cross_zone_scaling: true

--- a/configs/vhol-ray-data/aws.yaml
+++ b/configs/vhol-ray-data/aws.yaml
@@ -1,8 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-worker_node_types:
-  - name: "gpu-workers"
-    instance_type: "g5.xlarge"
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: gpu-workers
+  instance_type: g5.xlarge
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/vhol-ray-data/gce.yaml
+++ b/configs/vhol-ray-data/gce.yaml
@@ -1,8 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-worker_node_types:
-  - name: "gpu-workers"
-    instance_type: "g2-standard-4-nvidia-l4-1"
-    min_workers: 2
-    max_workers: 2
+worker_nodes:
+- name: gpu-workers
+  instance_type: g2-standard-4-nvidia-l4-1
+  min_nodes: 2
+  max_nodes: 2

--- a/configs/vla-fine-tuning/aws.yaml
+++ b/configs/vla-fine-tuning/aws.yaml
@@ -1,12 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: m5.2xlarge
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - name: l4-worker
-    instance_type: g6.4xlarge
-    min_workers: 4
-    max_workers: 4
-auto_select_worker_config: false
+worker_nodes:
+- name: l4-worker
+  instance_type: g6.4xlarge
+  min_nodes: 4
+  max_nodes: 4

--- a/configs/vla-fine-tuning/gce.yaml
+++ b/configs/vla-fine-tuning/gce.yaml
@@ -1,12 +1,7 @@
-head_node_type:
-  name: head
+head_node:
   instance_type: n2-standard-8
-  resources:
-    cpu: 0
-    gpu: 0
-worker_node_types:
-  - name: l4-worker
-    instance_type: g2-standard-16-nvidia-l4-1
-    min_workers: 4
-    max_workers: 4
-auto_select_worker_config: false
+worker_nodes:
+- name: l4-worker
+  instance_type: g2-standard-16-nvidia-l4-1
+  min_nodes: 4
+  max_nodes: 4


### PR DESCRIPTION
Migrates all 111 compute configs under `configs/` from the legacy schema to the user-facing [`ComputeConfig`](https://docs.anyscale.com/reference/compute-config-api#computeconfig) schema; flips `ci/validate_build_yaml.py` to validate it.

Published bundles are unchanged — `rayapp build` converts to the legacy bundle format at publish time (ray-project/rayci#492, shipped in rayci v0.45.0, now pinned on main). Validated: converter audit 111/111; staging publishes tmpl-publish [#367](https://buildkite.com/anyscale/tmpl-publish/builds/367)–[#369](https://buildkite.com/anyscale/tmpl-publish/builds/369); release-binary smoke [#371](https://buildkite.com/anyscale/tmpl-publish/builds/371) (v0.45.0 → staging, clone path verified).
