### PR TITLE
fix(configs): pin head unschedulable — ray-data (batch 2)

### DIFF
--- a/configs/biotech_protein_embeddings/aws.yaml
+++ b/configs/biotech_protein_embeddings/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g5.xlarge

--- a/configs/biotech_protein_embeddings/gce.yaml
+++ b/configs/biotech_protein_embeddings/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g2-standard-8-nvidia-l4-1

--- a/configs/ecommerce_batch_embeddings/aws.yaml
+++ b/configs/ecommerce_batch_embeddings/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g4dn.xlarge

--- a/configs/ecommerce_batch_embeddings/gce.yaml
+++ b/configs/ecommerce_batch_embeddings/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1

--- a/configs/llm_batch_inference_text/aws.yaml
+++ b/configs/llm_batch_inference_text/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:8CPU-32GB
   instance_type: g6.2xlarge

--- a/configs/llm_batch_inference_text/gce.yaml
+++ b/configs/llm_batch_inference_text/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:8CPU-32GB
   instance_type: g2-standard-8-nvidia-l4-1

--- a/configs/llm_batch_inference_vision/aws.yaml
+++ b/configs/llm_batch_inference_vision/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:8CPU-32GB
   instance_type: g6.2xlarge

--- a/configs/llm_batch_inference_vision/gce.yaml
+++ b/configs/llm_batch_inference_vision/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:8CPU-32GB
   instance_type: g2-standard-8-nvidia-l4-1


### PR DESCRIPTION
Pins the head node unschedulable (`resources: {CPU: 0}`) in the aws + gce compute configs. These configs have worker groups or auto_select, so the head is a coordinator, not a work node: the launch-time conversion injects this when the field is absent, so setting it explicitly makes the repo config equal what ships to S3 (and `rayapp test` reproduces the real worker placement instead of co-locating on a schedulable head). Heads are CPU-only instances, so `CPU: 0` alone is unschedulable. Config-only.

Templates: llm_batch_inference_text, llm_batch_inference_vision, ecommerce_batch_embeddings, biotech_protein_embeddings

## Testing
Validated green via `/test-template` (Buildkite). The earlier `CPU: 0, GPU: 0` → `CPU: 0` normalization is a no-op on CPU-only heads (identical Ray resources), so not re-tested.

Part of the head-unschedulable sweep; a companion check (#924) enforces this policy repo-wide.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD