### PR TITLE
fix(configs): pin head unschedulable — train (batch 4)

### DIFF
--- a/configs/deepspeed_finetune/aws.yaml
+++ b/configs/deepspeed_finetune/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:8CPU-32GB
   instance_type: g6.2xlarge

--- a/configs/deepspeed_finetune/gce.yaml
+++ b/configs/deepspeed_finetune/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: g2-standard-8-nvidia-l4-1

--- a/configs/distributing-pytorch/aws.yaml
+++ b/configs/distributing-pytorch/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
-  instance_type: g4dn.xlarge
+  instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g4dn.12xlarge

--- a/configs/distributing-pytorch/gce.yaml
+++ b/configs/distributing-pytorch/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
-  instance_type: n1-standard-8-nvidia-tesla-t4-1
+  instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-tesla-t4-4

--- a/configs/pytorch-fsdp/aws.yaml
+++ b/configs/pytorch-fsdp/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xT4:4CPU-16GB
   instance_type: g4dn.xlarge

--- a/configs/pytorch-fsdp/gce.yaml
+++ b/configs/pytorch-fsdp/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1

--- a/configs/ray_train_workloads/aws.yaml
+++ b/configs/ray_train_workloads/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g5.4xlarge

--- a/configs/ray_train_workloads/gce.yaml
+++ b/configs/ray_train_workloads/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: a2-highgpu-1g

--- a/templates/distributing-pytorch/README.ipynb
+++ b/templates/distributing-pytorch/README.ipynb
@@ -38,7 +38,9 @@
    "source": [
     "## Step 1: Start with a basic single machine PyTorch example\n",
     "\n",
-    "In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine. Note that the code has multiple functions to highlight the changes needed to run things with Ray.\n",
+    "In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine (one GPU). Note that the code has multiple functions to highlight the changes needed to run things with Ray.\n",
+    "\n",
+    "Because the head node is a CPU-only coordinator, you run this single-machine example on a GPU worker by submitting it as a Ray task that requests one GPU. Steps 2 and 3 then distribute training across many workers with Ray Train and Ray Data.\n",
     "\n",
     "First, install and import the required Python modules."
    ]
@@ -203,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, run training."
+    "Finally, run training. The head node is a CPU-only coordinator, so submit `train_func` as a Ray task requesting one GPU (`num_gpus=1`); Ray schedules it on a GPU worker, where `torch.cuda` is available."
    ]
   },
   {
@@ -212,7 +214,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_func()"
+    "train_on_gpu_worker = ray.remote(num_gpus=1)(train_func)\n",
+    "ray.get(train_on_gpu_worker.remote())"
    ]
   },
   {

--- a/templates/distributing-pytorch/README.md
+++ b/templates/distributing-pytorch/README.md
@@ -22,7 +22,9 @@ git clone https://github.com/anyscale/templates && cd templates/templates/distri
 
 ## Step 1: Start with a basic single machine PyTorch example
 
-In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine. Note that the code has multiple functions to highlight the changes needed to run things with Ray.
+In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine (one GPU). Note that the code has multiple functions to highlight the changes needed to run things with Ray.
+
+Because the head node is a CPU-only coordinator, you run this single-machine example on a GPU worker by submitting it as a Ray task that requests one GPU. Steps 2 and 3 then distribute training across many workers with Ray Train and Ray Data.
 
 First, install and import the required Python modules.
 
@@ -151,11 +153,12 @@ def train_func():
         print({"epoch_num": epoch, "loss": valid_loss, "accuracy": accuracy})
 ```
 
-Finally, run training.
+Finally, run training. The head node is a CPU-only coordinator, so submit `train_func` as a Ray task requesting one GPU (`num_gpus=1`); Ray schedules it on a GPU worker, where `torch.cuda` is available.
 
 
 ```python
-train_func()
+train_on_gpu_worker = ray.remote(num_gpus=1)(train_func)
+ray.get(train_on_gpu_worker.remote())
 ```
 
 The training should take about 2 minutes and 10 seconds with an accuracy of about 0.35.  


### PR DESCRIPTION
Pins the head unschedulable (`CPU: 0`) for the batch-4 train templates. `deepspeed_finetune`, `pytorch-fsdp`, `ray_train_workloads` have CPU-only heads. `distributing-pytorch`'s head was a GPU instance only so its Step-1 single-machine baseline could use a local GPU — switch it to a CPU-only coordinator and run Step 1 on a GPU worker via a Ray task.

## Testing
`/test-template` on all four (distributing-pytorch's notebook refactor validated on GPU CI, buildkite #533 as #922 + re-run here).

## Notes
distributing-pytorch was briefly standalone (#922, now closed); folded back to keep batch 4 in one PR.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD
