### PR TITLE
ci: add merge-triggered Ray-bump fanout workflow

### DIFF
--- a/.claude/skills/template/workflows/bump-ray-version.md
+++ b/.claude/skills/template/workflows/bump-ray-version.md
@@ -14,6 +14,10 @@ The goal is a **working, CI-green template on the new Ray version**, not a minim
 
 Do them, and note them in the PR body. Reserve **stop / Blocked** for what you genuinely cannot fix from the template's own files — an unpublished base image, a staging/Buildkite outage, or a change that would alter the template's *intent* rather than just make it run. **When unsure, prefer making an obvious, low-risk fix over bailing** — that isn't "guessing."
 
+## Fast-stop — is this template in scope?
+
+**Before anything else (including preflight):** look up `<name>` in `BUILD.yaml`. If it's **absent**, or its entry has **`maintained: false`** (archived templates carry this flag), **stop immediately and return** — you shouldn't have been triggered; don't spend on preflight or a bump.
+
 ## Setup — preflight
 
 Run `bash .cursor/preflight.sh`. It verifies the companion skills (incl. `/anyscale-platform-fix`), secrets, and auth. On a non-zero exit, handle per **AGENTS.md "Cursor Cloud → Preconditions"** (report stderr + stop) — at this point no PR exists yet, so that report lands in the run/CI output.

--- a/.github/workflows/ray-bump-fanout.yaml
+++ b/.github/workflows/ray-bump-fanout.yaml
@@ -1,23 +1,22 @@
 name: ray-bump-fanout
 
-# Fan the per-template Ray-version bump out when a new base-lock set lands on main.
-# The prompt lives on the "Template update" Cursor automation (single source of
-# truth); this workflow only derives the target version and POSTs
-# {template_name, ray_version} once per template via ci/trigger-cursor-bump.py.
+# Fan the per-template Ray-version bump out for a target version. The prompt lives
+# on the "Template update" Cursor automation (single source of truth); this only
+# resolves the target set and POSTs {template_name, ray_version} once per template
+# via ci/trigger-cursor-bump.py.
 #
-# Design:
-#   - Version is DERIVED from dependencies/depsets/ (newest version with both a
-#     ray_<v>_img_* and a rayllm_<v>_* base lock) — no signal file to maintain.
-#   - Idempotent: fires only the DELTA (maintained templates that don't already
-#     have a [ray-update-<v>] PR), so re-runs and unrelated depset commits are safe.
+# Fire it by pushing a versioned tag `ray-fanout-<v>` — the deliberate "go". The
+# tag encodes the version and can't be re-pushed without force, so it can't
+# double-fire. Or run it manually (workflow_dispatch); manual runs preview by default.
+#
+# Delta = maintained BUILD.yaml entries not already at <v> (the trigger script's
+# version-skip). BUILD.yaml is the single source of truth — no PR bookkeeping.
 #
 # Requires repo/org secrets: CURSOR_TEMPLATE_UPDATER_WEBHOOK, CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN.
-# Depends on the webhook-model trigger script (PR #842) being on main.
 
 on:
   push:
-    branches: [main]
-    paths: ['dependencies/depsets/**']
+    tags: ['ray-fanout-*']
   workflow_dispatch:
     inputs:
       ray_version:
@@ -25,22 +24,20 @@ on:
         required: false
         default: ""
       dry_run:
-        description: "Preview only — no POSTs (manual runs default to preview)"
+        description: "Preview only — no POSTs"
         type: boolean
         default: true
 
 concurrency:
-  group: ray-bump-fanout      # one fanout at a time; never double-fire
+  group: ray-bump-fanout
   cancel-in-progress: false
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   fanout:
     runs-on: ubuntu-latest
-    # environment: fanout   # uncomment to require a human approval before firing
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -49,49 +46,52 @@ jobs:
     - name: Install dev deps
       run: pip install -r requirements-dev.txt
 
-    - name: Derive target Ray version
+    - name: Resolve target Ray version
       id: version
       env:
         INPUT_VERSION: ${{ inputs.ray_version }}
       run: |
         V="$INPUT_VERSION"
+        # tag push: refs/tags/ray-fanout-2.56.0 -> 2.56.0
+        if [ -z "$V" ] && [ "$GITHUB_EVENT_NAME" = "push" ]; then
+          V="${GITHUB_REF#refs/tags/ray-fanout-}"
+        fi
+        # blank manual run: newest version with a complete base-lock set
         if [ -z "$V" ]; then
-          # newest version present as BOTH a ray_<v>_img_* and a rayllm_<v>_* lock
-          printf '%s\n' dependencies/depsets/ray_*_img_*.lock | grep -oP 'ray_\K[0-9.]+(?=_img_)' | sort -u > /tmp/img.txt
-          printf '%s\n' dependencies/depsets/rayllm_*.lock    | grep -oP 'rayllm_\K[0-9.]+(?=_)'   | sort -u > /tmp/llm.txt
+          printf '%s\n' dependencies/depsets/ray_*_img_*.lock | grep -oP 'ray_\K[0-9.]+(?=_img_)' | sort -u > /tmp/img.txt || true
+          printf '%s\n' dependencies/depsets/rayllm_*.lock    | grep -oP 'rayllm_\K[0-9.]+(?=_)'   | sort -u > /tmp/llm.txt || true
           V="$(comm -12 /tmp/img.txt /tmp/llm.txt | sort -V | tail -1)"
         fi
         if [ -z "$V" ]; then
-          echo "::error::no complete base-lock set (ray_<v>_img_* AND rayllm_<v>_*) in dependencies/depsets/"
+          echo "::error::could not determine target Ray version"; exit 1
+        fi
+        # the version must have a complete base-lock set (both families present)
+        if ! compgen -G "dependencies/depsets/ray_${V}_img_*.lock" >/dev/null \
+          || ! compgen -G "dependencies/depsets/rayllm_${V}_*.lock" >/dev/null; then
+          echo "::error::no complete base-lock set (ray_${V}_img_* AND rayllm_${V}_*) in dependencies/depsets/"
           exit 1
         fi
         echo "value=$V" >> "$GITHUB_OUTPUT"
         echo "Target Ray version: $V"
 
-    - name: Compute delta (maintained templates without a [ray-update-<v>] PR)
+    - name: Compute delta (maintained templates not already at the target)
       id: delta
       env:
-        GH_TOKEN: ${{ github.token }}
         V: ${{ steps.version.outputs.value }}
       run: |
-        # --list is version-aware: it already drops templates whose BUILD.yaml is
-        # at $V (merged bumps), leaving the "behind $V" set.
-        python3 ci/trigger-cursor-bump.py --all -v "$V" --list 2>/dev/null | sort -u > /tmp/maintained.txt
-        # ...minus template names that already have an in-flight [ray-update-<v>] PR
-        # (BUILD.yaml won't reflect those until they merge).
-        gh pr list --state all --limit 400 --json title -q '.[].title' \
-          | grep -oP "^\[ray-update-${V}\] Update \K[^ ]+" | sort -u > /tmp/have_pr.txt || true
-        comm -23 /tmp/maintained.txt /tmp/have_pr.txt > /tmp/delta.txt
+        # --list is version-aware: it drops maintained entries already at $V
+        # (BUILD.yaml is the source of truth), leaving the "behind $V" set.
+        python3 ci/trigger-cursor-bump.py --all -v "$V" --list 2>/dev/null | sort -u > /tmp/delta.txt
         n="$(grep -c . /tmp/delta.txt || true)"
         echo "count=$n" >> "$GITHUB_OUTPUT"
         {
-          echo "### Ray $V fanout — $n template(s) to fire"
+          echo "### Ray $V fanout — $n template(s) behind"
           echo '```'; cat /tmp/delta.txt; echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Nothing to do
       if: steps.delta.outputs.count == '0'
-      run: echo "Every maintained template already has a bump PR for this version — nothing to fire."
+      run: echo "Every maintained template is already at this version — nothing to fire."
 
     - name: Fire the fanout
       if: steps.delta.outputs.count != '0'
@@ -101,7 +101,7 @@ jobs:
         V: ${{ steps.version.outputs.value }}
         INPUT_DRY_RUN: ${{ inputs.dry_run }}
       run: |
-        # push (a merge) fires for real; manual runs preview unless dry_run=false.
+        # A tag push fires for real; manual runs preview unless dry_run=false.
         if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_DRY_RUN" != "false" ]; then
           xargs -a /tmp/delta.txt python3 ci/trigger-cursor-bump.py -v "$V"
         else

--- a/.github/workflows/ray-bump-fanout.yaml
+++ b/.github/workflows/ray-bump-fanout.yaml
@@ -56,20 +56,13 @@ jobs:
         if [ -z "$V" ] && [ "$GITHUB_EVENT_NAME" = "push" ]; then
           V="${GITHUB_REF#refs/tags/ray-fanout-}"
         fi
-        # blank manual run: newest version with a complete base-lock set
-        if [ -z "$V" ]; then
-          printf '%s\n' dependencies/depsets/ray_*_img_*.lock | grep -oP 'ray_\K[0-9.]+(?=_img_)' | sort -u > /tmp/img.txt || true
-          printf '%s\n' dependencies/depsets/rayllm_*.lock    | grep -oP 'rayllm_\K[0-9.]+(?=_)'   | sort -u > /tmp/llm.txt || true
-          V="$(comm -12 /tmp/img.txt /tmp/llm.txt | sort -V | tail -1)"
-        fi
-        if [ -z "$V" ]; then
-          echo "::error::could not determine target Ray version"; exit 1
-        fi
-        # the version must have a complete base-lock set (both families present)
-        if ! compgen -G "dependencies/depsets/ray_${V}_img_*.lock" >/dev/null \
-          || ! compgen -G "dependencies/depsets/rayllm_${V}_*.lock" >/dev/null; then
-          echo "::error::no complete base-lock set (ray_${V}_img_* AND rayllm_${V}_*) in dependencies/depsets/"
-          exit 1
+        # ci/latest-depset-version.py validates a given version has a complete
+        # base-lock set, or derives the newest complete one; it exits non-zero
+        # (failing this step) if neither holds.
+        if [ -n "$V" ]; then
+          V="$(python3 ci/latest-depset-version.py --require "$V")"
+        else
+          V="$(python3 ci/latest-depset-version.py)"
         fi
         echo "value=$V" >> "$GITHUB_OUTPUT"
         echo "Target Ray version: $V"

--- a/.github/workflows/ray-bump-fanout.yaml
+++ b/.github/workflows/ray-bump-fanout.yaml
@@ -1,18 +1,13 @@
 name: ray-bump-fanout
 
-# Fan the per-template Ray-version bump out for a target version. The prompt lives
-# on the "Template update" Cursor automation (single source of truth); this only
-# resolves the target set and POSTs {template_name, ray_version} once per template
-# via ci/trigger-cursor-bump.py.
+# Fan the per-template Ray-version bump out. The prompt lives on the "Template
+# update" Cursor automation; this resolves the target version and POSTs
+# {template_name, ray_version} per template via ci/trigger-cursor-bump.py.
 #
-# Fire it by pushing a versioned tag `ray-fanout-<v>` — the deliberate "go". The
-# tag encodes the version and can't be re-pushed without force, so it can't
-# double-fire. Or run it manually (workflow_dispatch); manual runs preview by default.
+# Fire by pushing a `ray-fanout-<v>` tag (encodes the version; can't double-fire),
+# or run manually (workflow_dispatch — previews by default).
 #
-# Delta = maintained BUILD.yaml entries not already at <v> (the trigger script's
-# version-skip). BUILD.yaml is the single source of truth — no PR bookkeeping.
-#
-# Requires repo/org secrets: CURSOR_TEMPLATE_UPDATER_WEBHOOK, CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN.
+# Requires secrets: CURSOR_TEMPLATE_UPDATER_WEBHOOK, CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN.
 
 on:
   push:
@@ -56,9 +51,7 @@ jobs:
         if [ -z "$V" ] && [ "$GITHUB_EVENT_NAME" = "push" ]; then
           V="${GITHUB_REF#refs/tags/ray-fanout-}"
         fi
-        # ci/latest-depset-version.py validates a given version has a complete
-        # base-lock set, or derives the newest complete one; it exits non-zero
-        # (failing this step) if neither holds.
+        # validate the given version's base locks exist, else derive the newest (fails closed)
         if [ -n "$V" ]; then
           V="$(python3 ci/latest-depset-version.py --require "$V")"
         else
@@ -72,8 +65,7 @@ jobs:
       env:
         V: ${{ steps.version.outputs.value }}
       run: |
-        # --list is version-aware: it drops maintained entries already at $V
-        # (BUILD.yaml is the source of truth), leaving the "behind $V" set.
+        # version-aware --list drops entries already at $V (BUILD.yaml = source of truth)
         python3 ci/trigger-cursor-bump.py --all -v "$V" --list 2>/dev/null | sort -u > /tmp/delta.txt
         n="$(grep -c . /tmp/delta.txt || true)"
         echo "count=$n" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ray-bump-fanout.yaml
+++ b/.github/workflows/ray-bump-fanout.yaml
@@ -1,0 +1,106 @@
+name: ray-bump-fanout
+
+# Fan the per-template Ray-version bump out when a new base-lock set lands on main.
+# The prompt lives on the "Template update" Cursor automation (single source of
+# truth); this workflow only derives the target version and POSTs
+# {template_name, ray_version} once per template via ci/trigger-cursor-bump.py.
+#
+# Design:
+#   - Version is DERIVED from dependencies/depsets/ (newest version with both a
+#     ray_<v>_img_* and a rayllm_<v>_* base lock) — no signal file to maintain.
+#   - Idempotent: fires only the DELTA (maintained templates that don't already
+#     have a [ray-update-<v>] PR), so re-runs and unrelated depset commits are safe.
+#
+# Requires repo/org secrets: CURSOR_TEMPLATE_UPDATER_WEBHOOK, CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN.
+# Depends on the webhook-model trigger script (PR #842) being on main.
+
+on:
+  push:
+    branches: [main]
+    paths: ['dependencies/depsets/**']
+  workflow_dispatch:
+    inputs:
+      ray_version:
+        description: "Target Ray version (blank = derive newest complete set from dependencies/depsets/)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Preview only — no POSTs (manual runs default to preview)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ray-bump-fanout      # one fanout at a time; never double-fire
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  fanout:
+    runs-on: ubuntu-latest
+    # environment: fanout   # uncomment to require a human approval before firing
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dev deps
+      run: pip install -r requirements-dev.txt
+
+    - name: Derive target Ray version
+      id: version
+      env:
+        INPUT_VERSION: ${{ inputs.ray_version }}
+      run: |
+        V="$INPUT_VERSION"
+        if [ -z "$V" ]; then
+          # newest version present as BOTH a ray_<v>_img_* and a rayllm_<v>_* lock
+          printf '%s\n' dependencies/depsets/ray_*_img_*.lock | grep -oP 'ray_\K[0-9.]+(?=_img_)' | sort -u > /tmp/img.txt
+          printf '%s\n' dependencies/depsets/rayllm_*.lock    | grep -oP 'rayllm_\K[0-9.]+(?=_)'   | sort -u > /tmp/llm.txt
+          V="$(comm -12 /tmp/img.txt /tmp/llm.txt | sort -V | tail -1)"
+        fi
+        if [ -z "$V" ]; then
+          echo "::error::no complete base-lock set (ray_<v>_img_* AND rayllm_<v>_*) in dependencies/depsets/"
+          exit 1
+        fi
+        echo "value=$V" >> "$GITHUB_OUTPUT"
+        echo "Target Ray version: $V"
+
+    - name: Compute delta (maintained templates without a [ray-update-<v>] PR)
+      id: delta
+      env:
+        GH_TOKEN: ${{ github.token }}
+        V: ${{ steps.version.outputs.value }}
+      run: |
+        python3 ci/trigger-cursor-bump.py --all --list 2>/dev/null | sort -u > /tmp/maintained.txt
+        # template names that already have a [ray-update-<v>] PR (open/merged/closed)
+        gh pr list --state all --limit 400 --json title -q '.[].title' \
+          | grep -oP "^\[ray-update-${V}\] Update \K[^ ]+" | sort -u > /tmp/have_pr.txt || true
+        comm -23 /tmp/maintained.txt /tmp/have_pr.txt > /tmp/delta.txt
+        n="$(grep -c . /tmp/delta.txt || true)"
+        echo "count=$n" >> "$GITHUB_OUTPUT"
+        {
+          echo "### Ray $V fanout — $n template(s) to fire"
+          echo '```'; cat /tmp/delta.txt; echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Nothing to do
+      if: steps.delta.outputs.count == '0'
+      run: echo "Every maintained template already has a bump PR for this version — nothing to fire."
+
+    - name: Fire the fanout
+      if: steps.delta.outputs.count != '0'
+      env:
+        CURSOR_TEMPLATE_UPDATER_WEBHOOK: ${{ secrets.CURSOR_TEMPLATE_UPDATER_WEBHOOK }}
+        CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN: ${{ secrets.CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN }}
+        V: ${{ steps.version.outputs.value }}
+        INPUT_DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        # push (a merge) fires for real; manual runs preview unless dry_run=false.
+        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_DRY_RUN" != "false" ]; then
+          xargs -a /tmp/delta.txt python3 ci/trigger-cursor-bump.py -v "$V"
+        else
+          xargs -a /tmp/delta.txt python3 ci/trigger-cursor-bump.py -v "$V" --execute
+        fi

--- a/.github/workflows/ray-bump-fanout.yaml
+++ b/.github/workflows/ray-bump-fanout.yaml
@@ -74,8 +74,11 @@ jobs:
         GH_TOKEN: ${{ github.token }}
         V: ${{ steps.version.outputs.value }}
       run: |
-        python3 ci/trigger-cursor-bump.py --all --list 2>/dev/null | sort -u > /tmp/maintained.txt
-        # template names that already have a [ray-update-<v>] PR (open/merged/closed)
+        # --list is version-aware: it already drops templates whose BUILD.yaml is
+        # at $V (merged bumps), leaving the "behind $V" set.
+        python3 ci/trigger-cursor-bump.py --all -v "$V" --list 2>/dev/null | sort -u > /tmp/maintained.txt
+        # ...minus template names that already have an in-flight [ray-update-<v>] PR
+        # (BUILD.yaml won't reflect those until they merge).
         gh pr list --state all --limit 400 --json title -q '.[].title' \
           | grep -oP "^\[ray-update-${V}\] Update \K[^ ]+" | sort -u > /tmp/have_pr.txt || true
         comm -23 /tmp/maintained.txt /tmp/have_pr.txt > /tmp/delta.txt

--- a/ci/latest-depset-version.py
+++ b/ci/latest-depset-version.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Resolve the target Ray version for a fanout from dependencies/depsets/.
+
+The base locks there register the blessed image variants per Ray version:
+  ray_<v>_img_py<PY>.lock         (base image)
+  rayllm_<v>_py<PY>_cu<CU>.lock   (LLM image)
+A version is "complete" once both families are present. With no args this prints
+the newest complete version; with --require <v> it validates that <v> is complete
+(and echoes it). Exits non-zero with a message on stderr when there's nothing to
+resolve — so the caller can fail closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEPSETS = Path(__file__).resolve().parent.parent / "dependencies" / "depsets"
+
+
+def _versions(*patterns: str) -> set[str]:
+    rxs = [re.compile(p) for p in patterns]
+    out: set[str] = set()
+    for f in DEPSETS.glob("*.lock"):
+        for rx in rxs:
+            if m := rx.match(f.name):
+                out.add(m.group(1))
+    return out
+
+
+def complete_versions() -> set[str]:
+    """Versions present as BOTH a ray_<v>_img_* and a rayllm_<v>_* base lock
+    (the old ray_<v>_llm_* naming is also accepted for the LLM family)."""
+    img = _versions(r"ray_(\d+\.\d+\.\d+)_img_")
+    llm = _versions(r"rayllm_(\d+\.\d+\.\d+)_", r"ray_(\d+\.\d+\.\d+)_llm_")
+    return img & llm
+
+
+def _key(v: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in v.split("."))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--require", metavar="VERSION",
+        help="validate this version has a complete base-lock set (instead of deriving the newest)",
+    )
+    args = p.parse_args(argv)
+    complete = complete_versions()
+
+    if args.require:
+        if args.require not in complete:
+            print(
+                f"error: no complete base-lock set (ray_{args.require}_img_* AND "
+                f"rayllm_{args.require}_*) in dependencies/depsets/",
+                file=sys.stderr,
+            )
+            return 1
+        print(args.require)
+        return 0
+
+    if not complete:
+        print("error: no complete base-lock set in dependencies/depsets/", file=sys.stderr)
+        return 1
+    print(max(complete, key=_key))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/trigger-cursor-bump.py
+++ b/ci/trigger-cursor-bump.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -46,11 +47,24 @@ def warn(msg: str) -> None:
     print(msg, file=sys.stderr)
 
 
+def current_ray_version(entry: dict) -> str | None:
+    """The Ray version an entry currently pins — from byod.ray_version, or the
+    tag of a base image_uri (anyscale/ray[-llm]:<version>-…). None if unknown."""
+    cluster_env = entry.get("cluster_env", {})
+    if cluster_env.get("byod"):
+        return cluster_env["byod"].get("ray_version")
+    tag = cluster_env.get("image_uri", "").rsplit(":", 1)[-1]
+    m = re.match(r"(\d+\.\d+\.\d+)", tag)
+    return m.group(1) if m else None
+
+
 def resolve_templates(
-    entries: list[dict], requested: list[str], exclude: set[str]
+    entries: list[dict], requested: list[str], exclude: set[str], target_version: str
 ) -> list[str]:
     """Filter `requested` down to the launch set: drop excluded, unknown,
-    unmaintained, and duplicate names (each skip is reported to stderr)."""
+    unmaintained, already-at-`target_version`, and duplicate names (each skip is
+    reported to stderr). Skipping already-pinned entries keeps the fanout
+    idempotent — no wasted no-op agents for templates already on the target."""
     by_name = {e["name"]: e for e in entries}
     final: list[str] = []
     for name in requested:
@@ -60,6 +74,8 @@ def resolve_templates(
             warn(f"skip (not in BUILD.yaml): {name}")
         elif not by_name[name].get("maintained", True):
             warn(f"skip (maintained: false): {name}")
+        elif current_ray_version(by_name[name]) == target_version:
+            warn(f"skip (already at {target_version}): {name}")
         elif name not in final:
             final.append(name)
     return final
@@ -134,7 +150,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     exclude = {name for name in args.exclude.split(",") if name}
-    final = resolve_templates(entries, requested, exclude)
+    final = resolve_templates(entries, requested, exclude, args.ray_version)
     if not final:
         warn("error: no templates to fire after filtering")
         return 2

--- a/ci/trigger-cursor-bump.py
+++ b/ci/trigger-cursor-bump.py
@@ -151,14 +151,14 @@ def main(argv: list[str] | None = None) -> int:
 
     exclude = {name for name in args.exclude.split(",") if name}
     final = resolve_templates(entries, requested, exclude, args.ray_version)
-    if not final:
-        warn("error: no templates to fire after filtering")
-        return 2
 
-    if args.list_only:
+    if args.list_only:  # a query — an empty set is a valid answer, not an error
         warn(f"resolved {len(final)} template(s):")
         print("\n".join(final))
         return 0
+    if not final:
+        warn("error: no templates to fire after filtering")
+        return 2
 
     # SAFE BY DEFAULT: only --execute performs real POSTs; anything else previews.
     # An explicit --dry-run also wins, so a stray --execute can't override it.


### PR DESCRIPTION
Auto-fanout for a Ray version: resolve the target version, then POST `{template_name, ray_version}` to the "Template update" Cursor automation — one agent per maintained template.

## Trigger
- `git push origin ray-fanout-<v>` — fires for that version (the tag encodes it and can't be re-pushed → no double-fire).
- `workflow_dispatch` — manual; previews unless `dry_run: false`. Blank `ray_version` derives the newest complete depset set.

## Delta
`BUILD.yaml` is the source of truth: maintained entries not already at `<v>` (the trigger's version-skip). No PR bookkeeping.

## Changes
- `.github/workflows/ray-bump-fanout.yaml` — tag/dispatch trigger, thin orchestration.
- `ci/latest-depset-version.py` — resolve the target version (newest complete set, or `--require <v>`).
- `ci/trigger-cursor-bump.py` — `current_ray_version()` version-skip; `--list` exits 0 on an empty set.
- `.claude/skills/template/workflows/bump-ray-version.md` — FAST-STOP moved in, so the dashboard prompt slims to a bootstrap.

## Before it fires
Add secrets `CURSOR_TEMPLATE_UPDATER_WEBHOOK` + `CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN`, slim the dashboard prompt, merge. Dry-run first via `workflow_dispatch`.
