### PR TITLE
fix(configs): pin head unschedulable — ray-data (batch 3)

### DIFF
--- a/configs/audio-dataset-curation-llm-judge/aws.yaml
+++ b/configs/audio-dataset-curation-llm-judge/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g6.4xlarge

--- a/configs/audio-dataset-curation-llm-judge/gce.yaml
+++ b/configs/audio-dataset-curation-llm-judge/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n1-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g2-standard-16

--- a/configs/e2e-timeseries-forecasting/aws.yaml
+++ b/configs/e2e-timeseries-forecasting/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 4xT4:48CPU-192GB
   instance_type: g4dn.12xlarge

--- a/configs/e2e-timeseries-forecasting/gce.yaml
+++ b/configs/e2e-timeseries-forecasting/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n1-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 4xT4:16CPU-60GB
   instance_type: n1-standard-16-nvidia-t4-16gb-4

--- a/configs/unstructured_data_ingestion/aws.yaml
+++ b/configs/unstructured_data_ingestion/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 8CPU-32GB
   instance_type: m5.2xlarge

--- a/configs/unstructured_data_ingestion/gce.yaml
+++ b/configs/unstructured_data_ingestion/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n1-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 8CPU-32GB
   instance_type: n1-standard-8

--- a/configs/vhol-ray-data/aws.yaml
+++ b/configs/vhol-ray-data/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g5.xlarge

--- a/configs/vhol-ray-data/gce.yaml
+++ b/configs/vhol-ray-data/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g2-standard-4-nvidia-l4-1


### PR DESCRIPTION
Pins the head node unschedulable (`resources: {CPU: 0}`) in the aws + gce compute configs. These configs have worker groups or auto_select, so the head is a coordinator, not a work node: the launch-time conversion injects this when the field is absent, so setting it explicitly makes the repo config equal what ships to S3 (and `rayapp test` reproduces the real worker placement instead of co-locating on a schedulable head). Heads are CPU-only instances, so `CPU: 0` alone is unschedulable. Config-only.

Templates: unstructured_data_ingestion, vhol-ray-data, audio-dataset-curation-llm-judge, e2e-timeseries-forecasting

## Testing
Validated green via `/test-template` (Buildkite). The earlier `CPU: 0, GPU: 0` → `CPU: 0` normalization is a no-op on CPU-only heads (identical Ray resources), so not re-tested.

Part of the head-unschedulable sweep; a companion check (#924) enforces this policy repo-wide.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD