### PR TITLE
fix(templates): deliver added deps via runtime_env (audio, e2e-timeseries, image-search)

### DIFF
--- a/templates/audio-dataset-curation-llm-judge/README.ipynb
+++ b/templates/audio-dataset-curation-llm-judge/README.ipynb
@@ -7,11 +7,11 @@
     "# Audio batch inference\n",
     "\n",
     "<div align=\"left\">\n",
-    "  <a target=\"_blank\" href=\"https://console.anyscale.com/template-preview/audio-dataset-curation-llm-judge\"><img src=\"https://img.shields.io/badge/\ud83d\ude80 Run_on-Anyscale-9hf\"></a>&nbsp;\n",
+    "  <a target=\"_blank\" href=\"https://console.anyscale.com/template-preview/audio-dataset-curation-llm-judge\"><img src=\"https://img.shields.io/badge/🚀 Run_on-Anyscale-9hf\"></a>&nbsp;\n",
     "  <a href=\"https://github.com/anyscale/templates/tree/main/templates/audio-dataset-curation-llm-judge\" role=\"button\"><img src=\"https://img.shields.io/static/v1?label=&message=View%20On%20GitHub&color=586069&logo=github&labelColor=2f363d\"></a>&nbsp;\n",
     "</div>\n",
     "\n",
-    "**\u23f1\ufe0f Time to complete**: 30 min\n",
+    "**⏱️ Time to complete**: 30 min\n",
     "\n",
     "This tutorial demonstrates a batch inference pipeline that converts raw\n",
     "audio files into a curated subset using two different ML models.\n",
@@ -21,7 +21,7 @@
     "2. Resample each clip to 16 kHz for compatibility with Whisper.\n",
     "3. Transcribe the audio with the `openai/whisper-large-v3-turbo` model.\n",
     "4. Judge the educational quality of each transcription with a small Llama-3 model.\n",
-    "5. Persist only clips that score \u2265 3 to a Parquet dataset.\n",
+    "5. Persist only clips that score ≥ 3 to a Parquet dataset.\n",
     "\n",
     "Ray Data is particularly powerful for this use case because it:\n",
     "- **Parallelizes work** across a cluster of machines automatically\n",
