### PR TITLE
fix(configs): pin head unschedulable — intro/general (batch 1)

### DIFF
--- a/configs/basic-single-node/aws.yaml
+++ b/configs/basic-single-node/aws.yaml
@@ -1,3 +1,5 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 auto_select_worker_config: true

--- a/configs/basic-single-node/gce.yaml
+++ b/configs/basic-single-node/gce.yaml
@@ -1,3 +1,5 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 auto_select_worker_config: true

--- a/configs/getting-started/aws.yaml
+++ b/configs/getting-started/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: cpu_worker
   instance_type: m5.2xlarge

--- a/configs/getting-started/gce.yaml
+++ b/configs/getting-started/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: cpu_worker
   instance_type: n2-standard-8

--- a/configs/intro-ray-libraries/aws.yaml
+++ b/configs/intro-ray-libraries/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 4xT4:48CPU-192GB
   instance_type: g4dn.12xlarge

--- a/configs/intro-ray-libraries/gce.yaml
+++ b/configs/intro-ray-libraries/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n1-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 4xT4:16CPU-60GB
   instance_type: n1-standard-16-nvidia-t4-16gb-4

--- a/configs/ray-summit-core-masterclass/aws.yaml
+++ b/configs/ray-summit-core-masterclass/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.4xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:16CPU-64GB
   instance_type: g6.4xlarge

--- a/configs/ray-summit-core-masterclass/gce.yaml
+++ b/configs/ray-summit-core-masterclass/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-16
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:16CPU-64GB
   instance_type: g2-standard-16-nvidia-l4-1


### PR DESCRIPTION
Pins the head node unschedulable (`resources: {CPU: 0}`) in the aws + gce compute configs. These configs have worker groups or auto_select, so the head is a coordinator, not a work node: the launch-time conversion injects this when the field is absent, so setting it explicitly makes the repo config equal what ships to S3 (and `rayapp test` reproduces the real worker placement instead of co-locating on a schedulable head). Heads are CPU-only instances, so `CPU: 0` alone is unschedulable. Config-only.

Templates: getting-started, intro-ray-libraries, ray-summit-core-masterclass, basic-single-node

## Testing
Validated green via `/test-template` (Buildkite). The earlier `CPU: 0, GPU: 0` → `CPU: 0` normalization is a no-op on CPU-only heads (identical Ray resources), so not re-tested.

Part of the head-unschedulable sweep; a companion check (#924) enforces this policy repo-wide.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD