### PR TITLE
Fix worker dep propagation in fintech_quant and llm_batch_inference_vision

### DIFF
--- a/templates/fintech_quant/README.ipynb
+++ b/templates/fintech_quant/README.ipynb
@@ -3,7 +3,20 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Option chain pricing with Ray\n\n<div align=\"left\">\n  <a target=\"_blank\" href=\"https://console.anyscale.com/template-preview/fintech_quant\"><img src=\"https://img.shields.io/badge/🚀 Run_on-Anyscale-9hf\"></a>&nbsp;\n  <a href=\"https://github.com/anyscale/templates/tree/main/templates/fintech_quant\" role=\"button\"><img src=\"https://img.shields.io/static/v1?label=&message=View%20On%20GitHub&color=586069&logo=github&labelColor=2f363d\"></a>&nbsp;\n</div>\n\n**⏱️ Time to complete**: 30 min\n\n- Option chain pricing explodes into many independent calculations (symbol x contract x shock), which is a natural fit for task parallelism.\n- Ray Core lets us keep Python functions while distributing work across CPUs with `@ray.remote`.\n- Ray's dynamic execution model (from the Ray paper) is built for irregular workloads where task counts change at runtime."
+   "source": [
+    "# Option chain pricing with Ray\n",
+    "\n",
+    "<div align=\"left\">\n",
+    "  <a target=\"_blank\" href=\"https://console.anyscale.com/template-preview/fintech_quant\"><img src=\"https://img.shields.io/badge/🚀 Run_on-Anyscale-9hf\"></a>&nbsp;\n",
+    "  <a href=\"https://github.com/anyscale/templates/tree/main/templates/fintech_quant\" role=\"button\"><img src=\"https://img.shields.io/static/v1?label=&message=View%20On%20GitHub&color=586069&logo=github&labelColor=2f363d\"></a>&nbsp;\n",
+    "</div>\n",
+    "\n",
+    "**⏱️ Time to complete**: 30 min\n",
+    "\n",
+    "- Option chain pricing explodes into many independent calculations (symbol x contract x shock), which is a natural fit for task parallelism.\n",
+    "- Ray Core lets us keep Python functions while distributing work across CPUs with `@ray.remote`.\n",
+    "- Ray's dynamic execution model (from the Ray paper) is built for irregular workloads where task counts change at runtime."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -32,7 +45,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "!uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-strategy unsafe-best-match"
+   "source": [
+    "!uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-strategy unsafe-best-match"
+   ]
   },
   {
    "cell_type": "code",
@@ -46,7 +61,16 @@
     "\n",
     "from util import get_iv, get_npv, get_options_chain, save_csv, get_symbols_stat_print as SYMBOL_STATS_PRINT, FuncTimer as ft\n",
     "\n",
-    "os.environ[\"RAY_DEDUP_LOGS\"] = \"0\""
+    "os.environ[\"RAY_DEDUP_LOGS\"] = \"0\"\n",
+    "\n",
+    "# Connect to the Ray cluster and propagate dependencies to all workers.\n",
+    "# Installing with `uv pip --system` above only affects the driver, so set a\n",
+    "# runtime_env pointing at python_depset.lock to ensure Ray workers install the\n",
+    "# same pinned dependencies (for example, QuantLib).\n",
+    "ray.init(\n",
+    "    ignore_reinit_error=True,\n",
+    "    runtime_env={\"pip\": os.path.join(os.getcwd(), \"python_depset.lock\")},\n",
+    ")"
    ]
   },
   {

--- a/templates/fintech_quant/README.md
+++ b/templates/fintech_quant/README.md
@@ -38,6 +38,15 @@ import ray
 from util import get_iv, get_npv, get_options_chain, save_csv, get_symbols_stat_print as SYMBOL_STATS_PRINT, FuncTimer as ft
 
 os.environ["RAY_DEDUP_LOGS"] = "0"
+
+# Connect to the Ray cluster and propagate dependencies to all workers.
+# Installing with `uv pip --system` above only affects the driver, so set a
+# runtime_env pointing at python_depset.lock to ensure Ray workers install the
+# same pinned dependencies (for example, QuantLib).
+ray.init(
+    ignore_reinit_error=True,
+    runtime_env={"pip": os.path.join(os.getcwd(), "python_depset.lock")},
+)
 ```
 
 #### Serial implementation

--- a/templates/llm_batch_inference_vision/README.ipynb
+++ b/templates/llm_batch_inference_vision/README.ipynb
@@ -54,7 +54,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "!uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-strategy unsafe-best-match"
+   "source": [
+    "!uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-strategy unsafe-best-match"
+   ]
   },
   {
    "cell_type": "code",
@@ -62,10 +64,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import ray\n",
     "import datasets\n",
     "from PIL import Image\n",
     "from io import BytesIO\n",
+    "\n",
+    "# `uv pip install --system` above only installs on the driver/head node. Ray Data's\n",
+    "# `from_huggingface` read tasks run on worker nodes, so propagate the locked deps\n",
+    "# (notably `datasets`) to every worker via the runtime_env.\n",
+    "ray.init(\n",
+    "    ignore_reinit_error=True,\n",
+    "    runtime_env={\"pip\": os.path.join(os.getcwd(), \"python_depset.lock\")},\n",
+    ")\n",
     "\n",
     "# Load the BLIP3o/BLIP3o-Pretrain-Short-Caption dataset from Hugging Face with ~5M images.\n",
     "print(\"Loading BLIP3o/BLIP3o-Pretrain-Short-Caption dataset from Hugging Face...\")\n",

--- a/templates/llm_batch_inference_vision/README.md
+++ b/templates/llm_batch_inference_vision/README.md
@@ -39,10 +39,19 @@ First, load the data from a remote URL then repartition the dataset to ensure th
 
 
 ```python
+import os
 import ray
 import datasets
 from PIL import Image
 from io import BytesIO
+
+# `uv pip install --system` above only installs on the driver/head node. Ray Data's
+# `from_huggingface` read tasks run on worker nodes, so propagate the locked deps
+# (notably `datasets`) to every worker via the runtime_env.
+ray.init(
+    ignore_reinit_error=True,
+    runtime_env={"pip": os.path.join(os.getcwd(), "python_depset.lock")},
+)
 
 # Load the BLIP3o/BLIP3o-Pretrain-Short-Caption dataset from Hugging Face with ~5M images.
 print("Loading BLIP3o/BLIP3o-Pretrain-Short-Caption dataset from Hugging Face...")


### PR DESCRIPTION


Both templates install their python_depset.lock via `uv pip install --system`, which only installs on the head node and bypasses Anyscale's snapshot auto-injection into the worker runtime_env. Ray tasks/Data reads that run on worker nodes then fail to import the locked deps:

- fintech_quant: `parallel_price_option_chain.remote()` -> `ModuleNotFoundError: No module named 'QuantLib'` on a worker.
- llm_batch_inference_vision: `ray.data.from_huggingface` ReadHuggingFace tasks -> `No module named 'datasets'` on a worker.

`rayapp test` hides this (its repo compute config leaves the head schedulable, so the few tasks pack onto the head where the deps are); `rayapp probe` launches the published cluster and the tasks land on workers, exposing the bug.

Fix: add the established runtime_env pip pattern on ray.init so the locked closure is propagated to every worker, matching pytorch-profiling et al.:

    ray.init(
        ignore_reinit_error=True,
        runtime_env={"pip": os.path.join(os.getcwd(), "python_depset.lock")},
    )

READMEs regenerated from the notebooks. No requirements.txt changes, so no re-lock needed.

Published to staging environment and manually tested in the console
Tmpl-publish builds: 
https://buildkite.com/anyscale/tmpl-publish/builds/435
https://buildkite.com/anyscale/tmpl-publish/builds/436

Fintech quant tested in staging environment (last cell successfully executing without dependency errors)
<img width="1361" height="572" alt="image" src="https://github.com/user-attachments/assets/926c8329-fb4d-4c8a-aa65-46762622bafd" />
LLM batch inference vision tested in staging environment
<img width="3770" height="1776" alt="image" src="https://github.com/user-attachments/assets/1d1c5192-58fa-426d-adc1-8665ef434a96" />
