### PR TITLE
test(mcp-500): repro — head-pin + NO fix [DO NOT MERGE]

### DIFF
--- a/configs/basic-single-node/aws.yaml
+++ b/configs/basic-single-node/aws.yaml
@@ -1,3 +1,6 @@
 head_node:
   instance_type: m5.2xlarge
+  resources:
+    CPU: 0
+    GPU: 0
 auto_select_worker_config: true

--- a/configs/basic-single-node/gce.yaml
+++ b/configs/basic-single-node/gce.yaml
@@ -1,3 +1,6 @@
 head_node:
   instance_type: n2-standard-8
+  resources:
+    CPU: 0
+    GPU: 0
 auto_select_worker_config: true


### PR DESCRIPTION
**Validation branch — DO NOT MERGE (delete after).** Head-pins basic-single-node (the config mcp-ray-serve uses) so /test-template forces the mcp replica onto a worker — reproducing the probe's placement — WITHOUT the pydantic fix. Expected: FAIL with the head-vs-replica pydantic skew (the MCP-500 mechanism). Paired with the control PR (head-pin + fix) to prove the hypothesis.