### PR TITLE
fix(configs): pin head unschedulable — serve/CV (batch 7)

### DIFF
--- a/configs/ecommerce_multi_model_serving/aws.yaml
+++ b/configs/ecommerce_multi_model_serving/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g4dn.xlarge

--- a/configs/ecommerce_multi_model_serving/gce.yaml
+++ b/configs/ecommerce_multi_model_serving/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: n1-standard-8-nvidia-t4-16gb-1

--- a/configs/image-search-and-classification/aws.yaml
+++ b/configs/image-search-and-classification/aws.yaml
@@ -1,4 +1,6 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 enable_cross_zone_scaling: true
 auto_select_worker_config: true

--- a/configs/image-search-and-classification/gce.yaml
+++ b/configs/image-search-and-classification/gce.yaml
@@ -1,4 +1,6 @@
 head_node:
   instance_type: n1-standard-8
+  resources:
+    CPU: 0
 enable_cross_zone_scaling: true
 auto_select_worker_config: true

--- a/configs/multi_agent_a2a/aws.yaml
+++ b/configs/multi_agent_a2a/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:16CPU-64GB
   instance_type: g6.4xlarge

--- a/configs/multi_agent_a2a/gce.yaml
+++ b/configs/multi_agent_a2a/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: 1xL4:16CPU-64GB
   instance_type: g2-standard-16-nvidia-l4-1

--- a/configs/object-detection-video-processing/aws.yaml
+++ b/configs/object-detection-video-processing/aws.yaml
@@ -1,7 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
   resources:
-    CPU: 8
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g4dn.xlarge

--- a/configs/object-detection-video-processing/gce.yaml
+++ b/configs/object-detection-video-processing/gce.yaml
@@ -1,7 +1,7 @@
 head_node:
   instance_type: n2-standard-8
   resources:
-    CPU: 8
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: n1-highcpu-4-nvidia-t4-16gb-1


### PR DESCRIPTION
Pins the head unschedulable (`CPU: 0`) for batch-7: `ecommerce_multi_model_serving`, `image-search-and-classification`, `multi_agent_a2a`, and `object-detection-video-processing` — which previously ran CPU video re-encoding on an explicit `CPU: 8` head, now `CPU: 0` so that work lands on the GPU workers.

## Testing
`/test-template` (object-detection validated on GPU CI, buildkite #534 as #923 + re-run here).

## Notes
object-detection was briefly standalone (#923, now closed); folded back here. multi_agent_a2a's fastapi pin is #907.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD
