### PR TITLE
fix(configs): pin head unschedulable — train/tune (batch 6)

### DIFF
--- a/configs/pytorch-profiling/aws.yaml
+++ b/configs/pytorch-profiling/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xT4:4CPU-16GB
   instance_type: g4dn.xlarge

--- a/configs/pytorch-profiling/gce.yaml
+++ b/configs/pytorch-profiling/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1

--- a/configs/ray-tune-train-integration/aws.yaml
+++ b/configs/ray-tune-train-integration/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g6.4xlarge

--- a/configs/ray-tune-train-integration/gce.yaml
+++ b/configs/ray-tune-train-integration/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g2-standard-16-nvidia-l4-1

--- a/configs/tensor_parallel_dtensor/aws.yaml
+++ b/configs/tensor_parallel_dtensor/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 4xT4:48CPU-192GB
   instance_type: g4dn.12xlarge

--- a/configs/tensor_parallel_dtensor/gce.yaml
+++ b/configs/tensor_parallel_dtensor/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-32-nvidia-t4-16gb-4

--- a/configs/tune_pytorch_asha/aws.yaml
+++ b/configs/tune_pytorch_asha/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g5.4xlarge

--- a/configs/tune_pytorch_asha/gce.yaml
+++ b/configs/tune_pytorch_asha/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: a2-highgpu-1g


### PR DESCRIPTION
Pins the head node unschedulable (`resources: {CPU: 0}`) in the aws + gce compute configs. These configs have worker groups or auto_select, so the head is a coordinator, not a work node: the launch-time conversion injects this when the field is absent, so setting it explicitly makes the repo config equal what ships to S3 (and `rayapp test` reproduces the real worker placement instead of co-locating on a schedulable head). Heads are CPU-only instances, so `CPU: 0` alone is unschedulable. Config-only.

Templates: tensor_parallel_dtensor, ray-tune-train-integration, tune_pytorch_asha, pytorch-profiling

## Testing
Validated green via `/test-template` (Buildkite). The earlier `CPU: 0, GPU: 0` → `CPU: 0` normalization is a no-op on CPU-only heads (identical Ray resources), so not re-tested.

Part of the head-unschedulable sweep; a companion check (#924) enforces this policy repo-wide.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD