### PR TITLE
docs(template): add agent-team publish-fanout workflow + triage rubric

### DIFF
--- a/.claude/skills/template/SKILL.md
+++ b/.claude/skills/template/SKILL.md
@@ -17,6 +17,7 @@ Invoked bare (just `/template`) by a human — i.e. **not** the ray-bump automat
 - **Update** content/config, no Ray bump → `workflows/update-template.md`
 - **Ray-version bump** (non-interactive) → `workflows/bump-ray-version.md`
 - **Upgrade locked dependencies** (recompile depsets for a new Ray version) → `workflows/upgrade-dependencies.md`
+- **Publish a Ray-bump fanout** to prod (agent team, once the per-template bump PRs exist) → `workflows/publish-ray-bump-fanout.md`
 - **Archive** a retired or past-event template → `workflows/archive-template.md`
 
 Supporting: `references/conventions.md` · `references/dependencies.md` · `references/testing-template.md` · `references/publish-to-backend.md` · `references/run-tests-locally-with-rayapp.md` · `schemas/build-yaml-schema.yaml` · `schemas/compute-config-schema.yaml` · `.claude/skills/template/scripts/push-custom-image-to-gcp.sh`.

--- a/.claude/skills/template/references/publish-to-backend.md
+++ b/.claude/skills/template/references/publish-to-backend.md
@@ -31,13 +31,25 @@ Bold = manual gates you Unblock. **Never unblock a publish step until this pipel
    content published is set by the `tmpl-*` input fields above — latest `main`.) Init runs ~10–60s.
 2. **Unblock `input-tmpl-name`** with the three fields above.
 3. Wait `build-template` (~2–3 min) **and** `test-template` (~5–10 min, up to ~45–60 for some) →
-   passed. If `test-template` fails, `retry_job` and wait again (retry at least once before giving
-   up). Then **unblock `block-publish-dev`**.
+   passed. On any stage failure, triage per **Failure handling** below. Then **unblock `block-publish-dev`**.
 4. Wait `publish-dev` → passed (~3–5 min). **Unblock `block-publish-staging`**.
 5. Wait `publish-staging` → passed (~3–5 min). **Unblock `block-publish-production`**.
 6. Wait `publish-production` → passed (~3–5 min).
 
 **Anyscale auth errors** in `build-template` / `test-template` usually mean a prod/staging env or token mismatch — see `run-tests-locally-with-rayapp.md` "Auth errors?".
+
+## Failure handling — retry or skip?
+
+On a job reaching a terminal non-passed state at **any** stage, classify before acting — bias to **retry the ambiguous; skip only the clearly template-caused or the reproducible**:
+
+| Class | Fingerprint | Action |
+|---|---|---|
+| **Transient / infra** | Buildkite API 429/5xx, timeouts, DNS/connection reset; job `broken`, lost agent, runner disconnect; **cluster capacity** — "worker group startup timed out", "insufficient cluster resources", instance/quota-launch timeout, spot reclaim; image-pull backoff / registry 5xx; Anyscale control-plane 5xx or a one-off token-refresh blip; **≥2 templates failing at the same instant with the same error** (shared infra event) | **Retry** |
+| **Genuine** | `test-template` assertion / notebook failure that **reproduces on retry**; `build-template` failure from the template's deps or Dockerfile (depset conflict, package not found, real compile error); a publish stage where the **backend rejects** the artifact (manifest/schema invalid, missing field); a persistent auth/config error you can't fix; **any failure identical across the full retry budget** | **Skip + report** |
+
+**Retry budget** per template per stage: ~2 `retry_job` + 1 full re-trigger (a fresh build re-resolves `main` HEAD + the latest pipeline), backoff 30–60s. API/network transients (429/5xx/timeout) → just retry the call; they don't consume the budget. **Cross-template correlation wins** — several templates failing together at one moment is one infra event; retry, don't skip. (In the 2.56.0 fanout, three templates hit `exit -1` at the same instant under 49-way concurrency; a sequential re-run passed all three — capacity, not bugs.)
+
+**Skip = hand off, don't fix.** On a genuine failure, capture the failing job's log tail + build URL, record it, and move on — repairing a broken bump is a human's call (or a `../workflows/bump-ray-version.md` fix loop), out of scope for a publish run.
 
 ## Updates (re-publishing an existing template)
 

--- a/.claude/skills/template/workflows/publish-ray-bump-fanout.md
+++ b/.claude/skills/template/workflows/publish-ray-bump-fanout.md
@@ -1,0 +1,54 @@
+# Publish a Ray-bump fanout (agent team)
+
+**Audience: you are the team leader.** A human hands you a target Ray `<version>` after a bump fanout (per-template PRs, label `ray-update`). You review and land those bumps, then fan out **worker subagents** — ≤8 templates each — that drive every merged template through `tmpl-publish` to prod. Workers publish; you coordinate and report. Interactive at the edges (confirm scope, hand off failures), autonomous in between.
+
+This runs the per-template flow in `../references/publish-to-backend.md` at fleet scale — it does not restate the pipeline mechanics or its **Failure handling** rubric (retry vs. skip).
+
+## Roles & concurrency
+
+- **Leader (you):** discover → review + land → fan out → aggregate. Owns all merges and the human hand-off list.
+- **Worker** (subagent, `general-purpose`; Bash + Read + Buildkite MCP): one batch of ≤8 templates, published **sequentially**.
+- **Concurrency = parallel across workers, sequential within a worker.** Keep total in-flight builds at ~8–10. More has driven `test-template` to fail on cluster-capacity contention (worker-group startup timeouts) — spurious failures that read like template bugs. 54 templates → 7 workers → ≤7 concurrent builds, safely under the line.
+
+## 1. Discover & scope
+
+1. Inputs: target Ray `<version>` (required); optional explicit template list (default: every template bumped to `<version>` this release).
+2. `gh pr list --label ray-update --state open --search "<version>"` → the bumps to review + land. Add any already-merged `<version>` bumps the human named (the straggler case: publish-only, they skip step 2).
+3. Present the vetted plan — N to merge, M to publish, anomalies held — and get **one go-ahead** before landing or publishing. Prod is outward-facing; confirm once, then run autonomously.
+
+## 2. Review & land (leader, sequential)
+
+Per open bump PR:
+- **Triage-review the diff.** A clean bump touches only: the image (`cluster_env.image_uri` tag / BYOD `docker_image` + `ray_version`, or `Dockerfile FROM`), `templates/<name>/python_depset.lock`, `BUILD.yaml` `ray_version`, and in-template version strings — target version correct, required checks green.
+- **Anomaly** — a stray file, an unexpected edit, red CI, or a diff that doesn't read as a pure bump → **hold for the human**; never publish a bump you couldn't vet.
+- **Clean** → squash-merge **and delete the branch** (`gh pr merge --squash --delete-branch`, to keep the remote uncluttered). **Space the merges (~5s) and back off on any write error** — bulk approve+merge trips GitHub's secondary rate limit.
+
+The vetted templates are now on `main` (the pipeline publishes `main` HEAD).
+
+## 3. Fan out
+
+1. Partition the vetted templates into batches of ≤8; create a scratch results dir and note its path.
+2. Spawn `ceil(n/8)` workers with the Agent tool (`general-purpose`, background), each given: its batch, `<version>`, the results-dir path, and the **Worker contract** below.
+3. Poll the results dir for progress while they run.
+
+## 4. Worker contract
+
+Hand each worker this. It first loads the Buildkite MCP tools (deferred — `ToolSearch` "buildkite"; authenticate if prompted) and reads `../references/publish-to-backend.md` (incl. its **Failure handling** section). Then, for **each** template in its batch, **sequentially**:
+
+1. **Pre-publish review** — confirm the merged bump actually landed (`git show origin/main -- templates/<name> BUILD.yaml`): image tag → `<version>`, lock recompiled if the template ships one. Wrong → record `SKIPPED:review:<why>`, next. Never publish a bad artifact.
+2. **Publish** per `publish-to-backend.md`: trigger → unblock `input-tmpl-name` (fields) → **wait `build-template` + `test-template` pass** → dev → staging → prod. Invariant: **never unblock a publish gate before `test-template` is green.**
+3. **On any failure, any stage** → classify per **Failure handling** in `publish-to-backend.md`: transient/infra → bounded retry; genuine → capture the failing job's log tail + build URL, record `SKIPPED:<stage>:<reason>`, next template.
+4. **Record** one line per template to `<results-dir>/<name>.json` as it goes — `{status: PUBLISHED|SKIPPED, stage, reason, build_url}`. On entry, skip any template already `PUBLISHED` (idempotent resume after a kill).
+5. **Return** a compact per-template summary to the leader.
+
+Sharp edge: unblocking `input-tmpl-name` needs a *fields* payload; if the MCP can't send unblock fields, fall back to a REST `curl` (`PUT .../jobs/{id}/unblock` with `BUILDKITE_API_TOKEN`) for that one call.
+
+## 5. Aggregate & report
+
+Collect the workers' summaries (and the results dir):
+- ✅ **Published** (n)
+- ⏭️ **Skipped — needs human**: template · stage · reason · log link
+- 🔍 **Held at review**: template · anomaly (step 2)
+- Totals + wall-clock.
+
+The skipped + held lists are the human hand-off. Re-invoking is safe — already-`PUBLISHED` templates are skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Per-template tests — comment `/test-template <id> [<id>...]` (up to 3, paralle
 
 Tested vs archived — every template under `templates/` must have a `test` block (the `ci/validate_build_yaml.py` gate enforces it). Untested content lives in `archive/` (test-exempt, not built or surfaced in the gallery): *retire* a stale template, or publish an event template *without the test gate* (urgent fix). Procedures: the `/template` skill's `workflows/archive-template.md` and the "Publish without the test gate" section of `references/publish-to-backend.md`.
 
+Publish to prod — after a Ray-bump fanout, `/template`'s `workflows/publish-ray-bump-fanout.md` publishes the merged templates via a Claude agent team: a leader reviews + lands the bump PRs, then fans out worker agents (≤8 each) driving each through the `tmpl-publish` pipeline — retrying transient/infra failures, skipping genuine ones for human review. Pipeline mechanics + failure triage: `references/publish-to-backend.md`.
+
 PR labels (apply all that fit):
 - `cursor-cloud` — origin: Cursor Cloud agent.
 - `ray-update` — content: Ray version bump.


### PR DESCRIPTION
Reusable `/template` workflow for publishing a Ray-bump fanout to prod via a coordinated agent team — a leader reviews and lands the bump PRs, then fans out worker subagents (≤8 templates each) that drive `tmpl-publish` to prod, retrying transient/infra failures and skipping genuine ones for human hand-off. Generalizes the throwaway scripts from the 2.56.0 rollout; the retry-vs-skip rubric (folded into `publish-to-backend.md`) encodes that run's capacity-contention lesson.

## Testing
`pre-commit` on the changed files — passed. Docs-only skill/agent files (depset/BUILD hooks correctly skip).

https://claude.ai/code/session_019cj5edDvLEHT5v5kG8wzQW