### PR TITLE
fix(tune_pytorch_asha): run README.ipynb in test, not source nb name

### DIFF
--- a/tests/tune_pytorch_asha/tests.sh
+++ b/tests/tune_pytorch_asha/tests.sh
@@ -7,4 +7,8 @@ uv pip install -q --system papermill
 # Fast synthetic-data path: 2 trials x 2 epochs of FakeData (no CIFAR-10 download).
 # Exercises the full Tune + ASHA + checkpoint + eval + plot pipeline; trials use the cluster's GPU workers.
 export SMOKE_TEST=true
-papermill tune_pytorch_asha.ipynb output.ipynb -k python3 --log-output
+# The publish bundle names the entry notebook README.ipynb on main builds but keeps the
+# source name (tune_pytorch_asha.ipynb) on branch builds — run whichever is present.
+for nb in *.ipynb; do
+  papermill "$nb" "/tmp/${nb%.ipynb}.out.ipynb" -k python3 --log-output --cwd .
+done


### PR DESCRIPTION
The revived `tune_pytorch_asha` test ran `papermill tune_pytorch_asha.ipynb`, but the tmpl-publish build packages the entry notebook as `README.ipynb`, so `test-template` failed with `FileNotFoundError`.

## What changed
`tests/tune_pytorch_asha/tests.sh` runs `papermill README.ipynb` (+ `--cwd .`, output to /tmp), matching every other single-notebook template.

## Why
The published `tune_pytorch_asha.zip` inflates `README.ipynb` (source `tune_pytorch_asha.ipynb` is renamed on build); the batch-4 test revival (#711) referenced the source name. Blocks the prod republish.