### PR TITLE
fix(llm_batch_inference_vision): migrate to multimodal image API

### DIFF
--- a/templates/llm_batch_inference_vision/README.ipynb
+++ b/templates/llm_batch_inference_vision/README.ipynb
@@ -146,7 +146,7 @@
     "- `batch_size`: Number of requests to batch together (set to 16 for vision models).\n",
     "- `accelerator_type`: GPU type to use (L4 in this case).\n",
     "- `concurrency`: Number of parallel workers (4 in this case).\n",
-    "- `has_image`: Enable image input support.\n",
+    "- `prepare_multimodal_stage`: Enable multimodal (image) input support.\n",
     "\n",
     "Vision models process each image as hundreds or thousands of vision tokens, unlike text-only models. You can set a larger token limit using `max_model_len`. You also need to use smaller batch sizes because image processing increases per-request memory. Adjust both `max_model_len` and `batch_size` for your vision token requirements and available memory."
    ]
@@ -169,7 +169,7 @@
     "    batch_size=16,\n",
     "    accelerator_type=\"L4\",\n",
     "    concurrency=int(os.getenv(\"CONCURRENCY\", \"4\")),\n",
-    "    has_image=True,  # Enable image input.\n",
+    "    prepare_multimodal_stage=True,  # Enable multimodal (image) input.\n",
     ")\n"
    ]
   },
@@ -236,8 +236,8 @@
     "                        \"text\": \"Describe this image in detail. Focus on the main subjects, actions, and setting.\"\n",
     "                    },\n",
     "                    {\n",
-    "                        \"type\": \"image\",\n",
-    "                        \"image\": image  # Ray Data accepts PIL Image or image URL.\n",
+    "                        \"type\": \"image_pil\",\n",
+    "                        \"image_pil\": image  # PIL Image object; for a URL use {\"type\": \"image_url\", \"image_url\": {\"url\": ...}}.\n",
     "                    }\n",
     "                ]\n",
     "            },\n",
@@ -451,7 +451,7 @@
     "    batch_size=16,\n",
     "    accelerator_type=\"L4\", # Or upgrade to larger GPU\n",
     "    concurrency=10, # Increase the number of parallel workers\n",
-    "    has_image=True,  # Enable image input\n",
+    "    prepare_multimodal_stage=True,  # Enable multimodal (image) input\n",
     ")\n",
     "\n",
     "# Build the LLM processor with the configuration and functions.\n",

--- a/templates/llm_batch_inference_vision/README.md
+++ b/templates/llm_batch_inference_vision/README.md
@@ -108,7 +108,7 @@ This example uses the `Qwen/Qwen2.5-VL-3B-Instruct` model, a vision-language mod
 - `batch_size`: Number of requests to batch together (set to 16 for vision models).
 - `accelerator_type`: GPU type to use (L4 in this case).
 - `concurrency`: Number of parallel workers (4 in this case).
-- `has_image`: Enable image input support.
+- `prepare_multimodal_stage`: Enable multimodal (image) input support.
 
 Vision models process each image as hundreds or thousands of vision tokens, unlike text-only models. You can set a larger token limit using `max_model_len`. You also need to use smaller batch sizes because image processing increases per-request memory. Adjust both `max_model_len` and `batch_size` for your vision token requirements and available memory.
 
@@ -126,7 +126,7 @@ processor_config = vLLMEngineProcessorConfig(
     batch_size=16,
     accelerator_type="L4",
     concurrency=int(os.getenv("CONCURRENCY", "4")),
-    has_image=True,  # Enable image input.
+    prepare_multimodal_stage=True,  # Enable multimodal (image) input.
 )
 
 ```
@@ -180,8 +180,8 @@ def preprocess(row: dict[str, Any]) -> dict[str, Any]:
                         "text": "Describe this image in detail. Focus on the main subjects, actions, and setting."
                     },
                     {
-                        "type": "image",
-                        "image": image  # Ray Data accepts PIL Image or image URL.
+                        "type": "image_pil",
+                        "image_pil": image  # PIL Image object; for a URL use {"type": "image_url", "image_url": {"url": ...}}.
                     }
                 ]
             },
@@ -343,7 +343,7 @@ processor_config_large = vLLMEngineProcessorConfig(
     batch_size=16,
     accelerator_type="L4", # Or upgrade to larger GPU
     concurrency=10, # Increase the number of parallel workers
-    has_image=True,  # Enable image input
+    prepare_multimodal_stage=True,  # Enable multimodal (image) input
 )
 
 # Build the LLM processor with the configuration and functions.

--- a/templates/llm_batch_inference_vision/batch_inference_vision.py
+++ b/templates/llm_batch_inference_vision/batch_inference_vision.py
@@ -41,7 +41,7 @@ processor_config = vLLMEngineProcessorConfig(
     batch_size=16,
     accelerator_type="L4",
     concurrency=4,
-    has_image=True,  # Enable image input.
+    prepare_multimodal_stage=True,  # Enable multimodal (image) input.
 )
 
 
@@ -78,8 +78,8 @@ def preprocess(row: dict[str, Any]) -> dict[str, Any]:
                         "text": "Describe this image in detail. Focus on the main subjects, actions, and setting."
                     },
                     {
-                        "type": "image",
-                        "image": image  # Ray Data accepts PIL Image or image URL.
+                        "type": "image_pil",
+                        "image_pil": image  # PIL Image object; for a URL use {"type": "image_url", "image_url": {"url": ...}}.
                     }
                 ]
             },

--- a/templates/llm_batch_inference_vision/batch_inference_vision_scaled.py
+++ b/templates/llm_batch_inference_vision/batch_inference_vision_scaled.py
@@ -36,7 +36,7 @@ processor_config_large = vLLMEngineProcessorConfig(
     batch_size=16,
     accelerator_type="L4", # Or upgrade to larger GPU
     concurrency=10, # Increase the number of parallel workers
-    has_image=True,  # Enable image input
+    prepare_multimodal_stage=True,  # Enable multimodal (image) input
 )
 
 
@@ -73,8 +73,8 @@ def preprocess(row: dict[str, Any]) -> dict[str, Any]:
                         "text": "Describe this image in detail. Focus on the main subjects, actions, and setting."
                     },
                     {
-                        "type": "image",
-                        "image": image  # Ray Data accepts PIL Image or image URL.
+                        "type": "image_pil",
+                        "image_pil": image  # PIL Image object; for a URL use {"type": "image_url", "image_url": {"url": ...}}.
                     }
                 ]
             },


### PR DESCRIPTION
Migrates `llm_batch_inference_vision` off the legacy per-image batch API removed/deprecated in ray-project/ray#63570 (`has_image` → `prepare_multimodal_stage`; message content `{"type": "image", "image": img}` → `{"type": "image_pil", "image_pil": img}`). The `"image"` message form warns as of #63570 and is removed in Ray 2.58.0; the template runs on Ray 2.56.0, which already ships the multimodal API. Addresses the upstream review note: https://github.com/ray-project/ray/pull/63570#discussion_r3279467506

## Caveats
- Originally scoped two templates; `ray-data-llm` was deleted in #769, so only this one remains. `README.md` is regenerated from `README.ipynb` (enforced by the `check-readme` hook).

## Testing
- `/test-template llm_batch_inference_vision` — Buildkite GPU (L4) run, dispatched below.
- Local: pre-commit green (incl. `check-readme` nbconvert match); grep confirms no legacy API refs remain.

https://claude.ai/code/session_012ynJSHPAPfgkwG5eBUkKE2
