### PR TITLE
Require tests for templates/ entries; exempt archive/ (+ archive workflow)

### DIFF
--- a/.claude/skills/template/SKILL.md
+++ b/.claude/skills/template/SKILL.md
@@ -5,7 +5,7 @@ description: Create, maintain, format, and publish Anyscale console templates. U
 
 # Template skill
 
-A console template = a `BUILD.yaml` entry + `templates/<name>/` content + `configs/<name>/` compute configs + a `tests/<name>/` test.
+A console template = a `BUILD.yaml` entry + `templates/<name>/` content + `configs/<name>/` compute configs + a `tests/<name>/` test. Every template under `templates/` is tested (the validator enforces it); `archive/` holds **test-exempt** content — retired/past-event templates, plus fast untested iteration that can still be published — via `workflows/archive-template.md`.
 
 **How to use:** create/update are **interactive** — interview the user, explain at the point of need, and ask for any missing input. **ray-bump is non-interactive** (the `template-updater` Cursor cloud agent; signals: `.cursor/` setup, a `cursor/...` branch, an automation trigger): never prompt, use defaults; on missing input or preflight failure, post to the PR and stop. Track multi-step runs with your task tool.
 
@@ -16,6 +16,7 @@ Invoked bare (just `/template`) by a human — i.e. **not** the ray-bump automat
 - **Create** a new template → `workflows/create-template.md`
 - **Update** content/config, no Ray bump → `workflows/update-template.md`
 - **Ray-version bump** (non-interactive) → `workflows/bump-ray-version.md`
+- **Archive** a retired or past-event template → `workflows/archive-template.md`
 
 Supporting: `references/conventions.md` · `references/testing-template.md` · `references/publish-to-backend.md` · `references/run-tests-locally-with-rayapp.md` · `schemas/build-yaml-schema.yaml` · `schemas/compute-config-schema.yaml` · `.claude/skills/template/scripts/push-custom-image-to-gcp.sh`.
 

--- a/.claude/skills/template/references/publish-to-backend.md
+++ b/.claude/skills/template/references/publish-to-backend.md
@@ -44,3 +44,13 @@ Bold = manual gates you Unblock. **Never unblock a publish step until this pipel
 An update is just another run: trigger a fresh build (step 1) with the same `message=<name>` and
 input fields. Prefer a fresh trigger over `rebuild_build` — it re-resolves `main` HEAD (your latest
 merged content) and the current pipeline, whereas a rebuild replays the original build's older commits.
+
+## Publish without the test gate (events / urgent fixes)
+
+For an event template that must ship or be fixed faster than the test pipeline (~5–60 min). `rayapp` treats `test` as optional and the BUILD.yaml validator requires it only under `templates/`, so an entry pointing at `archive/` publishes with no `test-template` stage:
+
+1. Put the template under `archive/` and point its `BUILD.yaml` entry's `dir` + `compute_config` there, with **no `test` field** (`templates/` demands a test; `archive/` is exempt). The move: `../workflows/archive-template.md`.
+2. Publish as above — `test-template` has nothing to run, so the fix ships immediately.
+3. After the event: restore it to `templates/` **with a test**, or retire it (`../workflows/archive-template.md`).
+
+Use sparingly — it bypasses the test gate. Anything not under event-time pressure stays in `templates/`, tested.

--- a/.claude/skills/template/schemas/build-yaml-schema.yaml
+++ b/.claude/skills/template/schemas/build-yaml-schema.yaml
@@ -35,7 +35,9 @@
     AWS: configs/<config-dir>/aws.yaml
     GCP: configs/<config-dir>/gce.yaml
 
-  # REQUIRED.
+  # REQUIRED for entries under templates/ — active templates are tested. Entries
+  # under archive/ are exempt (test-free — e.g. fast event iteration or a retired
+  # template; see workflows/archive-template.md).
   test:
     command: bash tests.sh            # REQUIRED.
     tests_path: tests/<name>/         # REQUIRED. Relative path (no absolute, no "..").

--- a/.claude/skills/template/workflows/archive-template.md
+++ b/.claude/skills/template/workflows/archive-template.md
@@ -1,0 +1,16 @@
+# Archive a template
+
+Retire a template that's no longer maintained but worth keeping — past **event/workshop** material (Ray Summit, bootcamps, labs) or a superseded-but-instructive example. It moves to `archive/`: kept in-repo, but not built, tested, or published, and not in the console gallery. The `archive/` layout (events vs reference, the `configs/` + `content/` split, year-prefixing) lives in **`archive/README.md`**.
+
+- **Archive vs delete:** archive content worth keeping; just delete dead duplicates, cruft, or anything preserved elsewhere (git history keeps it either way).
+- **Publishing** a template *without* the test gate (urgent event fix) is a different intent — see "Publish without the test gate" in `../references/publish-to-backend.md`.
+
+## Steps — one PR per template
+
+1. **Remove the `BUILD.yaml` entry** — CI stops building / testing / publishing it.
+2. **Move the content** with `git mv` (history follows):
+   - `templates/<name>/` → `archive/events/<year>-<event>/<name>/content/` (event) or `archive/reference/<name>/content/` (non-event).
+   - `configs/<name>/` — the compute config, if any → the sibling `archive/.../<name>/configs/`.
+   - The template's own in-dir configs (training / deploy / job YAML) stay inside `content/`.
+3. **Sweep stragglers:** `grep -rn "<name>"` for cross-links and CI references; clean any that point at the moved template.
+4. **Verify:** `pre-commit run --all-files` and premerge stay green.

--- a/.claude/skills/template/workflows/create-template.md
+++ b/.claude/skills/template/workflows/create-template.md
@@ -54,7 +54,7 @@ Apply `../references/conventions.md` to the new template.
 
 ## 7. Test gate — non-skippable
 
-Commit on a branch and open a PR against `main`. Run `/test-template`, get it green **before publishing**. Dispatch, monitoring, and failure recovery: `../references/testing-template.md`.
+Commit on a branch and open a PR against `main`. Run `/test-template`, get it green **before publishing**. Dispatch, monitoring, and failure recovery: `../references/testing-template.md`. (Exception — an event template under time pressure can publish *test-free* by routing through `archive/`: see "Publish without the test gate" in `../references/publish-to-backend.md`.)
 
 ## 8. Merge to `main`
 

--- a/.claude/skills/template/workflows/update-template.md
+++ b/.claude/skills/template/workflows/update-template.md
@@ -20,4 +20,4 @@ Commit on a branch and open a PR against `main`. Run `/test-template`, get it gr
 
 ## 5. Republish
 
