### PR TITLE
fix(ci): make disabled check-depsets a real passing no-op

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -59,4 +59,7 @@ jobs:
       # transient download.pytorch.org 503. Kept as a passing no-op (not deleted)
       # so a required status check of this name stays green instead of blocking
       # merges. Re-enable via the scoped + retried replacement in #834.
-      run: echo "check-depsets temporarily disabled — see PR #834 to re-enable."
+      # NOTE: block scalar (`run: |`) is required — an inline `run: echo "... #NNN"`
+      # treats the ` #` as a YAML comment and truncates the command.
+      run: |
+        echo "check-depsets temporarily disabled — see PR #834 to re-enable."

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -59,7 +59,6 @@ jobs:
       # transient download.pytorch.org 503. Kept as a passing no-op (not deleted)
       # so a required status check of this name stays green instead of blocking
       # merges. Re-enable via the scoped + retried replacement in #834.
-      # NOTE: block scalar (`run: |`) is required — an inline `run: echo "... #NNN"`
       # treats the ` #` as a YAML comment and truncates the command.
       run: |
         echo "check-depsets temporarily disabled — see PR #834 to re-enable."

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -59,6 +59,5 @@ jobs:
       # transient download.pytorch.org 503. Kept as a passing no-op (not deleted)
       # so a required status check of this name stays green instead of blocking
       # merges. Re-enable via the scoped + retried replacement in #834.
-      # treats the ` #` as a YAML comment and truncates the command.
       run: |
         echo "check-depsets temporarily disabled — see PR #834 to re-enable."


### PR DESCRIPTION
#836's no-op `check-depsets` step actually **hard-fails**: the inline `run: echo "… #834 …"` parses ` #834` as a YAML comment, truncating the command to `echo "… see PR` (unterminated quote) → under `bash -e` that's exit 2. So `check-depsets` has failed on every PR since #836 merged.

Fix: block scalar (`run: |`) so `#` is literal. Verified the parsed `run` value is intact and exits 0.
