### PR TITLE
fix(configs): pin head unschedulable — train (batch 5)

### DIFF
--- a/configs/creatives_diffusion_finetuning/aws.yaml
+++ b/configs/creatives_diffusion_finetuning/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g4dn.xlarge

--- a/configs/creatives_diffusion_finetuning/gce.yaml
+++ b/configs/creatives_diffusion_finetuning/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1

--- a/configs/finetune-stable-diffusion/aws.yaml
+++ b/configs/finetune-stable-diffusion/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g5.2xlarge

--- a/configs/finetune-stable-diffusion/gce.yaml
+++ b/configs/finetune-stable-diffusion/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n1-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g2-standard-8

--- a/configs/tensor_parallel_autotp/aws.yaml
+++ b/configs/tensor_parallel_autotp/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 4xT4:48CPU-192GB
   instance_type: g4dn.12xlarge

--- a/configs/tensor_parallel_autotp/gce.yaml
+++ b/configs/tensor_parallel_autotp/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-32-nvidia-t4-16gb-4

--- a/configs/vla-fine-tuning/aws.yaml
+++ b/configs/vla-fine-tuning/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: l4-worker
   instance_type: g6.4xlarge

--- a/configs/vla-fine-tuning/gce.yaml
+++ b/configs/vla-fine-tuning/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: l4-worker
   instance_type: g2-standard-16-nvidia-l4-1


### PR DESCRIPTION
Pins the head node unschedulable (`resources: {CPU: 0}`) in the aws + gce compute configs. These configs have worker groups or auto_select, so the head is a coordinator, not a work node: the launch-time conversion injects this when the field is absent, so setting it explicitly makes the repo config equal what ships to S3 (and `rayapp test` reproduces the real worker placement instead of co-locating on a schedulable head). Heads are CPU-only instances, so `CPU: 0` alone is unschedulable. Config-only.

Templates: creatives_diffusion_finetuning, finetune-stable-diffusion, tensor_parallel_autotp, vla-fine-tuning

## Testing
Validated green via `/test-template` (Buildkite). The earlier `CPU: 0, GPU: 0` → `CPU: 0` normalization is a no-op on CPU-only heads (identical Ray resources), so not re-tested.

Part of the head-unschedulable sweep; a companion check (#924) enforces this policy repo-wide.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD