### PR TITLE
docs(skill): document the ComputeConfig schema for configs/

### DIFF
--- a/.claude/skills/template/references/conventions.md
+++ b/.claude/skills/template/references/conventions.md
@@ -21,7 +21,7 @@ templates/
 
 ## Conventions
 
-Run the `check-build-yaml` hook first (see **Validate locally**) — it authoritatively covers BUILD.yaml schema, referenced paths, naming, and the legacy compute-config check. Fix what it reports, then verify:
+Run the `check-build-yaml` hook first (see **Validate locally**) — it authoritatively covers BUILD.yaml schema, referenced paths, naming, and the compute-config schema check. Fix what it reports, then verify:
 
 - **BUILD.yaml entry** matches `../schemas/build-yaml-schema.yaml`. Under `cluster_env:`, use either `cluster_env.image_uri` OR `cluster_env.byod`, never both. Image taxonomy: SKILL.md "Image URI cases".
 - **Compute configs** present at `configs/<name>/aws.yaml` and `configs/<name>/gce.yaml`. Schema: `../schemas/compute-config-schema.yaml`.
@@ -33,11 +33,10 @@ Run the `check-build-yaml` hook first (see **Validate locally**) — it authorit
 - **Ray-doc links → canonical URL.** For templates that also ship in the Ray repo/docs, link Ray documentation as `https://docs.ray.io/en/latest/...` — never a relative path or a `github.com/ray-project/ray/...` blob link. Exception: link GitHub directly only when the point is to show the source code itself.
 - **Ray Train templates use the V2 API, never V1.**
 
-⚠️ **Compute configs use the OLD (legacy) API**, NOT the new ComputeConfig API. ALWAYS mirror an existing `configs/<name>/` entry. Do NOT consult the live anyscale docs — they document only the new schema. Legacy references:
-- ComputeTemplateConfig: https://docs.anyscale.com/ref/0.26.64/compute-config-api#computetemplateconfig-legacy
-- ComputeNodeType:       https://docs.anyscale.com/ref/0.26.64/compute-config-api#computenodetype-legacy
-- WorkerNodeType:        https://docs.anyscale.com/ref/0.26.64/other#workernodetype-legacy
-- Resources:             https://docs.anyscale.com/ref/0.26.64/other#resources-legacy
+⚠️ **Compute configs use the new user-facing ComputeConfig schema** (`head_node` / `worker_nodes` / `market_type` / …), NOT the legacy `head_node_type` format. Mirror an existing `configs/<name>/` entry. Reference:
+- ComputeConfig: https://docs.anyscale.com/reference/compute-config-api#computeconfig
+
+(`rayapp build` converts new→legacy at publish time — ray-project/rayci#492 — so published bundles still carry the legacy schema the console clone path parses.)
 
 ## Validate locally
 

--- a/.claude/skills/template/references/conventions.md
+++ b/.claude/skills/template/references/conventions.md
@@ -33,10 +33,10 @@ Run the `check-build-yaml` hook first (see **Validate locally**) — it authorit
 - **Ray-doc links → canonical URL.** For templates that also ship in the Ray repo/docs, link Ray documentation as `https://docs.ray.io/en/latest/...` — never a relative path or a `github.com/ray-project/ray/...` blob link. Exception: link GitHub directly only when the point is to show the source code itself.
 - **Ray Train templates use the V2 API, never V1.**
 
-⚠️ **Compute configs use the new user-facing ComputeConfig schema** (`head_node` / `worker_nodes` / `market_type` / …), NOT the legacy `head_node_type` format. Mirror an existing `configs/<name>/` entry. Reference:
+⚠️ **Compute configs use the user-facing ComputeConfig schema** (`head_node` / `worker_nodes` / `market_type` / …), NOT the legacy `head_node_type` format. Mirror an existing `configs/<name>/` entry. Reference:
 - ComputeConfig: https://docs.anyscale.com/reference/compute-config-api#computeconfig
 
-(`rayapp build` converts new→legacy at publish time — ray-project/rayci#492 — so published bundles still carry the legacy schema the console clone path parses.)
+(`rayapp build` converts configs to the legacy bundle format at publish time — ray-project/rayci#492 — so published bundles still carry the legacy schema the console clone path parses.)
 
 ## Validate locally
 

--- a/.claude/skills/template/schemas/compute-config-schema.yaml
+++ b/.claude/skills/template/schemas/compute-config-schema.yaml
@@ -1,78 +1,87 @@
-# Compute Config Schema (Legacy API format)
+# Compute Config Schema (ComputeConfig — user-facing API format)
 #
-# These YAML files live under configs/<template-name>/{aws,gce}.yaml
-# They use the LEGACY compute config format (not the workspace_v2 CLI format).
+# These YAML files live under configs/<template-name>/{aws,gce}.yaml and use the
+# user-facing ComputeConfig schema:
+#   https://docs.anyscale.com/reference/compute-config-api#computeconfig
 #
 # IMPORTANT: Omit fields that match their default value. Only include what you
 # actually need to override. This keeps configs minimal and avoids confusion
 # about which values are intentional vs just restating defaults.
 #
-# NOT included in the template config: `cloud` (operational reference, not a per-template setting).
+# NOT included in the template config: `cloud` / `cloud_resource` (operational
+# references, injected at clone time — not per-template settings).
 
 # --- Full schema (with defaults noted) ---
 
-head_node_type:                        # REQUIRED
-  name: head                           # REQUIRED. Node type name.
-  instance_type: m5.2xlarge            # Optional. Cloud instance type.
-  resources:                           # Optional. Only include to override defaults.
-    cpu: 0                             #   Default: auto-detected. Set 0 to exclude from scheduling.
-    gpu: 0                             #   Default: auto-detected. Set 0 to exclude from scheduling.
+head_node:                             # Optional. Defaults to the cloud's default head node.
+  instance_type: m5.2xlarge            # Optional. Cloud instance type. (The head has NO `name`.)
+  resources:                           # Optional. Only include to override auto-detected resources.
+    CPU: 0                             #   Set 0 to exclude the head from scheduling. Keys are CAPITALIZED.
+    # GPU: 0                           #   Default: auto-detected from the instance type.
     # memory: 0                        #   Default: auto-detected.
     # object_store_memory: 0           #   Default: auto-detected.
-    # custom_resources: {}             #   Default: empty.
-  # required_resources: {}             # Optional. Default: none. Omit if not needed.
-  # labels: {}                         # Optional. Default: empty. Omit if not needed.
-  # required_labels: {}                # Optional. Default: empty. Omit if not needed.
-  # flags: {}                          # Optional. Default: empty. Omit if not needed.
-  # aws_advanced_configurations_json: {}  # Omit unless needed.
-  # gcp_advanced_configurations_json: {}  # Omit unless needed.
+    # "accelerator_type:T4": 1         #   Custom Ray resources go here as flat keys.
+  # required_resources: {}             # Optional. For custom (free-pod) instance shapes. Omit if not needed.
+  # labels: {}                         # Optional. Omit if not needed.
+  # required_labels: {}                # Optional. Omit if not needed.
+  # advanced_instance_config: {}       # Optional. Cloud-provider passthrough (see below). Omit unless needed.
+  # flags: {}                          # Optional. Omit if not needed.
 
-worker_node_types:                     # Default: []. Omit or use [] if auto_select_worker_config is true.
-  - name: gpu-worker                   # REQUIRED per worker type.
+worker_nodes:                          # Optional. Omit for serverless auto-select; use [] for head-only.
+                                       # MUST be omitted when auto_select_worker_config is true.
+  - name: gpu-worker                   # Optional. Defaults to the instance type. Must be unique per group.
     instance_type: g4dn.12xlarge       # Optional. Cloud instance type.
-    min_workers: 2                     # Optional. Default: 0. Omit if 0.
-    max_workers: 2                     # Optional. Default: 0. Omit if 0.
-    # use_spot: false                  # Default: false. Omit unless true.
-    # fallback_to_ondemand: false      # Default: false. Omit unless true.
-    # resources: {}                    # Optional. Same as head_node_type.resources. Omit if auto-detected.
+    # min_nodes: 0                     # Default: 0. Omit if 0.
+    max_nodes: 2                       # Default: 10. Set the autoscaling ceiling explicitly.
+    # market_type: ON_DEMAND           # ON_DEMAND (default) | SPOT | PREFER_SPOT. Omit if ON_DEMAND.
+    # resources: {}                    # Optional. Same shape as head_node.resources.
     # required_resources: {}           # Optional. Omit if not needed.
-    # labels: {}                       # Optional. Omit if not needed.
-    # required_labels: {}              # Optional. Omit if not needed.
+    # labels: {} / required_labels: {} # Optional. Omit if not needed.
+    # advanced_instance_config: {}     # Optional. Per-group cloud-provider passthrough.
     # flags: {}                        # Optional. Omit if not needed.
 
-auto_select_worker_config: true        # Default: false. Omit if false.
-                                       # When true, worker_node_types can be empty [].
+auto_select_worker_config: true        # Default: false. Omit if false. When true, OMIT worker_nodes
+                                       # (the two are mutually exclusive).
 
-# flags: {}                            # Optional. Default: empty. Omit if not needed.
-#   allow-cross-zone-autoscaling: true # Common flag for multi-AZ scheduling.
+# enable_cross_zone_scaling: true      # Default: false. Omit if false. (Replaces the legacy
+#                                        flags: {allow-cross-zone-autoscaling: true}.)
+# zones: [us-west-2a, us-west-2b]      # Optional. Defaults to all zones in the cloud's region.
+# min_resources: {CPU: 1}              # Optional. Cluster-wide minimum logical resources.
+# max_resources: {CPU: 6, GPU: 10}     # Optional. Cluster-wide maximum logical resources.
+# advanced_instance_config: {}         # Optional. Top-level cloud-provider passthrough (AWS or GCP).
+# flags: {}                            # Optional. Advanced/experimental cluster flags.
 
 # --- Common patterns ---
 #
-# CPU-only single node (auto workers):
-#   head_node_type:
-#     name: head
+# CPU-only single node (serverless auto-select):
+#   head_node:
 #     instance_type: m5.2xlarge        # AWS
 #     # instance_type: n2-standard-8   # GCP
-#   worker_node_types: []
 #   auto_select_worker_config: true
 #
-# GPU workers (explicit):
-#   head_node_type:
-#     name: head
+# GPU workers (explicit); head excluded from scheduling:
+#   head_node:
 #     instance_type: m5.2xlarge
-#     resources: { cpu: 0, gpu: 0 }    # Head excluded from scheduling
-#   worker_node_types:
+#     resources: {CPU: 0}              # When workers exist, the head is unschedulable by default.
+#   worker_nodes:
 #     - name: gpu-worker
 #       instance_type: g4dn.12xlarge
-#       min_workers: 2
-#       max_workers: 2
+#       max_nodes: 2
+#
+# Spot workers:
+#   worker_nodes:
+#     - instance_type: g6.2xlarge
+#       max_nodes: 4
+#       market_type: PREFER_SPOT       # spot, fall back to on-demand
+#
+# advanced_instance_config (cloud-provider passthrough; the key is provider-neutral, the body is not):
+#   # AWS: {BlockDeviceMappings: [{DeviceName: /dev/sda1, Ebs: {VolumeSize: 1000, DeleteOnTermination: true}}]}
+#   # GCP: {instance_properties: {labels: {as-feature-multi-zone: 'true'}}}
 #
 # AWS instance types commonly used:
 #   CPU: m5.2xlarge, m5.4xlarge
-#   GPU: g5.xlarge (1x A10G), g5.2xlarge (1x A10G), g6.2xlarge (1x L4),
-#        p4d.24xlarge (8x A100)
+#   GPU: g5.xlarge (1x A10G), g6.2xlarge (1x L4), p4d.24xlarge (8x A100)
 #
 # GCP instance types commonly used:
 #   CPU: n2-standard-8, n2-standard-16
-#   GPU: g2-standard-8-nvidia-l4-1, g2-standard-12-nvidia-l4-1 (1x L4),
-#        a2-highgpu-1g-nvidia-a100-40gb-1 (1x A100)
+#   GPU: g2-standard-12-nvidia-l4-1 (1x L4), a2-highgpu-1g-nvidia-a100-40gb-1 (1x A100)

--- a/.claude/skills/template/workflows/create-template.md
+++ b/.claude/skills/template/workflows/create-template.md
@@ -33,17 +33,14 @@ Append a list item per `../schemas/build-yaml-schema.yaml`. Set the image for th
 anyscale workspace_v2 get --id expwrk_<id> --json | jq '.config.compute_config'
 ```
 
-That returns the new ComputeConfig API shape; translate into the legacy schema (full fields + patterns in `../schemas/compute-config-schema.yaml`; legacy-API warning in `../references/conventions.md`). Key fields:
+That returns the ComputeConfig shape `configs/` uses directly (full fields + patterns in `../schemas/compute-config-schema.yaml`). Copy it, pruned to the minimal form:
 
-| New ComputeConfig (workspace_v2) | Legacy (`configs/<name>/*.yaml`) |
-|---|---|
-| head node instance type | `head_node_type.instance_type` |
-| worker group instance type | `worker_node_types[].instance_type` |
-| worker min / max count | `min_workers` / `max_workers` |
-| spot / market type | `use_spot: true` |
-| cross-zone / multi-AZ | `flags: {allow-cross-zone-autoscaling: true}` |
+- drop `cloud` / `cloud_resource` (injected at clone time)
+- drop fields matching their defaults: `min_nodes: 0`, `market_type: ON_DEMAND`, `auto_select_worker_config: false`, `enable_cross_zone_scaling: false`
+- drop auto-detected node `resources` (with workers present, the head is unschedulable by default); keep explicit overrides like `CPU: 0`
+- keep `max_nodes` explicit on every worker group
 
-Omit any field that matches its default (per the schema). Write `configs/<name>/aws.yaml` and `gce.yaml` by instance family.
+Write `configs/<name>/aws.yaml` and `gce.yaml` by instance family.
 
 **Fallback — guided Q&A.** No tested workspace → walk the user through those same fields.
 


### PR DESCRIPTION
Documents the user-facing `ComputeConfig` schema as the `configs/` convention: rewrites `schemas/compute-config-schema.yaml`, updates the warning in `references/conventions.md`, and simplifies the create-template compute-config step (workspace config is copied as-is, pruned of defaults — no more schema translation).

Lands after #742.
