### PR TITLE
fix(vla-fine-tuning): pin pi05_base checkpoint revision

### DIFF
--- a/templates/vla-fine-tuning/README.ipynb
+++ b/templates/vla-fine-tuning/README.ipynb
@@ -284,7 +284,7 @@
     "\n",
     "    from lerobot.policies.factory import make_pre_post_processors\n",
     "    preprocessor, _ = make_pre_post_processors(\n",
-    "        policy.module.config, pretrained_path=\"lerobot/pi05_base\", dataset_stats=config[\"stats\"],\n",
+    "        policy.module.config, pretrained_path=util.pi05_base_path(), dataset_stats=config[\"stats\"],\n",
     "    )\n",
     "\n",
     "    # -- Hyperparameters and LR schedule ----------------------------------------\n",

--- a/templates/vla-fine-tuning/README.md
+++ b/templates/vla-fine-tuning/README.md
@@ -298,7 +298,7 @@ def train_loop_per_worker(config: dict):
 
     from lerobot.policies.factory import make_pre_post_processors
     preprocessor, _ = make_pre_post_processors(
-        policy.module.config, pretrained_path="lerobot/pi05_base", dataset_stats=config["stats"],
+        policy.module.config, pretrained_path=util.pi05_base_path(), dataset_stats=config["stats"],
     )
 
     # -- Hyperparameters and LR schedule ----------------------------------------

--- a/templates/vla-fine-tuning/util.py
+++ b/templates/vla-fine-tuning/util.py
@@ -80,9 +80,18 @@ def renamed_image_keys(source, camera_rename):
 # ============================================================================
 # Model Loading
 # ============================================================================
+PI05_BASE_REPO = "lerobot/pi05_base"
+PI05_BASE_REVISION = "a538eb273274eb30f126a118f39dbc0ee212c883"
 
 
-def load_pi05_policy(pretrained_path="lerobot/pi05_base"):
+def pi05_base_path():
+    """Local snapshot of lerobot/pi05_base, pinned to a lerobot-0.4.3-compatible revision."""
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(PI05_BASE_REPO, revision=PI05_BASE_REVISION)
+
+
+def load_pi05_policy(pretrained_path=None):
     """Load PI0.5, apply the attention mask patch, and freeze the backbone.
 
     Returns the policy with only the action/time projection heads unfrozen
@@ -94,6 +103,9 @@ def load_pi05_policy(pretrained_path="lerobot/pi05_base"):
     doesn't crash on sequence-length mismatches.
     """
     from lerobot.policies.pi05 import PI05Policy
+
+    if pretrained_path is None:
+        pretrained_path = pi05_base_path()
 
     apply_pi05_attention_mask_patch()
 

--- a/templates/vla-fine-tuning/vla.py
+++ b/templates/vla-fine-tuning/vla.py
@@ -240,7 +240,7 @@ def train_loop_per_worker(config: dict):
 
     from lerobot.policies.factory import make_pre_post_processors
     preprocessor, _ = make_pre_post_processors(
-        policy.module.config, pretrained_path="lerobot/pi05_base", dataset_stats=config["stats"],
+        policy.module.config, pretrained_path=util.pi05_base_path(), dataset_stats=config["stats"],
     )
 
     # -- Hyperparameters and LR schedule ----------------------------------------


### PR DESCRIPTION
## What changed
`vla-fine-tuning` pins the `lerobot/pi05_base` HF checkpoint to revision `a538eb27` and loads it from a local snapshot via `util.pi05_base_path()`, applied at both the policy-load and `make_pre_post_processors` sites.

## Why
The checkpoint added relative-action processor steps in revision `7de66397` (2026-06-03, "Add relative action processor steps (#6)") whose config requires `lerobot>=0.5.1`. The template pins `lerobot==0.4.3` and fetched the checkpoint unpinned, so `make_pre_post_processors` started failing on the unknown `relative_actions_processor` step — breaking `/test-template`. Pinning to the last revision before that change keeps the policy and processor pipeline on the same 0.4.3-compatible config.

## Notes
No prod republish from this branch; this only restores `/test-template`.