-**Merge the green PR to `main` first** (the pipeline publishes templates `main`), then re-publish the artifact (dev → staging → prod) via `../references/publish-to-backend.md`.
+**Merge the green PR to `main` first** (the pipeline publishes templates `main`), then re-publish the artifact (dev → staging → prod) via `../references/publish-to-backend.md`. (Urgent event fix that can't wait on tests? Re-publish *test-free* via an `archive/` entry — see "Publish without the test gate" there.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Local: edit → `pre-commit run --all-files` → push. Pre-commit covers lint, f
 
 Per-template tests — comment `/test-template <id> [<id>...]` (up to 3, parallel) on the PR to dispatch the Buildkite `template-test` pipeline (workspace + actual test run). For local iteration before pushing, `rayapp test <id>` runs the same flow (see `references/run-tests-locally-with-rayapp.md` in the `/template` skill for setup).
 
+Tested vs archived — every template under `templates/` must have a `test` block (the `ci/validate_build_yaml.py` gate enforces it). Untested content lives in `archive/` (test-exempt, not built or surfaced in the gallery): *retire* a stale template, or publish an event template *without the test gate* (urgent fix). Procedures: the `/template` skill's `workflows/archive-template.md` and the "Publish without the test gate" section of `references/publish-to-backend.md`.
+
 PR labels (apply all that fit):
 - `cursor-cloud` — origin: Cursor Cloud agent.
 - `ray-update` — content: Ray version bump.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BUILD.yaml                # Manifest of every template (entry point, image, comp
 templates/<name>/         # Template content — notebook or .py + Dockerfile (if custom image)
 tests/<name>/tests.sh     # Per-template smoke test, executed by CI
 configs/<name>/           # Compute configs: aws.yaml + gce.yaml (or reuse basic-single-node/)
+archive/                  # Retired / test-exempt templates — kept for reference, off the test gate
 ci/                       # Schema validators + the README auto-generator
 .claude/skills/template/  # Maintenance procedures (Ray bumps, formatting, publishing)
 ```
@@ -36,8 +37,10 @@ The sections below describe what the skill (or you, manually) does under the hoo
    - A `Dockerfile` only if you need a custom image — otherwise reference a stock `anyscale/ray:...` image
 2. **Test** at `tests/<name>/tests.sh` — runs in CI to confirm the template still works end-to-end
 3. **Compute config:** most templates reuse `configs/basic-single-node/`. If you need custom compute, add `configs/<name>/aws.yaml` + `configs/<name>/gce.yaml`
-4. **`BUILD.yaml` entry** — schema in [`.claude/skills/template/references/build-yaml-schema.yaml`](.claude/skills/template/references/build-yaml-schema.yaml), strictly validated by `ci/validate_build_yaml.py` (also runs as a pre-commit hook)
-5. **Custom image** (only if you set `cluster_env.byod`): build and push with [`.claude/skills/template/scripts/publish-custom-image.sh`](.claude/skills/template/scripts/publish-custom-image.sh)`<dockerfile-dir> <name> <ray-version>`. You need permissions to push to Anyscale's public GCP Artifact registry.
+4. **`BUILD.yaml` entry** — schema in [`.claude/skills/template/schemas/build-yaml-schema.yaml`](.claude/skills/template/schemas/build-yaml-schema.yaml), strictly validated by `ci/validate_build_yaml.py` (also runs as a pre-commit hook)
+5. **Custom image** (only if you set `cluster_env.byod`): build and push with [`.claude/skills/template/scripts/push-custom-image-to-gcp.sh`](.claude/skills/template/scripts/push-custom-image-to-gcp.sh)`<dockerfile-dir> <name> <ray-version>`. You need permissions to push to Anyscale's public GCP Artifact registry.
+
+**Retiring or fast-publishing.** Every template under `templates/` must have a test (CI enforces it). To retire one — kept for reference but off the test gate — or to publish an event template without waiting on tests, move it under `archive/`; see the `/template` skill (`workflows/archive-template.md`, and "Publish without the test gate" in `references/publish-to-backend.md`).
 
 ## Local development
 

--- a/ci/validate_build_yaml.py
+++ b/ci/validate_build_yaml.py
@@ -62,8 +62,10 @@ class ClusterEnv(Strict):
 
 
 class ComputeConfig(Strict):
-    GCP: str = Field(pattern=r"^configs/.+/gce\.yaml$")
-    AWS: str = Field(pattern=r"^configs/.+/aws\.yaml$")
+    # configs/<name>/ for active templates; archive/.../<name>/configs/ for
+    # archived ones (which co-locate their compute config under the template).
+    GCP: str = Field(pattern=r"^(?:configs|archive)/.+/gce\.yaml$")
+    AWS: str = Field(pattern=r"^(?:configs|archive)/.+/aws\.yaml$")
 
 
 class Test(Strict):
@@ -74,10 +76,27 @@ class Test(Strict):
 
 class Entry(Strict):
     name: str = Field(pattern=r"^[a-z0-9_-]+$")
-    dir: str = Field(pattern=r"^templates/")
+    # templates/<name>/ for active templates; archive/<...>/<name>/ for archived
+    # ones (retired, past-event, or fast untested iteration).
+    dir: str = Field(pattern=r"^(?:templates|archive)/")
     cluster_env: ClusterEnv
     compute_config: ComputeConfig
-    test: Test
+    # Mandatory for templates/ entries — active templates are tested. Entries
+    # under archive/ are exempt: archived content can be published test-free
+    # (e.g. an urgent mid-event fix). Optional here so the validator can raise a
+    # clear, actionable error instead of pydantic's generic "Field required".
+    test: Optional[Test] = None
+
+    @model_validator(mode="after")
+    def _templates_must_be_tested(self):
+        if self.dir.startswith("templates/") and self.test is None:
+            raise ValueError(
+                f"{self.name}: no `test` block — every template under templates/ "
+                "must be tested. To publish without a test (fast event iteration "
+                "or a retired template), move it under archive/ instead; archive/ "
+                "entries are test-exempt."
+            )
+        return self
 
 
 # ComputeConfig schema, applied to BUILD.yaml-referenced files.
@@ -150,27 +169,31 @@ def check_filesystem_and_uniqueness(entries: list[Entry]) -> list[str]:
             errors.append(f"{e.name}: duplicate dir: {e.dir}")
         seen_dirs.add(e.dir)
 
-        if e.test.tests_path in seen_tests_paths:
-            errors.append(f"{e.name}: duplicate tests_path: {e.test.tests_path}")
-        seen_tests_paths.add(e.test.tests_path)
+        if e.test is not None:
+            if e.test.tests_path in seen_tests_paths:
+                errors.append(f"{e.name}: duplicate tests_path: {e.test.tests_path}")
+            seen_tests_paths.add(e.test.tests_path)
 
-        # dir basename must equal the entry's name. Catches stale dirs when
-        # an entry is renamed.
-        dir_basename = Path(e.dir.rstrip("/")).name
-        if dir_basename != e.name:
-            errors.append(
-                f"{e.name}.dir: basename {dir_basename!r} must equal name "
-                f"{e.name!r} (expected templates/{e.name}/)"
-            )
+        # dir basename must equal the entry's name (templates/ convention) —
+        # catches stale dirs on rename. archive/ entries are laid out freely
+        # (e.g. archive/.../<name>/content), so this is templates/-only.
+        if e.dir.startswith("templates/"):
+            dir_basename = Path(e.dir.rstrip("/")).name
+            if dir_basename != e.name:
+                errors.append(
+                    f"{e.name}.dir: basename {dir_basename!r} must equal name "
+                    f"{e.name!r} (expected templates/{e.name}/)"
+                )
 
         # tests_path basename must equal the entry's name. Catches stale
         # tests_path values when an entry is renamed.
-        tests_basename = Path(e.test.tests_path.rstrip("/")).name
-        if tests_basename != e.name:
-            errors.append(
-                f"{e.name}.test.tests_path: basename {tests_basename!r} must "
-                f"equal name {e.name!r} (expected tests/{e.name}/)"
-            )
+        if e.test is not None:
+            tests_basename = Path(e.test.tests_path.rstrip("/")).name
+            if tests_basename != e.name:
+                errors.append(
+                    f"{e.name}.test.tests_path: basename {tests_basename!r} must "
+                    f"equal name {e.name!r} (expected tests/{e.name}/)"
+                )
 
         # GCP and AWS configs must live in the same directory under configs/.
         # Catches one-cloud-customized-but-not-the-other mistakes.
@@ -188,7 +211,8 @@ def check_filesystem_and_uniqueness(entries: list[Entry]) -> list[str]:
         # and configs/). Shared `configs/basic-single-node/` is exempt.
         cfg_dir_basename = gcp_parent.name
         if (
-            gcp_parent == aws_parent
+            gcp_parent.parts and gcp_parent.parts[0] == "configs"
+            and gcp_parent == aws_parent
             and cfg_dir_basename != "basic-single-node"
             and cfg_dir_basename != e.name
         ):
@@ -204,10 +228,11 @@ def check_filesystem_and_uniqueness(entries: list[Entry]) -> list[str]:
             path = getattr(e.compute_config, cloud)
             if not (REPO_ROOT / path).is_file():
                 errors.append(f"{e.name}.compute_config.{cloud}: not found: {path}")
-        if not (REPO_ROOT / e.test.tests_path).is_dir():
-            errors.append(f"{e.name}.test.tests_path: not found: {e.test.tests_path}")
-        elif not (REPO_ROOT / e.test.tests_path / "tests.sh").is_file():
-            errors.append(f"{e.name}.test.tests_path: missing tests.sh in {e.test.tests_path}")
+        if e.test is not None:
+            if not (REPO_ROOT / e.test.tests_path).is_dir():
+                errors.append(f"{e.name}.test.tests_path: not found: {e.test.tests_path}")
+            elif not (REPO_ROOT / e.test.tests_path / "tests.sh").is_file():
+                errors.append(f"{e.name}.test.tests_path: missing tests.sh in {e.test.tests_path}")
     return errors
 
 


### PR DESCRIPTION
Formalizes the `archive/` convention and the **tested vs test-exempt** split between `templates/` and `archive/`.

## Validator (`ci/validate_build_yaml.py`)
- **`templates/` entries require a `test`** — active templates are tested; omitting it fails with an actionable "move it under archive/" message.
- **`archive/` entries are test-exempt** — `dir` / `compute_config` may point under `archive/`; the `templates/`-naming conventions are relaxed there. (`rayapp` already treats `test` as optional, so an `archive/` entry publishes with no test stage.)

## Docs
- **`workflows/archive-template.md`** — the retire flow (remove BUILD entry → `git mv` to `archive/`); layout lives in `archive/README.md`.
- **`references/publish-to-backend.md`** — new "Publish without the test gate (events / urgent fixes)" section, linked from `create-template.md` and `update-template.md`.
- **`SKILL.md`** pointer + tested/test-exempt invariant; **schema** note on `test`.
- **`AGENTS.md`** + **`README.md`** — the tested-vs-archive rule and the `archive/` layout.

## Rule
Active templates (`templates/`) are tested. Untested content lives in `archive/` — *retire* a stale template (no BUILD entry), or publish an event template *without the test gate* (urgent fix, test-free `archive/` entry).

## Testing
`validate_build_yaml.py`: current BUILD.yaml (55 entries) passes; a `templates/` entry with no test is rejected with the archive message; an `archive/` entry validates with or without a test.
