### PR TITLE
[ray-update-2.56.0] Update job-intro to Ray 2.56.0

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -5,7 +5,7 @@
   owner_team: general
   dir: templates/job-intro
   cluster_env:
-    image_uri: anyscale/ray:2.55.1-py311
+    image_uri: anyscale/ray:2.56.0-py311
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump `job-intro` to Ray 2.56.0.

## Changes
- `BUILD.yaml`: `cluster_env.image_uri` → `anyscale/ray:2.56.0-py311` (Anyscale base image; tag verified on Docker Hub). No BYOD Dockerfile, no locked depset, no in-template Ray version strings — the image bump is the whole change.

## Tests / validation
- **Local:** `pre-commit run --all-files` — passed.
- **CI:** Buildkite `template-test` build [#445](https://buildkite.com/anyscale/template-test/builds/445) — **passed** (~11m).

## Publish
The agent's `BUILDKITE_API_TOKEN` is read-only (no `write_builds` scope), so `tmpl-publish` could not be auto-kicked. After merge to `main`, a maintainer should trigger it manually:

- Pipeline: <https://buildkite.com/anyscale/tmpl-publish>
- Trigger build with `branch=master`, `commit=HEAD`, `message=job-intro`
- On the `input-tmpl-name` block: `tmpl-name=job-intro`, `tmpl-branch=main`, `tmpl-commit=HEAD`
- Walk the dev → staging → production manual gates (see `.claude/skills/template/references/publish-to-backend.md`).

Labels: `ray-update`, `cursor-cloud`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91bbd152-0c6c-465f-ba79-5f348b9e5584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91bbd152-0c6c-465f-ba79-5f348b9e5584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

