### PR TITLE
fix(langchain-agent-ray-serve): pin fastapi/starlette to base image

### DIFF
--- a/templates/langchain-agent-ray-serve/python_depset.lock
+++ b/templates/langchain-agent-ray-serve/python_depset.lock
@@ -307,9 +307,9 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via openai
-fastapi==0.121.0 \
-    --hash=sha256:06663356a0b1ee93e875bbf05a31fb22314f5bed455afaaad2b2dad7f26e98fa \
-    --hash=sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106
+fastapi==0.133.0 \
+    --hash=sha256:0a78878483d60702a1dde864c24ab349a1a53ef4db6b6f74f8cd4a2b2bc67d2f \
+    --hash=sha256:b900a2bf5685cdb0647a41d5900bdeafc3a9e8a28ac08c6246b76699e164d60d
     # via -r templates/langchain-agent-ray-serve/requirements.txt
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -1150,10 +1150,11 @@ sse-starlette==3.0.3 \
     --hash=sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971 \
     --hash=sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431
     # via mcp
-starlette==0.49.3 \
-    --hash=sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284 \
-    --hash=sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f
+starlette==1.0.1 \
+    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
+    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
     # via
+    #   -r templates/langchain-agent-ray-serve/requirements.txt
     #   fastapi
     #   mcp
 tenacity==9.1.4 \
@@ -1243,6 +1244,7 @@ typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via
+    #   fastapi
     #   mcp
     #   pydantic
     #   pydantic-settings

--- a/templates/langchain-agent-ray-serve/requirements.txt
+++ b/templates/langchain-agent-ray-serve/requirements.txt
@@ -1,5 +1,7 @@
 # Core dependencies
-fastapi
+# Match the ray-llm base image; build_openai_app is built against these (a downgrade breaks multi-node).
+fastapi==0.133.0
+starlette==1.0.1
 langchain
 langchain-mcp-adapters
 langchain-openai


### PR DESCRIPTION
The langchain template's `requirements.txt` listed a bare `fastapi`, letting the depset resolver downgrade the base-image framework (fastapi 0.133.0 → 0.121.0, starlette 1.0.1 → 0.49.3). The `build_openai_app` LLM ingress is built against the image's fastapi, so on a real multi-node launch it crashed with `ModuleNotFoundError: fastapi._compat.may_v1` — the `template-probe` failure the single-node publish test never caught.

## What changed
- Pin `fastapi==0.133.0` + `starlette==1.0.1` (ray-llm 2.56.0 image versions) and recompile the lock.
- langchain / langgraph / mcp / openai unchanged — they resolve against the image framework, so the downgrade was never needed.

## Testing
`./update_deps.sh --name langchain_agent_ray_serve_depset_2.56.0_3.12` recompiles cleanly; only fastapi + starlette move (to the image versions). Full multi-node validation is the `template-probe` re-run.

## Caveats
PR 2 of the dependency-skew plan. `multi_agent_a2a` has the same class via a genuine `a2a-sdk` conflict — separate PR 2b (isolation).