@@ -72,6 +72,15 @@
     "\n",
     "TRANSCRIPTION_MODEL = \"openai/whisper-tiny\"\n",
     "JUDGE_MODEL = \"unsloth/Meta-Llama-3.1-8B-Instruct\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ray.init(runtime_env={\"pip\": os.path.join(os.getcwd(), \"python_depset.lock\")})"
    ]
   },
   {
@@ -280,7 +289,7 @@
     "## LLM-based quality filter\n",
     "\n",
     "A Llama-3 model serves as a *machine judge* that scores each transcription\n",
-    "from 1 \ud83d\udc4e to 5 \ud83d\udc4d on its educational value. The **LLM Processor** API wraps the heavy\n",
+    "from 1 👎 to 5 👍 on its educational value. The **LLM Processor** API wraps the heavy\n",
     "lifting of batching, prompt formatting, and vLLM engine interaction using a declarative API style.\n",
     "\n",
     "Ray Data provides a high-level API for integrating LLMs into data pipelines. The preprocessing and postprocessing functions handle data preparation and result parsing."

--- a/templates/audio-dataset-curation-llm-judge/README.md
+++ b/templates/audio-dataset-curation-llm-judge/README.md
@@ -56,6 +56,11 @@ TRANSCRIPTION_MODEL = "openai/whisper-tiny"
 JUDGE_MODEL = "unsloth/Meta-Llama-3.1-8B-Instruct"
 ```
 
+
+```python
+ray.init(runtime_env={"pip": os.path.join(os.getcwd(), "python_depset.lock")})
+```
+
 ## Streaming data ingestion
 
 `ray.data.read_parquet` reads the records lazily **and** distributes them across the cluster.

--- a/templates/e2e-timeseries-forecasting/e2e_timeseries/01-Distributed-Training.ipynb
+++ b/templates/e2e-timeseries-forecasting/e2e_timeseries/01-Distributed-Training.ipynb
@@ -91,7 +91,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ray.init(runtime_env={\"py_modules\": [e2e_timeseries]})"
+    "TEMPLATE_ROOT = os.path.dirname(os.path.dirname(e2e_timeseries.__file__))\n",
+    "ray.init(runtime_env={\n",
+    "    \"py_modules\": [e2e_timeseries],\n",
+    "    \"pip\": os.path.join(TEMPLATE_ROOT, \"python_depset.lock\"),\n",
+    "})"
    ]
   },
   {

--- a/templates/e2e-timeseries-forecasting/e2e_timeseries/02-Validation.ipynb
+++ b/templates/e2e-timeseries-forecasting/e2e_timeseries/02-Validation.ipynb
@@ -103,7 +103,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ray.init(runtime_env={\"py_modules\": [e2e_timeseries]})"
+    "TEMPLATE_ROOT = os.path.dirname(os.path.dirname(e2e_timeseries.__file__))\n",
+    "ray.init(runtime_env={\n",
+    "    \"py_modules\": [e2e_timeseries],\n",
+    "    \"pip\": os.path.join(TEMPLATE_ROOT, \"python_depset.lock\"),\n",
+    "})"
    ]
   },
   {

--- a/templates/e2e-timeseries-forecasting/e2e_timeseries/03-Serving.ipynb
+++ b/templates/e2e-timeseries-forecasting/e2e_timeseries/03-Serving.ipynb
@@ -86,7 +86,11 @@
     "import e2e_timeseries\n",
     "from e2e_timeseries.model import DLinear\n",
     "\n",
-    "ray.init(runtime_env={\"py_modules\": [e2e_timeseries]})"
+    "TEMPLATE_ROOT = os.path.dirname(os.path.dirname(e2e_timeseries.__file__))\n",
+    "ray.init(runtime_env={\n",
+    "    \"py_modules\": [e2e_timeseries],\n",
+    "    \"pip\": os.path.join(TEMPLATE_ROOT, \"python_depset.lock\"),\n",
+    "})"
    ]
   },
   {

--- a/templates/image-search-and-classification/configs/generate_embeddings.yaml
+++ b/templates/image-search-and-classification/configs/generate_embeddings.yaml
@@ -6,7 +6,7 @@ name: image-batch-embeddings
 # like anyscale/ray:2.43.0-slim-py312-cu125, a user-provided base image (provided
 # that it meets certain specs), or you can build new images using the Anyscale
 # image builder at https://console.anyscale-staging.com/v2/container-images.
-image_uri:  anyscale/ray:2.51.0-slim-py312-cu128
+image_uri:  anyscale/ray:2.56.0-slim-py312-cu128
 # containerfile: /home/ray/default/containerfile
 
 # When empty, Anyscale will auto-select the instance types. You can also specify
@@ -48,7 +48,7 @@ excludes: # (Optional) List of files to exclude from being packaged up for the j
 requirements: # (Optional) List of requirements files to install. Can also be a path to a requirements.txt.
     - ipywidgets==8.1.3
     - matplotlib==3.10.0
-    - mlflow==2.19.0
+    - mlflow==2.22.0
     - torch==2.7.1
     - transformers==4.52.3
     - scikit-learn==1.6.0

--- a/templates/image-search-and-classification/configs/service.yaml
+++ b/templates/image-search-and-classification/configs/service.yaml
@@ -6,7 +6,7 @@ name: doggos-app
 # like anyscale/ray:2.43.0-slim-py312-cu125, a user-provided base image (provided
 # that it meets certain specs), or you can build new images using the Anyscale
 # image builder at https://console.anyscale-staging.com/v2/container-images.
-image_uri:  anyscale/ray:2.51.0-slim-py312-cu128
+image_uri:  anyscale/ray:2.56.0-slim-py312-cu128
 # containerfile: /home/ray/default/containerfile
 
 # When empty, Anyscale will auto-select the instance types. You can also specify
@@ -48,7 +48,7 @@ excludes: # (Optional) List of files to exclude from being packaged up for the j
 requirements: # (Optional) List of requirements files to install. Can also be a path to a requirements.txt.
     - ipywidgets==8.1.3
     - matplotlib==3.10.0
-    - mlflow==2.19.0
+    - mlflow==2.22.0
     - torch==2.7.1
     - transformers==4.52.3
     - scikit-learn==1.6.0

--- a/templates/image-search-and-classification/configs/train_model.yaml
+++ b/templates/image-search-and-classification/configs/train_model.yaml
@@ -6,7 +6,7 @@ name: train-image-model
 # like anyscale/ray:2.43.0-slim-py312-cu125, a user-provided base image (provided
 # that it meets certain specs), or you can build new images using the Anyscale
 # image builder at https://console.anyscale-staging.com/v2/container-images.
-image_uri:  anyscale/ray:2.51.0-slim-py312-cu128
+image_uri:  anyscale/ray:2.56.0-slim-py312-cu128
 # containerfile: /home/ray/default/containerfile
 
 # When empty, Anyscale will auto-select the instance types. You can also specify
@@ -48,7 +48,7 @@ excludes: # (Optional) List of files to exclude from being packaged up for the j
 requirements: # (Optional) List of requirements files to install. Can also be a path to a requirements.txt.
     - ipywidgets==8.1.3
     - matplotlib==3.10.0
-    - mlflow==2.19.0
+    - mlflow==2.22.0
     - torch==2.7.1
     - transformers==4.52.3
     - scikit-learn==1.6.0

--- a/templates/image-search-and-classification/containerfile
+++ b/templates/image-search-and-classification/containerfile
@@ -14,4 +14,4 @@ FROM anyscale/ray:2.56.0-slim-py312-cu128
 # RUN echo "Testing Ray import..." && python -c "import ray"
 RUN python3 -m pip install --no-cache-dir \
     "matplotlib==3.10.0" "torch==2.7.1" "transformers==4.52.3" \
-    "scikit-learn==1.6.0" "mlflow==2.19.0" "ipywidgets==8.1.3"
+    "scikit-learn==1.6.0" "mlflow==2.22.0" "ipywidgets==8.1.3"


### PR DESCRIPTION
Wire added deps to workers/replicas via runtime_env so the standalone Service/Job path matches the workspace (per the /template skill Runtime skew guidance, #905). Part of the dependency good-practice pass.

## What changed
- audio-dataset-curation-llm-judge: add ray.init(runtime_env={pip: lock}) — it had none, so the resample UDF + Whisper/Llama actors got deps only via workspace auto-propagation.
- e2e-timeseries-forecasting (3 notebooks): add pip:lock to the existing runtime_env (was py_modules only), anchored to the package file.
- image-search-and-classification: version currency only (Ray 2.51→2.56, mlflow 2.19→2.22 across 3 configs + containerfile); ship-path deps already correctly scoped.
- numpy pin deferred to the in-flight migrate-to-multimodal branch.

## Testing
/test-template on the three templates. Note: /test-template runs the workspace path (auto-propagation covers it), so it won't fully exercise the standalone Service/Job path these fixes improve.