### PR TITLE
Remove orphaned compute-config dirs

### DIFF
--- a/configs/basic-serverless-config/aws.yaml
+++ b/configs/basic-serverless-config/aws.yaml
@@ -1,3 +1,0 @@
-head_node:
-  instance_type: m5.2xlarge
-auto_select_worker_config: true

--- a/configs/basic-serverless-config/gce.yaml
+++ b/configs/basic-serverless-config/gce.yaml
@@ -1,3 +1,0 @@
-head_node:
-  instance_type: n1-standard-8
-auto_select_worker_config: true

--- a/configs/intro-workspaces/aws.yaml
+++ b/configs/intro-workspaces/aws.yaml
@@ -1,3 +1,0 @@
-head_node:
-  instance_type: m5.2xlarge
-worker_nodes: []

--- a/configs/intro-workspaces/gce.yaml
+++ b/configs/intro-workspaces/gce.yaml
@@ -1,3 +1,0 @@
-head_node:
-  instance_type: n2-standard-8
-worker_nodes: []

--- a/configs/serverless/aws.yaml
+++ b/configs/serverless/aws.yaml
@@ -1,6 +1,0 @@
-head_node:
-  instance_type: m5.2xlarge
-  resources:
-    CPU: 8
-enable_cross_zone_scaling: true
-auto_select_worker_config: true

--- a/configs/serverless/gcp.yaml
+++ b/configs/serverless/gcp.yaml
@@ -1,3 +1,0 @@
-head_node:
-  instance_type: n2-standard-8
-auto_select_worker_config: true


### PR DESCRIPTION
Three `configs/` dirs referenced by nothing — not in `BUILD.yaml`, and not by any template, CI job, or script. Stale orphans:

- `configs/serverless/` — 2025-04 image-search/LLM template leftover (still on the old `gcp.yaml` naming); unreferenced since.
- `configs/basic-serverless-config/` — 2024 leftover, never referenced.
- `configs/intro-workspaces/` — orphaned when the `intro-workspaces` template was renamed (#626).

CI-safe: `validate_build_yaml.py` only checks BUILD-referenced paths, and these are referenced nowhere.
