### PR TITLE
fix(configs): pin head unschedulable — vertical (batch 8)

### DIFF
--- a/configs/biotech_boltz_screening/aws.yaml
+++ b/configs/biotech_boltz_screening/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g5.2xlarge

--- a/configs/biotech_boltz_screening/gce.yaml
+++ b/configs/biotech_boltz_screening/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g2-standard-8-nvidia-l4-1

--- a/configs/entity-recognition-with-llms/aws.yaml
+++ b/configs/entity-recognition-with-llms/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker-4xL4
   instance_type: g6.12xlarge

--- a/configs/entity-recognition-with-llms/gce.yaml
+++ b/configs/entity-recognition-with-llms/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker-4xL4
   instance_type: g2-standard-48

--- a/configs/fintech_fraud_risk/aws.yaml
+++ b/configs/fintech_fraud_risk/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.4xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: cpu-worker
   instance_type: m5.4xlarge

--- a/configs/fintech_fraud_risk/gce.yaml
+++ b/configs/fintech_fraud_risk/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-16
+  resources:
+    CPU: 0
 worker_nodes:
 - name: cpu-worker
   instance_type: n2-standard-16

--- a/configs/fintech_quant/aws.yaml
+++ b/configs/fintech_quant/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: cpu-worker
   instance_type: m5.2xlarge

--- a/configs/fintech_quant/gce.yaml
+++ b/configs/fintech_quant/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: cpu-worker
   instance_type: n2-standard-8


### PR DESCRIPTION
Pins the head node unschedulable (`resources: {CPU: 0}`) in the aws + gce compute configs. These configs have worker groups or auto_select, so the head is a coordinator, not a work node: the launch-time conversion injects this when the field is absent, so setting it explicitly makes the repo config equal what ships to S3 (and `rayapp test` reproduces the real worker placement instead of co-locating on a schedulable head). Heads are CPU-only instances, so `CPU: 0` alone is unschedulable. Config-only.

Templates: biotech_boltz_screening, entity-recognition-with-llms, fintech_fraud_risk, fintech_quant

## Testing
Validated green via `/test-template` (Buildkite). The earlier `CPU: 0, GPU: 0` → `CPU: 0` normalization is a no-op on CPU-only heads (identical Ray resources), so not re-tested.

Part of the head-unschedulable sweep; a companion check (#924) enforces this policy repo-wide.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD