### PR TITLE
fix(multi_agent_a2a): pin fastapi/starlette to base image

### DIFF
--- a/templates/multi_agent_a2a/python_depset.lock
+++ b/templates/multi_agent_a2a/python_depset.lock
@@ -5,6 +5,10 @@ a2a-sdk==0.3.22 \
     --hash=sha256:77a5694bfc4f26679c11b70c7f1062522206d430b34bc1215cfbb1eba67b7e7d \
     --hash=sha256:b98701135bb90b0ff85d35f31533b6b7a299bf810658c1c65f3814a6c15ea385
     # via -r templates/multi_agent_a2a/requirements.txt
+annotated-doc==0.0.4 \
+    --hash=sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320 \
+    --hash=sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4
+    # via fastapi
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
@@ -315,9 +319,9 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via openai
-fastapi==0.115.12 \
-    --hash=sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681 \
-    --hash=sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d
+fastapi==0.133.0 \
+    --hash=sha256:0a78878483d60702a1dde864c24ab349a1a53ef4db6b6f74f8cd4a2b2bc67d2f \
+    --hash=sha256:b900a2bf5685cdb0647a41d5900bdeafc3a9e8a28ac08c6246b76699e164d60d
     # via
     #   -r templates/multi_agent_a2a/requirements.txt
     #   a2a-sdk
@@ -1408,10 +1412,11 @@ sse-starlette==3.0.3 \
     # via
     #   a2a-sdk
     #   mcp
-starlette==0.46.2 \
-    --hash=sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35 \
-    --hash=sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5
+starlette==1.0.1 \
+    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
+    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
     # via
+    #   -r templates/multi_agent_a2a/requirements.txt
     #   a2a-sdk
     #   fastapi
     #   mcp
@@ -1496,11 +1501,13 @@ typing-extensions==4.15.0 \
     #   pydantic
     #   pydantic-core
     #   referencing
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via
+    #   fastapi
     #   mcp
     #   pydantic
     #   pydantic-settings

--- a/templates/multi_agent_a2a/requirements.txt
+++ b/templates/multi_agent_a2a/requirements.txt
@@ -1,5 +1,7 @@
 # Core dependencies
-fastapi==0.115.12
+# Match the ray-llm base image; build_openai_app is built against these (a downgrade breaks multi-node).
+fastapi==0.133.0
+starlette==1.0.1
 langchain==1.0.5
 langchain-mcp-adapters==0.1.12
 langchain-openai==1.0.2


### PR DESCRIPTION
`multi_agent_a2a`'s `requirements.txt` pinned `fastapi==0.115.12`, which (with `unsafe-best-match`) also dragged starlette to 0.46.2 — below the ray-llm base image (fastapi 0.133.0 / starlette 1.0.1). The `build_openai_app` LLM app (`runtime_env: {}`) inherited that downgrade and crashed on multi-node launches, the same class as #906.

The `a2a-sdk` "conflict" turned out not to be one: `a2a-sdk[http-server]==0.3.22` declares `fastapi>=0.115.2` and unbounded `starlette`, so it resolves cleanly against the image versions. The old pin was defensive, not required — no isolation needed.

## What changed
- Pin `fastapi==0.133.0` + `starlette==1.0.1` (image versions) and recompile the lock.
- a2a-sdk / protobuf / langchain / langgraph / mcp unchanged; only fastapi + starlette move (plus `annotated-doc`, a fastapi 0.133 transitive dep).

## Testing
`./update_deps.sh --name multi_agent_a2a_depset_2.56.0_3.12_cu130` recompiles cleanly. Note: starlette jumps 0.46 → 1.0 (major) for a2a-sdk — its metadata allows it and the base image ships 1.0.1, but the a2a template suite (`tests/test_a2a.py`, `test_agents_sse.py`) + the `template-probe` re-run are the runtime confirmation.

## Caveats
PR 2b of the dependency-skew plan (companion to #906). If the a2a suite surfaces a real starlette-1.0 runtime break, the fallback is per-app `runtime_env` isolation for the a2a deployments.
