### PR TITLE
fix(template): per-template depset recipe for the automated Ray bump

### DIFF
--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -1,66 +1,78 @@
 # Template dependencies (depsets)
 
-How locked Python dependencies work for templates. The upgrade procedure lives in
-`../workflows/upgrade-dependencies.md`; this file is the system reference it leans on.
+How templates' locked Python deps work. System reference for the depset steps in
+`../workflows/upgrade-dependencies.md` (whole-repo) and `../workflows/bump-ray-version.md` (per-template).
 
-## What ships with a template
+## What ships, and how it reaches workers
 
-Most templates carry a fully-pinned, hashed **`templates/<name>/python_depset.lock`** alongside
-their `requirements.txt`. The template installs it into the driver and into Ray workers:
+Most templates carry a fully-pinned, hashed **`templates/<name>/python_depset.lock`** next to their
+`requirements.txt`. The template installs it in **both** places:
 
 ```python
-!uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-strategy unsafe-best-match
-ray.init(runtime_env={"pip": os.path.join(DEMO_ROOT, "python_depset.lock"), ...})
+!uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-strategy unsafe-best-match  # driver
+ray.init(runtime_env={"pip": os.path.join(DEMO_ROOT, "python_depset.lock"), ...})                            # workers
 ```
 
-So the lock must be self-consistent **and** consistent with the Ray version preinstalled in the
-template's image. A Ray-version bump that changes the image without recompiling the lock leaves the
-two out of sync — see `../workflows/bump-ray-version.md`.
+`--system` covers only the driver; **workers get the deps solely via `runtime_env`** — omit it and they
+silently run whatever the image shipped. The lock must also match the Ray version baked into the image; a
+bump that moves the image without recompiling the lock desyncs them (`../workflows/bump-ray-version.md`).
 
 ## The tool: `raydepsets`
 
-A standalone binary fetched by repo-root **`update_deps.sh`** from
-`github.com/ray-project/raydepsets/releases` (pinned `v0.0.1`), cached at `/tmp/raydepsets`. Run it
-through the wrapper, never directly:
+Repo-root **`update_deps.sh`** fetches the pinned `raydepsets` binary (v0.0.1, cached at `/tmp/raydepsets`)
+and runs `raydepsets build dependencies/template.depsets.yaml --workspace-dir <root>`, compiling via
+`uv pip compile --generate-hashes`. Always go through the wrapper:
 
 ```bash
 ./update_deps.sh                       # build every depset
-./update_deps.sh --name <depset-name>  # build one depset (+ its dependencies)
-./update_deps.sh --check               # recompile to a temp dir, diff vs committed locks, fail on drift
+./update_deps.sh --name <depset-name>  # build one (interpolated name, e.g. ray_depset_2.56.0_3.11)
+./update_deps.sh --check               # recompile to a temp dir, diff vs committed; the CI gate
 ```
 
-`update_deps.sh` expands to `raydepsets build dependencies/template.depsets.yaml --workspace-dir <repo-root> "$@"`.
-It compiles via `uv pip compile --generate-hashes`.
+## Running it (linux-x86_64 only; macOS via Docker)
 
-> The tool's upstream source is `~/repos/ray/ci/raydepsets/`, but that HEAD has drifted from the
-> pinned `v0.0.1` binary (HEAD's `expand` takes a `depsets:` list; v0.0.1 takes `source_depset:`).
-> **`dependencies/template.depsets.yaml` is the source of truth for the schema that actually runs.**
+`raydepsets` v0.0.1 ships **only** a `linux-x86_64` build (a Python zipapp bundling a per-platform `uv`).
+
+- **On linux-x86_64** (CI, a devbox, the Cursor env): `./update_deps.sh …` just works.
+- **On macOS**: run it in a `linux/amd64` container with a `uname` shim — under qemu `platform.processor()`
+  is empty, so raydepsets aborts with `Unsupported platform/processor: Linux/`. Shim `uname -p → x86_64`:
+
+  ```bash
+  docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w python:3.12 bash -c '
+    cat > /usr/local/bin/uname <<"EOF"
+  #!/bin/sh
+  [ "$1" = -p ] && echo x86_64 || exec /bin/uname "$@"
+  EOF
+    chmod +x /usr/local/bin/uname
+    bash update_deps.sh --name ray_depset_2.56.0_3.11   # or plain: bash update_deps.sh
+  '
+  ```
+
+Output is identical to a native Linux run (`uv` resolves for `--python-platform=linux` regardless of host).
+`--check` needs all entries (can't combine with `--name`). Base locks come from Ray's published `deplocks/`,
+which lag a release by days — the **image** lock (`deplocks/ray_img/`) usually lands before the **LLM** lock
+(`deplocks/llm/`), so an image bump can proceed while the LLM side waits.
 
 ## The config: `dependencies/template.depsets.yaml`
 
-Two top-level keys.
-
-**`build_arg_sets`** — named `${VAR}` bundles. Today:
+Two top-level keys. **`build_arg_sets`** — named `${VAR}` bundles:
 
 ```yaml
 build_arg_sets:
   ray2551_py311_cu128: {RAY_VERSION: "2.55.1", PYTHON_VERSION: "3.11", PYTHON_SHORT: "311", CUDA_VARIANT: "cu128"}
-  ray2551_py312_cu128: {RAY_VERSION: "2.55.1", PYTHON_VERSION: "3.12", PYTHON_SHORT: "312", CUDA_VARIANT: "cu128"}
 ```
 
-**`depsets`** — a list of entries. Each entry's `build_arg_sets:` field lists which bundle(s) it
-expands over; the tool emits one concrete depset per bundle, substituting `${VAR}` into `name`,
-`output`, `requirements`, `source_depset`, `append_flags`, and `pre_hooks`.
+**`depsets`** — entries; each entry's `build_arg_sets:` lists the bundle(s) it builds over, and the tool
+emits one concrete depset per bundle, substituting `${VAR}` into every field. Two kinds:
 
-### Two kinds of entries
-
-**Base `compile`** (2 entries) — fetch Ray's published locks and compile the shared base locks.
-Output paths are **version-stamped**, so a new Ray version writes new files:
+**Base `compile`** (2 entries) — re-emit Ray's published image lock as the shared base lock, **version-stamped**
+(new Ray version → new file). The output is Ray's fetched `ray_img` lock recompiled for our target — `ray`
+excluded, re-hashed — so it's near-identical in content but reproducible and committable:
 
 ```yaml
 - name: ray_depset_${RAY_VERSION}_${PYTHON_VERSION}
   operation: compile
-  requirements: [/tmp/ray-deps/ray_img_py${PYTHON_SHORT}.lock]
+  requirements: [/tmp/ray-deps/ray_img_py${PYTHON_SHORT}.lock]   # fetched by the pre_hooks
   output: dependencies/depsets/ray_${RAY_VERSION}_img_py${PYTHON_SHORT}.lock
   append_flags: [--python-version=${PYTHON_VERSION}, --python-platform=linux, --unsafe-package ray]
   build_arg_sets: [ray2551_py311_cu128, ray2551_py312_cu128]
@@ -69,10 +81,10 @@ Output paths are **version-stamped**, so a new Ray version writes new files:
     - dependencies/scripts/fetch-ray-constraints.sh ${RAY_VERSION} ${PYTHON_VERSION}
 ```
 
-`ray_llm_depset_*` is the same shape for the LLM image → `dependencies/depsets/rayllm_<ver>_*.lock`.
+`ray_llm_depset_*` is the same for the LLM image → `rayllm_<ver>_*.lock`.
 
-**Per-template `expand`** (the rest) — layer a template's `requirements.txt` on top of a base
-depset. Output is **NOT version-stamped** — overwritten in place:
+**Per-template `expand`** (the rest) — layer a template's `requirements.txt` on a base depset. Output is
+**overwritten in place** (not version-stamped):
 
 ```yaml
 - name: <tmpl>_depset_${RAY_VERSION}_${PYTHON_VERSION}
@@ -80,44 +92,36 @@ depset. Output is **NOT version-stamped** — overwritten in place:
   source_depset: ray_depset_${RAY_VERSION}_${PYTHON_VERSION}   # or ray_llm_depset_...
   requirements: [templates/<tmpl>/requirements.txt]
   output: templates/<tmpl>/python_depset.lock
-  append_flags: [--index https://download.pytorch.org/whl/<cuXXX>, --python-version=${PYTHON_VERSION}, --python-platform=linux, --unsafe-package ray]
   build_arg_sets: [ray2551_py312_cu128]
 ```
 
-Because `source_depset` interpolates `${RAY_VERSION}`, repointing an entry's `build_arg_sets:` to a
-new-version bundle automatically pulls from the new base lock — that's the lever the upgrade uses.
+`source_depset` interpolates `${RAY_VERSION}`, so repointing an entry's `build_arg_sets:` to a new-version
+bundle pulls from the new base lock — the lever both upgrade paths use. The `fetch-ray-*.sh` pre-hooks curl
+Ray's published locks/constraints into `/tmp/ray-deps/`, with fallbacks for releases predating `deplocks/`.
 
-### Pre-hooks
-`dependencies/scripts/fetch-ray-{depsets,llm-depsets,constraints}.sh` curl Ray's published locks and
-constraints for the target version from `raw.githubusercontent.com/ray-project/ray/ray-<version>/...`
-into `/tmp/ray-deps/` before the base compile. They carry fallbacks for older Ray releases that
-don't publish `deplocks/`.
+## Changing a template's dependencies
+
+1. Edit `templates/<name>/requirements.txt`.
+2. Regenerate its lock: `./update_deps.sh --name <its-entry>` (linux/Docker — see "Running it").
+3. Confirm the template installs the regenerated lock on the driver **and** forwards it via `runtime_env`
+   (see "What ships") — otherwise workers keep running stale deps.
+4. Pin the traps below.
 
 ## CI gate
-`.github/workflows/premerge.yaml` → **`check-depsets`** runs `./update_deps.sh --check`. It
-recompiles **all** active entries into a temp dir and unified-diffs against the committed locks;
-any drift fails the job.
+
+`premerge.yaml` → **`check-depsets`** runs `./update_deps.sh --check`: recompiles all active entries into a
+temp dir and diffs against the committed locks; any drift fails.
 
 ## Gotchas
 
-- **`check-depsets` couples every active entry to its committed lock, per branch.** To stack or
-  split depset PRs, comment out the entries you're not building on that branch (this is why the
-  config has large commented-out blocks — staged rollout).
-- **`check-depsets` re-resolves against *live* indexes, so unrelated PRs fail on collateral.** Every
-  run recompiles all active entries from live PyPI/PyTorch and diffs vs committed — a PR that touched
-  one template (or none) can go red on *another* template's **ambient drift** (upstream published
-  newer deps) or a **transient index 503**. Refresh drifted locks in-passing and include them; treat
-  503s as infra. The gate is scoped to PRs that change a lock's inputs and retries transient errors,
-  and a scheduled job recompiles the full matrix and opens a refresh PR when drift accumulates — so
-  collateral doesn't block unrelated PRs. Persistent drift in a lock you changed still fails, by design.
-- **Per-template locks are overwritten in place; base locks are version-stamped.** On a version
-  bump, delete the stale `dependencies/depsets/ray_<old>_*` files once nothing references them.
-- **runtime_env pip hash mismatch** on version-bumped transitive deps: `uv` can emit one
-  wrong-interpreter hash. Fix by pinning the offending package to the base-image version.
-- **`uv pip install --system` bypasses Anyscale's worker propagation**, and un-pinned depsets float
-  `numpy` to 2.x. Pin `numpy`/`pandas`/`pyarrow` to the base image; prefer the `runtime_env` pip
-  install for workers.
-- **Unpinned `datasets`** resolves to ancient `2.14.4` and breaks on modern `fsspec`. Pin
-  `datasets==3.6.0` + `fsspec==2023.12.1` in the template `requirements.txt`.
-- **Upstream lag:** Ray's `deplocks/` (and base images) publish a few days after a Ray release; a
-  bump can't complete until they're up.
+- **The gate re-resolves against *live* indexes, so it fails on collateral.** Every run recompiles all
+  active entries from live PyPI/PyTorch, so a PR can go red on *another* template's **ambient drift**
+  (upstream shipped newer deps) or a **transient 503**. Refresh drifted locks in-passing and include them;
+  treat 503s as infra. (To stack/split depset PRs, comment out the entries you're not building — hence the
+  config's commented-out blocks.)
+- **`runtime_env` pip hash mismatch** on bumped transitive deps: `uv` can emit one wrong-interpreter hash.
+  Pin the offending package to the base-image version.
+- **Un-pinned floats.** `--system` installs float `numpy` to 2.x → pin `numpy`/`pandas`/`pyarrow` to the base
+  image. Un-pinned `datasets` resolves to ancient `2.14.4` and breaks modern `fsspec` → pin `datasets==3.6.0`
+  + `fsspec==2023.12.1` in `requirements.txt`.
+- **Upstream lag:** Ray's `deplocks/` and base images publish days after a release; a bump waits on them.

--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -26,7 +26,7 @@ and runs `raydepsets build dependencies/template.depsets.yaml --workspace-dir <r
 ```bash
 ./update_deps.sh                       # build every depset
 ./update_deps.sh --name <depset-name>  # build one (interpolated name, e.g. ray_depset_2.56.0_3.11)
-./update_deps.sh --check               # recompile to a temp dir, diff vs committed; the CI gate
+./update_deps.sh --check               # recompile to a temp dir, diff vs committed (local validation)
 ```
 
 ## Running it
@@ -92,18 +92,11 @@ Ray's published locks/constraints into `/tmp/ray-deps/`, with fallbacks for rele
    (see "What ships") — otherwise workers keep running stale deps.
 4. Pin the traps below.
 
-## CI gate
-
-`premerge.yaml` → **`check-depsets`** runs `./update_deps.sh --check`: recompiles all active entries into a
-temp dir and diffs against the committed locks; any drift fails.
-
 ## Gotchas
 
-- **The gate re-resolves against *live* indexes, so it fails on collateral.** Every run recompiles all
-  active entries from live PyPI/PyTorch, so a PR can go red on *another* template's **ambient drift**
-  (upstream shipped newer deps) or a **transient 503**. Refresh drifted locks in-passing and include them;
-  treat 503s as infra. (To stack/split depset PRs, comment out the entries you're not building — hence the
-  config's commented-out blocks.)
+- **`update_deps.sh` re-resolves against *live* indexes.** A fresh run can shift an untouched lock when
+  upstream ships newer deps (ambient drift) or fail on a transient PyPI/PyTorch 503. Refresh drifted locks
+  in-passing; treat 503s as infra.
 - **`runtime_env` pip hash mismatch** on bumped transitive deps: `uv` can emit one wrong-interpreter hash.
   Pin the offending package to the base-image version.
 - **Un-pinned floats.** `--system` installs float `numpy` to 2.x → pin `numpy`/`pandas`/`pyarrow` to the base

--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -29,29 +29,14 @@ and runs `raydepsets build dependencies/template.depsets.yaml --workspace-dir <r
 ./update_deps.sh --check               # recompile to a temp dir, diff vs committed; the CI gate
 ```
 
-## Running it (linux-x86_64 only; macOS via Docker)
+## Running it
 
-`raydepsets` v0.0.1 ships **only** a `linux-x86_64` build (a Python zipapp bundling a per-platform `uv`).
-
-- **On linux-x86_64** (CI, a devbox, the Cursor env): `./update_deps.sh …` just works.
-- **On macOS**: run it in a `linux/amd64` container with a `uname` shim — under qemu `platform.processor()`
-  is empty, so raydepsets aborts with `Unsupported platform/processor: Linux/`. Shim `uname -p → x86_64`:
-
-  ```bash
-  docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w python:3.12 bash -c '
-    cat > /usr/local/bin/uname <<"EOF"
-  #!/bin/sh
-  [ "$1" = -p ] && echo x86_64 || exec /bin/uname "$@"
-  EOF
-    chmod +x /usr/local/bin/uname
-    bash update_deps.sh --name ray_depset_2.56.0_3.11   # or plain: bash update_deps.sh
-  '
-  ```
-
-Output is identical to a native Linux run (`uv` resolves for `--python-platform=linux` regardless of host).
-`--check` needs all entries (can't combine with `--name`). Base locks come from Ray's published `deplocks/`,
-which lag a release by days — the **image** lock (`deplocks/ray_img/`) usually lands before the **LLM** lock
-(`deplocks/llm/`), so an image bump can proceed while the LLM side waits.
+`raydepsets` v0.0.1 ships both `linux-x86_64` and `darwin-arm64` builds (Python zipapps bundling a
+per-platform `uv`), so `./update_deps.sh` runs natively on Linux **and** macOS — output is identical
+either way (`uv` always resolves for `--python-platform=linux`). `--check` needs all entries (can't
+combine with `--name`). Base locks come from Ray's published `deplocks/`, which lag a release by days —
+the **image** lock (`deplocks/ray_img/`) usually lands before the **LLM** lock (`deplocks/llm/`), so an
+image bump can proceed while the LLM side waits.
 
 ## The config: `dependencies/template.depsets.yaml`
 
@@ -102,7 +87,7 @@ Ray's published locks/constraints into `/tmp/ray-deps/`, with fallbacks for rele
 ## Changing a template's dependencies
 
 1. Edit `templates/<name>/requirements.txt`.
-2. Regenerate its lock: `./update_deps.sh --name <its-entry>` (linux/Docker — see "Running it").
+2. Regenerate its lock: `./update_deps.sh --name <its-entry>` (see "Running it").
 3. Confirm the template installs the regenerated lock on the driver **and** forwards it via `runtime_env`
    (see "What ships") — otherwise workers keep running stale deps.
 4. Pin the traps below.

--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -103,6 +103,13 @@ any drift fails the job.
 - **`check-depsets` couples every active entry to its committed lock, per branch.** To stack or
   split depset PRs, comment out the entries you're not building on that branch (this is why the
   config has large commented-out blocks — staged rollout).
+- **`check-depsets` re-resolves against *live* indexes, so unrelated PRs fail on collateral.** Every
+  run recompiles all active entries from live PyPI/PyTorch and diffs vs committed — a PR that touched
+  one template (or none) can go red on *another* template's **ambient drift** (upstream published
+  newer deps) or a **transient index 503**. Refresh drifted locks in-passing and include them; treat
+  503s as infra. The gate is scoped to PRs that change a lock's inputs and retries transient errors,
+  and a scheduled job recompiles the full matrix and opens a refresh PR when drift accumulates — so
+  collateral doesn't block unrelated PRs. Persistent drift in a lock you changed still fails, by design.
 - **Per-template locks are overwritten in place; base locks are version-stamped.** On a version
   bump, delete the stale `dependencies/depsets/ray_<old>_*` files once nothing references them.
 - **runtime_env pip hash mismatch** on version-bumped transitive deps: `uv` can emit one

--- a/.claude/skills/template/workflows/bump-ray-version.md
+++ b/.claude/skills/template/workflows/bump-ray-version.md
@@ -4,10 +4,6 @@
 
 Cursor environment quirks — `GH_TOKEN=$ANYSCALE_GH_TOKEN` on `gh` writes, `cursor/...` branch naming, `pre-commit` not auto-firing under `core.hooksPath`, and the PR labels — live in **AGENTS.md "Cursor Cloud"**. Follow them there; this runbook does not restate them.
 
-## Batch vs per-template
-
-This runbook is the **per-template** path (one bump, one PR). For a **full-fleet** bump, recompile the depsets **once up front** rather than N times: a human runs `upgrade-dependencies.md` first — add the new bundle, repoint every entry, regenerate the matrix, drop stale base locks — and merges that single depset PR; then each run here is a pure `BUILD.yaml` image bump with no depset edit, so parallel PRs never collide on the shared `template.depsets.yaml` bundle or base lock. Bumping only one or a few templates? Skip the batch PR and let each run do its own incremental lock repoint (step 1, "Recompile the dependency lock"). The recompile rules are identical either way (`../references/dependencies.md`) — the only question is whether lock work happens once in a batch PR or inline per template.
-
 ## Setup — preflight
 
 Run `bash .cursor/preflight.sh`. It verifies the companion skills (incl. `/anyscale-platform-fix`), secrets, and auth. On a non-zero exit, handle per **AGENTS.md "Cursor Cloud → Preconditions"** (report stderr + stop) — at this point no PR exists yet, so that report lands in the run/CI output.

--- a/.claude/skills/template/workflows/bump-ray-version.md
+++ b/.claude/skills/template/workflows/bump-ray-version.md
@@ -38,12 +38,10 @@ The image Ray version and the template's locked deps must agree. Which case appl
   1. Add a `ray<NEW>_py<PY>_cu<CU>` bundle to `build_arg_sets`, mirroring this template's existing `ray<OLD>_*` bundle (same Python/CUDA). **Add — do not replace** the old bundle; every other template still rides it.
   2. Add that bundle to the base `compile` entry this template expands from (`ray_depset` or `ray_llm_depset`), so the new version-stamped base lock (`dependencies/depsets/ray_<NEW>_img_py<PY>.lock`) is generated and committed.
   3. Repoint **only this template's** `expand` entry: its `build_arg_sets` `ray<OLD>_* → ray<NEW>_*`.
-  4. `./update_deps.sh --name <this-entry-name>` — regenerates this template's lock plus the base lock it derives from. (System + tokens: `../references/dependencies.md`; whole-repo batch upgrade: `upgrade-dependencies.md`.)
+  4. `./update_deps.sh --name <this-entry-name>` — regenerates this template's lock plus the base lock it derives from. Runs on **linux-x86_64 only** (macOS: Docker) — see `../references/dependencies.md` "Running it"; whole-repo batch upgrade: `upgrade-dependencies.md`.
   5. Commit together: the `BUILD.yaml` bump, this template's `python_depset.lock`, the new base lock, and the `template.depsets.yaml` edit.
 
   **Do not** repoint other entries or *replace* the old bundles — that's the whole-repo batch path (`upgrade-dependencies.md`, a human doing all templates at once). On a single-template branch it forces every other template's lock to regenerate, blowing up the diff and the merge.
-
-> **`check-depsets` is repo-global — expect collateral failures.** The CI gate (`./update_deps.sh --check`) re-resolves **every** active lock against live indexes and diffs against what's committed, so it can go red on templates you never touched: (a) **ambient upstream drift** — an unrelated lock no longer matches a fresh resolve; regenerate the drifted locks in-passing and include them (expected, not a bump error); (b) **transient index errors** — e.g. a `download.pytorch.org` 503 mid-resolve; infra, re-run per `../references/testing-template.md`. Neither means your bump is wrong.
 
 ## 2. Open the PR
 

--- a/.claude/skills/template/workflows/bump-ray-version.md
+++ b/.claude/skills/template/workflows/bump-ray-version.md
@@ -34,7 +34,7 @@ The image Ray version and the template's locked deps must agree. Which case appl
   1. Add a `ray<NEW>_py<PY>_cu<CU>` bundle to `build_arg_sets`, mirroring this template's existing `ray<OLD>_*` bundle (same Python/CUDA). **Add — do not replace** the old bundle; every other template still rides it.
   2. Add that bundle to the base `compile` entry this template expands from (`ray_depset` or `ray_llm_depset`), so the new version-stamped base lock (`dependencies/depsets/ray_<NEW>_img_py<PY>.lock`) is generated and committed.
   3. Repoint **only this template's** `expand` entry: its `build_arg_sets` `ray<OLD>_* → ray<NEW>_*`.
-  4. `./update_deps.sh --name <this-entry-name>` — regenerates this template's lock plus the base lock it derives from. Runs on **linux-x86_64 only** (macOS: Docker) — see `../references/dependencies.md` "Running it"; whole-repo batch upgrade: `upgrade-dependencies.md`.
+  4. `./update_deps.sh --name <this-entry-name>` — regenerates this template's lock plus the base lock it derives from (runs natively on Linux or macOS; `../references/dependencies.md` "Running it"). Whole-repo batch upgrade: `upgrade-dependencies.md`.
   5. Commit together: the `BUILD.yaml` bump, this template's `python_depset.lock`, the new base lock, and the `template.depsets.yaml` edit.
 
   **Do not** repoint other entries or *replace* the old bundles — that's the whole-repo batch path (`upgrade-dependencies.md`, a human doing all templates at once). On a single-template branch it forces every other template's lock to regenerate, blowing up the diff and the merge.

--- a/.claude/skills/template/workflows/bump-ray-version.md
+++ b/.claude/skills/template/workflows/bump-ray-version.md
@@ -4,6 +4,10 @@
 
 Cursor environment quirks — `GH_TOKEN=$ANYSCALE_GH_TOKEN` on `gh` writes, `cursor/...` branch naming, `pre-commit` not auto-firing under `core.hooksPath`, and the PR labels — live in **AGENTS.md "Cursor Cloud"**. Follow them there; this runbook does not restate them.
 
+## Batch vs per-template
+
+This runbook is the **per-template** path (one bump, one PR). For a **full-fleet** bump, recompile the depsets **once up front** rather than N times: a human runs `upgrade-dependencies.md` first — add the new bundle, repoint every entry, regenerate the matrix, drop stale base locks — and merges that single depset PR; then each run here is a pure `BUILD.yaml` image bump with no depset edit, so parallel PRs never collide on the shared `template.depsets.yaml` bundle or base lock. Bumping only one or a few templates? Skip the batch PR and let each run do its own incremental lock repoint (step 1, "Recompile the dependency lock"). The recompile rules are identical either way (`../references/dependencies.md`) — the only question is whether lock work happens once in a batch PR or inline per template.
+
 ## Setup — preflight
 
 Run `bash .cursor/preflight.sh`. It verifies the companion skills (incl. `/anyscale-platform-fix`), secrets, and auth. On a non-zero exit, handle per **AGENTS.md "Cursor Cloud → Preconditions"** (report stderr + stop) — at this point no PR exists yet, so that report lands in the run/CI output.
@@ -25,7 +29,21 @@ curl -sf "https://hub.docker.com/v2/repositories/anyscale/ray/tags/<tag>/" >/dev
 
 Then bump `BUILD.yaml` `ray_version` and grep/update any in-template version strings.
 
-**Pair with the dependency recompile.** If `<name>` ships a `templates/<name>/python_depset.lock`, the image bump alone leaves its locked deps compiled against the old Ray version. The lock must be regenerated against `<version>` — see `upgrade-dependencies.md` (`references/dependencies.md` for the system). Image Ray version and lock Ray version must match.
+### Recompile the dependency lock
+
+The image Ray version and the template's locked deps must agree. Which case applies is decided by whether `<name>` has an entry in `dependencies/template.depsets.yaml` (equivalently, ships `templates/<name>/python_depset.lock`):
+
+- **No lock** (base-image or BYOD templates — e.g. `parallel-experiments`, `groot-ray-serve`, `intro-ray-libraries`) — nothing to recompile; the image bump *is* the whole change. Go to step 2.
+- **Has a lock** — regenerate it against `<version>`, **incrementally**. This is a *per-template* PR, so touch only this template's slice of the config:
+  1. Add a `ray<NEW>_py<PY>_cu<CU>` bundle to `build_arg_sets`, mirroring this template's existing `ray<OLD>_*` bundle (same Python/CUDA). **Add — do not replace** the old bundle; every other template still rides it.
+  2. Add that bundle to the base `compile` entry this template expands from (`ray_depset` or `ray_llm_depset`), so the new version-stamped base lock (`dependencies/depsets/ray_<NEW>_img_py<PY>.lock`) is generated and committed.
+  3. Repoint **only this template's** `expand` entry: its `build_arg_sets` `ray<OLD>_* → ray<NEW>_*`.
+  4. `./update_deps.sh --name <this-entry-name>` — regenerates this template's lock plus the base lock it derives from. (System + tokens: `../references/dependencies.md`; whole-repo batch upgrade: `upgrade-dependencies.md`.)
+  5. Commit together: the `BUILD.yaml` bump, this template's `python_depset.lock`, the new base lock, and the `template.depsets.yaml` edit.
+
+  **Do not** repoint other entries or *replace* the old bundles — that's the whole-repo batch path (`upgrade-dependencies.md`, a human doing all templates at once). On a single-template branch it forces every other template's lock to regenerate, blowing up the diff and the merge.
+
+> **`check-depsets` is repo-global — expect collateral failures.** The CI gate (`./update_deps.sh --check`) re-resolves **every** active lock against live indexes and diffs against what's committed, so it can go red on templates you never touched: (a) **ambient upstream drift** — an unrelated lock no longer matches a fresh resolve; regenerate the drifted locks in-passing and include them (expected, not a bump error); (b) **transient index errors** — e.g. a `download.pytorch.org` 503 mid-resolve; infra, re-run per `../references/testing-template.md`. Neither means your bump is wrong.
 
 ## 2. Open the PR
 
@@ -53,7 +71,7 @@ Bump <name> to Ray <version>.
 
 ## 3. Validate via CI
 
-Comment `/test-template <name>` on the PR; follow `../references/testing-template.md` for dispatch + Buildkite-MCP monitoring. Green → step 5. Failure → step 4.
+Comment `/test-template <name>` on the PR (**required — the run cannot end before this; see "Done criteria" below**); follow `../references/testing-template.md` for dispatch + Buildkite-MCP monitoring. Green → step 5. Failure → step 4.
 
 ## 4. Fix on failure
 
@@ -62,3 +80,12 @@ Triage and recover per `../references/testing-template.md` "Recovery" (agent-fix
 ## 5. Mark ready + start the publish
 
 When all checks are green, mark the PR ready for review, **start a `tmpl-publish` build** (`../references/publish-to-backend.md`), and **add its Buildkite build link to the PR body** so reviewers can drive it. **Then return — the run ends here.** Don't wait for review, PR comments, or the publish gates: those manual gates govern the actual dev→staging→prod rollout after a human merges (the pipeline ships templates `main`).
+
+## Done criteria
+
+"Returns as soon as the job is done" means one of exactly **two** terminal states — never any other:
+
+- **Shipped** — checks green → PR marked ready + `tmpl-publish` build started + its link in the body (step 5).
+- **Blocked** — a hand-off comment posted explaining the failure, PR left as draft (step 4).
+
+Opening the draft PR is **not** "done." A draft with no `/test-template` dispatched and no hand-off comment is the one state you must never leave behind: it sits un-tested and un-triaged forever. If you have not reached **Shipped** or **Blocked**, you are not finished — dispatch the test (step 3) and follow through.

--- a/.claude/skills/template/workflows/create-template.md
+++ b/.claude/skills/template/workflows/create-template.md
@@ -21,7 +21,7 @@ Interview the user; explain each piece when you reach it. Collect:
 
 Move the content into `templates/<name>/`. For a notebook template, the main notebook **is** `README.ipynb` (the test runs it; `README.md` is its rendered copy — README convention in `../references/conventions.md`); scripts and Dockerfiles sit alongside it.
 
-**Dependencies.** If the template pins deps via a `python_depset.lock` (most do — system in `../references/dependencies.md`), drop its `requirements.txt` into `templates/<name>/` and add a per-template `expand` entry to `dependencies/template.depsets.yaml` (`source_depset` = the base lock for the template's image, `build_arg_sets` = the matching `ray<ver>_py<XX>` bundle). Compile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean (that's the `check-depsets` CI gate). A stock-image template with only `!pip` installs needs no lock.
+**Dependencies.** If the template pins deps via a `python_depset.lock` (most do — system in `../references/dependencies.md`), drop its `requirements.txt` into `templates/<name>/` and add a per-template `expand` entry to `dependencies/template.depsets.yaml` (`source_depset` = the base lock for the template's image, `build_arg_sets` = the matching `ray<ver>_py<XX>` bundle). Compile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean. A stock-image template with only `!pip` installs needs no lock.
 
 ## 3. BUILD.yaml entry
 

--- a/.claude/skills/template/workflows/update-template.md
+++ b/.claude/skills/template/workflows/update-template.md
@@ -10,7 +10,7 @@ Ask which template (`<name>`) and what's changing — notebook/code, compute con
 
 Edit files under `templates/<name>/` (and `configs/<name>/` or `tests/<name>/` as needed). Author README content in `README.ipynb` (README convention in `../references/conventions.md`). If the change touches the image: identify the case in SKILL.md "Image URI cases" (for custom-GCP, rebuild and push via `.claude/skills/template/scripts/push-custom-image-to-gcp.sh`). For a Ray-**version** bump specifically, use `bump-ray-version.md` — it owns the full per-case bump procedure.
 
-**Dependency change** (add/remove/repin a package in a template that ships a `python_depset.lock`): edit `templates/<name>/requirements.txt`, then recompile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean (the `check-depsets` gate). System + gotchas: `../references/dependencies.md`. This is *not* a Ray-version bump; recompiling **all** depsets for a new Ray version is `upgrade-dependencies.md`.
+**Dependency change** (add/remove/repin a package in a template that ships a `python_depset.lock`): edit `templates/<name>/requirements.txt`, then recompile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean. System + gotchas: `../references/dependencies.md`. This is *not* a Ray-version bump; recompiling **all** depsets for a new Ray version is `upgrade-dependencies.md`.
 
 ## 3. Format
 

--- a/.claude/skills/template/workflows/upgrade-dependencies.md
+++ b/.claude/skills/template/workflows/upgrade-dependencies.md
@@ -7,6 +7,14 @@ Ray version by adding a `build_arg_set` for that version and recompiling with `r
 `python_depset.lock` was compiled against must match — run this alongside
 `bump-ray-version.md`, not instead of it. System details: `../references/dependencies.md`.
 
+**Audience — a human upgrading the whole repo at once.** This is the batch path: add the new
+bundle, repoint *every* active entry, recompile the matrix, drop stale base locks. The automated
+per-template bump does **not** follow this — it keeps the old bundle and repoints only its own
+entry, because a single-template branch that replaces bundles or repoints all entries breaks
+`check-depsets` for every other template. That incremental recipe lives in `bump-ray-version.md`
+→ "Recompile the dependency lock." Use *this* file only when deliberately recompiling many
+templates together.
+
 Inputs: target Ray version `<NEW>` (e.g. `2.56.0`). Derive tokens: bundle prefix `ray2560`,
 `PYTHON_SHORT` `311`/`312`, `RAY_VERSION` `2.56.0`.
 

--- a/.claude/skills/template/workflows/upgrade-dependencies.md
+++ b/.claude/skills/template/workflows/upgrade-dependencies.md
@@ -44,6 +44,7 @@ base `compile` entries emit new version-stamped locks, and each `expand` entry's
 ./update_deps.sh                       # everything
 ./update_deps.sh --name <depset-name>  # one entry while iterating
 ```
+Runs on **linux-x86_64 only**; on macOS use Docker — see `../references/dependencies.md` "Running it".
 
 **Batched rollout (recommended for a full bump).** `--check` and a full `./update_deps.sh` build the
 entire matrix and are slow. Split into grouped PRs the way the initial rollout did (see `git log`
@@ -64,5 +65,4 @@ Then sanity-check a representative lock installs and the template runs (`rayapp 
 `../references/testing-template.md`.
 
 ## Common failures
-See `../references/dependencies.md` "Gotchas" — runtime_env pip hash mismatch (pin to base-image
-version), `numpy` floating to 2.x under un-pinned `--system` installs, `datasets`/`fsspec` trap.
+See `../references/dependencies.md` "Gotchas".

--- a/.claude/skills/template/workflows/upgrade-dependencies.md
+++ b/.claude/skills/template/workflows/upgrade-dependencies.md
@@ -36,7 +36,7 @@ base `compile` entries emit new version-stamped locks, and each `expand` entry's
 ./update_deps.sh                       # everything
 ./update_deps.sh --name <depset-name>  # one entry while iterating
 ```
-Runs on **linux-x86_64 only**; on macOS use Docker — see `../references/dependencies.md` "Running it".
+Runs natively on Linux or macOS — see `../references/dependencies.md` "Running it".
 
 **Batched rollout (recommended for a full bump).** `--check` and a full `./update_deps.sh` build the
 entire matrix and are slow. Split into grouped PRs the way the initial rollout did (see `git log`

--- a/.claude/skills/template/workflows/upgrade-dependencies.md
+++ b/.claude/skills/template/workflows/upgrade-dependencies.md
@@ -7,14 +7,6 @@ Ray version by adding a `build_arg_set` for that version and recompiling with `r
 `python_depset.lock` was compiled against must match — run this alongside
 `bump-ray-version.md`, not instead of it. System details: `../references/dependencies.md`.
 
-**Audience — a human upgrading the whole repo at once.** This is the batch path: add the new
-bundle, repoint *every* active entry, recompile the matrix, drop stale base locks. The automated
-per-template bump does **not** follow this — it keeps the old bundle and repoints only its own
-entry, because a single-template branch that replaces bundles or repoints all entries breaks
-`check-depsets` for every other template. That incremental recipe lives in `bump-ray-version.md`
-→ "Recompile the dependency lock." Use *this* file only when deliberately recompiling many
-templates together.
-
 Inputs: target Ray version `<NEW>` (e.g. `2.56.0`). Derive tokens: bundle prefix `ray2560`,
 `PYTHON_SHORT` `311`/`312`, `RAY_VERSION` `2.56.0`.
 

--- a/.claude/skills/template/workflows/upgrade-dependencies.md
+++ b/.claude/skills/template/workflows/upgrade-dependencies.md
@@ -40,17 +40,17 @@ Runs natively on Linux or macOS — see `../references/dependencies.md` "Running
 
 **Batched rollout (recommended for a full bump).** `--check` and a full `./update_deps.sh` build the
 entire matrix and are slow. Split into grouped PRs the way the initial rollout did (see `git log`
-PRs #730–#738): comment out every entry except the batch you're recompiling on this branch, so
-`check-depsets` only gates the locks you changed. Uncomment in later PRs.
+PRs #730–#738): comment out every entry except the batch you're recompiling on this branch, so the
+branch rebuilds only that batch. Uncomment in later PRs.
 
 ## 5. Drop stale base locks
 Per-template `python_depset.lock` files are overwritten in place, but base locks are version-stamped.
 Delete `dependencies/depsets/ray_<OLD>_*` / `rayllm_<OLD>_*` once nothing references the old version.
 (Keep N-1 only if a rollback path is wanted — decide explicitly.)
 
-## 6. Validate (the CI gate)
+## 6. Validate
 ```bash
-./update_deps.sh --check    # must be clean — this is exactly the check-depsets job
+./update_deps.sh --check    # must be clean (recompiles all entries + diffs vs committed)
 ```
 Then sanity-check a representative lock installs and the template runs (`rayapp test <name>` /
 `references/run-tests-locally-with-rayapp.md`). For per-template test dispatch and recovery, reuse

--- a/.cursor/preflight.sh
+++ b/.cursor/preflight.sh
@@ -91,6 +91,28 @@ if ! command -v buildkite-mcp-server >/dev/null 2>&1; then
   failures+=("buildkite-mcp-server not on PATH — Dockerfile bake step regressed; Buildkite MCP integration will fail to start")
 fi
 
+# Depset toolchain: a Ray bump on a lock-bearing template recompiles the lock via
+# update_deps.sh, which downloads the raydepsets binary (it bundles uv) and compiles.
+# Smoke-test that the binary is fetchable for this platform so a broken/unavailable
+# toolchain fails HERE, not mid-bump as a silent post-and-stop. Fetch to the path
+# update_deps.sh caches at, pre-warming it for the actual run.
+if [[ ! -x ./update_deps.sh ]]; then
+  failures+=("depset toolchain: ./update_deps.sh missing or not executable (wrong CWD, or repo not checked out?)")
+else
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64) rds_url="https://github.com/ray-project/raydepsets/releases/download/v0.0.1/raydepsets-linux-x86_64" ;;
+    Darwin-arm64) rds_url="https://github.com/ray-project/raydepsets/releases/download/v0.0.1/raydepsets-darwin-arm64" ;;
+    *)            rds_url="" ;;
+  esac
+  if [[ -z "$rds_url" ]]; then
+    failures+=("depset toolchain: no raydepsets v0.0.1 binary for $(uname -s)-$(uname -m) — run bumps on Linux-x86_64")
+  elif out=$(curl -fsSL "$rds_url" -o /tmp/raydepsets 2>&1) && chmod +x /tmp/raydepsets; then :; else
+    add_failure_with_output \
+      "depset toolchain: raydepsets binary not fetchable ($rds_url) — './update_deps.sh --check' will fail; check the pin/URL" \
+      "$out"
+  fi
+fi
+
 if [[ ${#failures[@]} -gt 0 ]]; then
   echo "Preflight FAILED:" >&2
   for f in "${failures[@]}"; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Manage production templates (BUILD.yaml entries). No services to run.
 
 Local: edit → `pre-commit run --all-files` → push. Pre-commit covers lint, formatting, codebase conventions. `rayapp build all` mirrors CI's build job locally.
 
-Locked deps — most templates ship a fully-pinned `templates/<id>/python_depset.lock` compiled by `./update_deps.sh` (raydepsets) and gated by `check-depsets` in CI. Changing a template's deps or bumping Ray means recompiling the lock; the `/template` skill's `references/dependencies.md` (system) and `workflows/upgrade-dependencies.md` (Ray-version recompile) own this.
+Locked deps — most templates ship a fully-pinned `templates/<id>/python_depset.lock` compiled by `./update_deps.sh` (raydepsets). Changing a template's deps or bumping Ray means recompiling the lock; the `/template` skill's `references/dependencies.md` (system) and `workflows/upgrade-dependencies.md` (Ray-version recompile) own this.
 
 Per-template tests — comment `/test-template <id> [<id>...]` (up to 3, parallel) on the PR to dispatch the Buildkite `template-test` pipeline (workspace + actual test run). For local iteration before pushing, `rayapp test <id>` runs the same flow (see `references/run-tests-locally-with-rayapp.md` in the `/template` skill for setup).
 


### PR DESCRIPTION
The `/template` Ray-bump automation had no per-template depset recipe, so the Ray 2.56.0 batch behaved inconsistently. This teaches the skill (and the cursor preflight) how depsets interact with a bump. **Docs + preflight only — no CI or lockfile changes** (those are #834 / #835 / #833).

## Why
- **No per-template depset recipe** — `bump-ray-version.md` only pointed at the whole-repo *batch* `upgrade-dependencies.md`; nothing covered no-lock templates or how to read the repo-global `check-depsets` gate.
- **#819 was a workflow drop** — the cleanest 2.56.0 PR stuck because the agent opened a draft and never dispatched `/test-template`.
- **`.cursor` was never the block** — `raydepsets` bundles `uv` and recompiled fine in the cursor env; but preflight never smoke-tested the toolchain, so a real breakage would only surface mid-bump.

## Changes
- `bump-ray-version.md` — per-template depset recipe (no-lock vs has-lock), batch-vs-per-template preamble, `check-depsets`-is-repo-global note, explicit **Done criteria**.
- `upgrade-dependencies.md` / `dependencies.md` — label the human/batch path; document the gate's collateral behavior.
- `.cursor/preflight.sh` — depset-toolchain smoke test (fail at preflight, not mid-bump).

## Testing
`pre-commit` on changed files passed. Docs/preflight only — no runtime impact; validated end-to-end by retriggering `template-updater` against the fixed skill.
