### PR TITLE
ci(depsets): temporarily disable the check-depsets gate

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -53,7 +53,10 @@ jobs:
   check-depsets:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Check depsets are up to date
-      run: ./update_deps.sh --check
+    - name: Depsets check temporarily disabled
+      # TEMPORARILY DISABLED. The gate re-resolves every lock against live PyPI/
+      # PyTorch on each PR, so it fails unrelated PRs on ambient drift or a
+      # transient download.pytorch.org 503. Kept as a passing no-op (not deleted)
+      # so a required status check of this name stays green instead of blocking
+      # merges. Re-enable via the scoped + retried replacement in #834.
+      run: echo "check-depsets temporarily disabled — see PR #834 to re-enable."


### PR DESCRIPTION
Temporarily disable `check-depsets`. It re-resolves every lock against live PyPI/PyTorch on every PR, so it fails unrelated PRs on ambient drift or a transient `download.pytorch.org` 503.

## What
`premerge.yaml` — the `check-depsets` job is now a passing no-op. **Kept, not deleted**, so a required status check of this name stays green instead of blocking merges.

## Re-enable
Merge #834 (scope-to-changed + retry), which replaces this job with a gate that only runs on PRs touching a lock. #834 / #835 stay draft until then.
