### PR TITLE
Remove inert /configs CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,3 @@
-# Configs
-
-# to make sure people are using serverless
-/configs @shomilj @sofianhnaide @scottsun94
-
 # Template infra
 /BUILD.yaml @anyscale/template-infra
 /.cursor/   @anyscale/cloud-agents


### PR DESCRIPTION
Removes the `/configs @shomilj @sofianhnaide @scottsun94` line from `.github/CODEOWNERS`.

**Why:** the rule is currently inert. GitHub's `codeowners/errors` API reports all three owners as **"Unknown owner"** ("make sure @X exists and has write access to the repository"), so it:
- never auto-requests them as reviewers, and
- enforces nothing (a non-owner's single approval already satisfies required review — code-owner review isn't a required check on `main`).

So this is a no-op functionally; it just deletes a dead rule. The `# Template infra` rules (`/BUILD.yaml`, `/.cursor/`) are untouched and remain valid.

**Alternative (not taken):** if `configs/` review is still desired, the fix would instead be to (1) correct the three handles to real accounts with repo write access, and (2) enable "Require review from Code Owners" in `main` branch protection. Flagging for reviewers to decide which direction is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)