### PR TITLE
docs(skills/template): add runtime dep-skew guidance

### DIFF
--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -14,8 +14,33 @@ ray.init(runtime_env={"pip": os.path.join(DEMO_ROOT, "python_depset.lock"), ...}
 ```
 
 `--system` covers only the driver; **workers get the deps solely via `runtime_env`** — omit it and they
-silently run whatever the image shipped. The lock must also match the Ray version baked into the image; a
-bump that moves the image without recompiling the lock desyncs them (`../workflows/bump-ray-version.md`).
+silently run whatever the image shipped. That `ray.init` env reaches Ray Core/Data workers (tasks/actors)
+but **not Ray Serve replicas** — serve/LLM templates must declare deps at the Serve app/deployment level
+(see "Runtime skew" below). The lock must also match the Ray version baked into the image; a bump that
+moves the image without recompiling the lock desyncs them (`../workflows/bump-ray-version.md`).
+
+## Runtime skew — right scope, don't move the base framework
+
+The `expand` lock **layers on** the base image's env; it must not *re-resolve down* a package the image's
+managed runtime imports (`ray`, `fastapi`, `starlette`, `pydantic`, `vllm`, `torch`). An unpinned dep can
+drag one **below** the image version — which passes CI and the publish "Test template" step (there
+everything co-locates on the head), then dies on a real multi-node launch, where a Serve replica or actor
+lands on a worker still on the image version and cross-node deserialization fails (classic:
+`ModuleNotFoundError: fastapi._compat.may_v1`). Only `ray` is `--unsafe-package`-protected today.
+
+**Author guidance, not a gate — you own your `requirements.txt`.** But heed it:
+
+- **The base framework stack is ground truth.** Prefer to leave those packages at the image version; to
+  hold one, pin it *to* that version in `requirements.txt`. Downgrading one is on you to keep consistent
+  cluster-wide.
+- **Deliver *added* deps at the right scope.** `ray.init(runtime_env=)` reaches Ray Core/Data workers but
+  **not Serve replicas**; declare a serve/LLM template's added deps on the Serve **app-level** `runtime_env`
+  (or `@serve.deployment(ray_actor_options={"runtime_env": …})`), never a head-only `--system` install.
+- **A genuine conflict → isolate it.** An added package that hard-pins a clashing version (e.g. `a2a-sdk`
+  forcing an old `fastapi`) goes in *its own* deployment's `runtime_env` — the LLM ingress keeps the image
+  framework; only that deployment gets the pin.
+- **Image = system deps only.** Bake apt/CUDA/`.so` into a custom image (custom-GCP case); never add a pip
+  layer there to dodge a lock conflict — that hides the same skew on another axis.
 
 ## The tool: `raydepsets`
 
@@ -89,8 +114,9 @@ Ray's published locks/constraints into `/tmp/ray-deps/`, with fallbacks for rele
 1. Edit `templates/<name>/requirements.txt`.
 2. Regenerate its lock: `./update_deps.sh --name <its-entry>` (see "Running it").
 3. Confirm the template installs the regenerated lock on the driver **and** forwards it via `runtime_env`
-   (see "What ships") — otherwise workers keep running stale deps.
-4. Pin the traps below.
+   at the right scope (Serve → app/deployment level; see "What ships" + "Runtime skew") — otherwise
+   workers/replicas keep running stale deps.
+4. Check the lock didn't drag a base-framework package below the image ("Runtime skew"); pin the traps below.
 
 ## Gotchas
 

--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -116,7 +116,8 @@ Ray's published locks/constraints into `/tmp/ray-deps/`, with fallbacks for rele
 3. Confirm the template installs the regenerated lock on the driver **and** forwards it via `runtime_env`
    at the right scope (Serve → app/deployment level; see "What ships" + "Runtime skew") — otherwise
    workers/replicas keep running stale deps.
-4. Check the lock didn't drag a base-framework package below the image ("Runtime skew"); pin the traps below.
+4. Check the lock didn't drag a base-framework package below the image ("Runtime skew"), and that `torch`'s
+   CUDA still matches the build image ("Gotchas"); pin the traps below.
 
 ## Gotchas
 
@@ -128,4 +129,9 @@ Ray's published locks/constraints into `/tmp/ray-deps/`, with fallbacks for rele
 - **Un-pinned floats.** `--system` installs float `numpy` to 2.x → pin `numpy`/`pandas`/`pyarrow` to the base
   image. Un-pinned `datasets` resolves to ancient `2.14.4` and breaks modern `fsspec` → pin `datasets==3.6.0`
   + `fsspec==2023.12.1` in `requirements.txt`.
+- **Torch CUDA must match the build image.** A template's `torch` (+ `torchvision`/`torchaudio`) must be
+  built for the image's `CUDA_VARIANT`. Write `--index https://download.pytorch.org/whl/${CUDA_VARIANT}`
+  (never a hardcoded `cu121`) so the index tracks the image, and **pin** `torch==<ver>` to a version that
+  ships wheels for that CUDA — an unpinned `torch>=…` lets `unsafe-best-match` pull PyPI's newest wheel, a
+  *newer* CUDA than the image, which fails at runtime. Fleet standard: `torch==2.7.0` → `+cu128`.
 - **Upstream lag:** Ray's `deplocks/` and base images publish days after a release; a bump waits on them.

--- a/.claude/skills/template/workflows/create-template.md
+++ b/.claude/skills/template/workflows/create-template.md
@@ -21,7 +21,7 @@ Interview the user; explain each piece when you reach it. Collect:
 
 Move the content into `templates/<name>/`. For a notebook template, the main notebook **is** `README.ipynb` (the test runs it; `README.md` is its rendered copy — README convention in `../references/conventions.md`); scripts and Dockerfiles sit alongside it.
 
-**Dependencies.** If the template pins deps via a `python_depset.lock` (most do — system in `../references/dependencies.md`), drop its `requirements.txt` into `templates/<name>/` and add a per-template `expand` entry to `dependencies/template.depsets.yaml` (`source_depset` = the base lock for the template's image, `build_arg_sets` = the matching `ray<ver>_py<XX>` bundle). Compile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean. A stock-image template with only `!pip` installs needs no lock.
+**Dependencies.** If the template pins deps via a `python_depset.lock` (most do — system in `../references/dependencies.md`), drop its `requirements.txt` into `templates/<name>/` and add a per-template `expand` entry to `dependencies/template.depsets.yaml` (`source_depset` = the base lock for the template's image, `build_arg_sets` = the matching `ray<ver>_py<XX>` bundle). Compile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean. A stock-image template with only `!pip` installs needs no lock. **Serve/LLM template, or adding a dep that could move the image's framework (`fastapi`/`starlette`/`pydantic`/`vllm`/`torch`)?** Read `../references/dependencies.md` "Runtime skew" first — the wrong delivery scope or a downgraded framework passes tests but dies on the real multi-node launch.
 
 ## 3. BUILD.yaml entry
 

--- a/.claude/skills/template/workflows/update-template.md
+++ b/.claude/skills/template/workflows/update-template.md
@@ -10,7 +10,7 @@ Ask which template (`<name>`) and what's changing — notebook/code, compute con
 
 Edit files under `templates/<name>/` (and `configs/<name>/` or `tests/<name>/` as needed). Author README content in `README.ipynb` (README convention in `../references/conventions.md`). If the change touches the image: identify the case in SKILL.md "Image URI cases" (for custom-GCP, rebuild and push via `.claude/skills/template/scripts/push-custom-image-to-gcp.sh`). For a Ray-**version** bump specifically, use `bump-ray-version.md` — it owns the full per-case bump procedure.
 
-**Dependency change** (add/remove/repin a package in a template that ships a `python_depset.lock`): edit `templates/<name>/requirements.txt`, then recompile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean. System + gotchas: `../references/dependencies.md`. This is *not* a Ray-version bump; recompiling **all** depsets for a new Ray version is `upgrade-dependencies.md`.
+**Dependency change** (add/remove/repin a package in a template that ships a `python_depset.lock`): edit `templates/<name>/requirements.txt`, then recompile its lock — `./update_deps.sh --name <the entry's name>` — and confirm `./update_deps.sh --check` is clean. System + gotchas: `../references/dependencies.md`. Serve/LLM template, or moving a base-framework package (`fastapi`/`starlette`/`pydantic`/…)? Heed "Runtime skew" there — the wrong delivery scope or a downgraded framework passes tests but fails on the real multi-node launch. This is *not* a Ray-version bump; recompiling **all** depsets for a new Ray version is `upgrade-dependencies.md`.
 
 ## 3. Format
 


### PR DESCRIPTION
The `/template` skill documented build-time depsets but nothing on **runtime** dependency skew — the class keeping `template-probe` red (a template downgrades a base-image framework, or ships added deps head-only; both pass CI + the publish test where everything co-locates on the head, then fail on a real multi-node launch). Adds a "Runtime skew" section and wires it into the create/update dependency steps.

## What changed
- New "Runtime skew" rules: right delivery scope (Serve app/deployment level, not head-only `--system`), don't downgrade a framework the managed runtime imports (`fastapi`/`starlette`/`pydantic`/`vllm`/`torch`), isolate genuine conflicts per-deployment, image = system deps only.
- Fixes the worker snippet that implied `ray.init(runtime_env=)` reaches Serve replicas.

## Testing
Docs-only; pre-commit hooks pass.

## Caveats
PR 1 of 4 in the dependency-skew plan — guidance, not enforcement. Template fixes and compute-config test==launch follow.
