### PR TITLE
ci(ray-bump): gate base-locks to minor Ray bumps (skip patches)

### DIFF
--- a/.github/workflows/ray-base-locks.yaml
+++ b/.github/workflows/ray-base-locks.yaml
@@ -8,6 +8,10 @@ name: ray-base-locks
 # this workflow opens a PR. A human reviews + merges it (the approval gate), then
 # pushes a `ray-fanout-<v>` tag to fire ray-bump-fanout.yaml.
 #
+# Minor-only: on the daily schedule it acts only on a new Ray *minor* (patches over the
+# current minor, e.g. 2.56.0 → 2.56.1, are skipped). To force a specific version anyway
+# (incl. a patch), dispatch this workflow with the `ray_version` input set (→ --version).
+#
 # If Ray shipped a different py/cuda matrix, the script stops with 'needs human'
 # (rc=2) and a maintainer runs .claude/skills/template/workflows/upgrade-dependencies.md.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,9 @@ repos:
         language: system
         pass_filenames: false
         files: ^BUILD\.yaml$
+      - id: ray-bump-unit-tests
+        name: prepare-base-locks unit tests (minor-only gate)
+        entry: python3 scripts/ray-bump/test_prepare_base_locks.py
+        language: system
+        pass_filenames: false
+        files: ^scripts/ray-bump/(prepare-base-locks|test_prepare_base_locks)\.py$

--- a/scripts/ray-bump/prepare-base-locks.py
+++ b/scripts/ray-bump/prepare-base-locks.py
@@ -10,6 +10,13 @@ yet, edits `dependencies/template.depsets.yaml` to add the version's
 `build_arg_sets` + wire them into the two base `compile` entries, then recompiles
 just those locks via `update_deps.sh`, leaving the changes staged for a PR.
 
+Version policy (minor-only): on the scheduled/auto path it acts only when the newest
+stable Ray advances the *minor* (or major) over our newest complete set — templates
+track minor Ray releases (~monthly), so a patch over the current minor (2.56.0 →
+2.56.1) is a no-op. A new minor adopts its newest patch (2.57.z, not forced 2.57.0).
+An explicit `--version` (or `--force`) bypasses the gate — a human override for a
+specific target.
+
 Copy-forward model: it clones the current newest-complete version's base-lock
 matrix (the image's Python set, the LLM's (py, cuda) set), substituting the new
 version, and verifies Ray published the matching deplocks at the `ray-<v>` tag. It
@@ -74,6 +81,11 @@ def compact(v: str) -> str:
     return v.replace(".", "")
 
 
+def _ver(s: str) -> tuple[int, ...]:
+    """Version string → int tuple for ordering (e.g. '2.56.1' → (2, 56, 1))."""
+    return tuple(int(x) for x in s.split("."))
+
+
 # ── upstream / repo state ──────────────────────────────────────────────────
 
 
@@ -87,7 +99,7 @@ def newest_stable_ray() -> str:
             stable.append(v)
     if not stable:
         raise RuntimeError("no stable ray release found on PyPI")
-    return max(stable, key=lambda s: tuple(int(x) for x in s.split(".")))
+    return max(stable, key=_ver)
 
 
 def _lock_versions(*patterns: str) -> set[str]:
@@ -112,7 +124,16 @@ def complete_versions() -> set[str]:
 
 def newest_complete() -> str | None:
     c = complete_versions()
-    return max(c, key=lambda s: tuple(int(x) for x in s.split("."))) if c else None
+    return max(c, key=_ver) if c else None
+
+
+def is_minor_upgrade(target: str, current: str | None) -> bool:
+    """Whether `target` advances (major, minor) beyond `current` — the only case the
+    scheduled path auto-prepares. Patch-only bumps (same major.minor) and versions
+    behind `current` return False; a missing `current` (bootstrap) returns True."""
+    if current is None:
+        return True
+    return _ver(target)[:2] > _ver(current)[:2]
 
 
 # ── Ray deplock discovery (what matrix did upstream actually ship?) ─────────
@@ -243,6 +264,17 @@ def main(argv: list[str] | None = None) -> int:
         log(f"error: bad version {target!r}")
         return 2
     log(f"Target Ray version: {target}")
+
+    # Minor-only gate (scheduled/auto path): templates track minor Ray releases, so a
+    # patch over the current minor (e.g. 2.56.0 → 2.56.1) shouldn't open a base-locks PR.
+    # An explicit --version (or --force) bypasses this — a human targeting a specific release.
+    if not args.version and not args.force:
+        current = newest_complete()
+        if not is_minor_upgrade(target, current):
+            log(f"Ray {target} is not a new minor over {current} "
+                "(templates track minor Ray releases; --version overrides) — nothing to do.")
+            set_output(status="skipped-patch", version=target)
+            return 0
 
     if target in complete_versions() and not args.force:
         log("Already have a complete base-lock set — nothing to do.")

--- a/scripts/ray-bump/test_prepare_base_locks.py
+++ b/scripts/ray-bump/test_prepare_base_locks.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Unit tests for prepare-base-locks.py — the minor-only version gate.
+
+Hermetic: mocks the two version-resolution funcs (newest_stable_ray = PyPI,
+newest_complete = local depsets), so nothing touches the network or the real
+dependencies/depsets/. The prepare path (which loads the config via ruamel) is
+stubbed with _yaml, so these tests need neither ruamel nor the real config —
+matching CI's pre-commit job, which installs requirements-dev.txt (no ruamel).
+
+Run directly: python3 scripts/ray-bump/test_prepare_base_locks.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+# The script's filename has hyphens, so load it by path rather than import.
+_MODULE_PATH = Path(__file__).with_name("prepare-base-locks.py")
+_spec = importlib.util.spec_from_file_location("prepare_base_locks", _MODULE_PATH)
+pbl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pbl)
+
+
+class _ReachedPrepare(Exception):
+    """Stands in for _yaml() to prove main() got past the gate into the prepare
+    body without needing ruamel or the real config."""
+
+
+def _run_main(argv, **returns):
+    """Run pbl.main(argv) with the named funcs patched to return `returns[name]`,
+    _yaml stubbed to raise _ReachedPrepare, and GITHUB_OUTPUT captured.
+
+    Returns (rc, reached, outputs): rc is main()'s exit code (None if it reached
+    the prepare body), reached is True iff it got there, outputs is the parsed
+    GITHUB_OUTPUT dict.
+    """
+    with tempfile.NamedTemporaryFile("w+", suffix=".out") as out, contextlib.ExitStack() as stack:
+        stack.enter_context(patch.dict(os.environ, {"GITHUB_OUTPUT": out.name}))
+        for name, val in returns.items():
+            stack.enter_context(patch.object(pbl, name, Mock(return_value=val)))
+        stack.enter_context(patch.object(pbl, "_yaml", Mock(side_effect=_ReachedPrepare)))
+        try:
+            rc, reached = pbl.main(argv), False
+        except _ReachedPrepare:
+            rc, reached = None, True
+        out.seek(0)
+        outputs = dict(ln.split("=", 1) for ln in out.read().splitlines() if "=" in ln)
+    return rc, reached, outputs
+
+
+class MinorUpgradeTest(unittest.TestCase):
+    """The pure gate decision."""
+
+    def test_patch_over_current_minor_is_not_an_upgrade(self):
+        self.assertFalse(pbl.is_minor_upgrade("2.56.1", "2.56.0"))
+
+    def test_new_minor_is_an_upgrade(self):
+        self.assertTrue(pbl.is_minor_upgrade("2.57.0", "2.56.0"))
+        self.assertTrue(pbl.is_minor_upgrade("2.57.2", "2.56.0"))
+
+    def test_new_major_is_an_upgrade(self):
+        self.assertTrue(pbl.is_minor_upgrade("3.0.0", "2.56.0"))
+
+    def test_same_version_is_not_an_upgrade(self):
+        self.assertFalse(pbl.is_minor_upgrade("2.56.0", "2.56.0"))
+
+    def test_behind_current_is_not_an_upgrade(self):
+        self.assertFalse(pbl.is_minor_upgrade("2.55.9", "2.56.0"))
+
+    def test_bootstrap_no_current_is_an_upgrade(self):
+        self.assertTrue(pbl.is_minor_upgrade("2.56.0", None))
+
+
+class MainGateTest(unittest.TestCase):
+    """The gate as wired into main() (scheduled/auto path vs --version bypass)."""
+
+    def test_auto_patch_bump_is_a_noop(self):
+        # current 2.56.0, PyPI newest 2.56.1 (patch) -> skip, rc=0.
+        rc, reached, out = _run_main([], newest_stable_ray="2.56.1", newest_complete="2.56.0")
+        self.assertEqual(rc, 0)
+        self.assertFalse(reached)
+        self.assertEqual(out.get("status"), "skipped-patch")
+
+    def test_auto_already_current_is_a_noop(self):
+        # current 2.56.0, PyPI newest 2.56.0 -> not ahead, rc=0.
+        rc, reached, _ = _run_main([], newest_stable_ray="2.56.0", newest_complete="2.56.0")
+        self.assertEqual(rc, 0)
+        self.assertFalse(reached)
+
+    def test_auto_new_minor_proceeds(self):
+        # current 2.56.0, PyPI newest 2.57.0 -> proceeds into the prepare body.
+        _, reached, _ = _run_main(
+            [], newest_stable_ray="2.57.0", newest_complete="2.56.0", complete_versions={"2.56.0"}
+        )
+        self.assertTrue(reached)
+
+    def test_auto_new_minor_adopts_newest_patch(self):
+        # current 2.56.0, PyPI newest 2.57.2 -> proceeds targeting 2.57.2 (not forced .0).
+        _, reached, _ = _run_main(
+            [], newest_stable_ray="2.57.2", newest_complete="2.56.0", complete_versions={"2.56.0"}
+        )
+        self.assertTrue(reached)
+
+    def test_explicit_version_bypasses_gate_for_patch(self):
+        # --version 2.56.1 (patch over 2.56.0) still proceeds — human override.
+        _, reached, _ = _run_main(
+            ["--version", "2.56.1"], newest_complete="2.56.0", complete_versions={"2.56.0"}
+        )
+        self.assertTrue(reached)
+
+    def test_force_bypasses_gate_for_patch(self):
+        # --force (no --version) also proceeds past the gate on a patch bump.
+        _, reached, _ = _run_main(
+            ["--force"], newest_stable_ray="2.56.1", newest_complete="2.56.0", complete_versions={"2.56.0"}
+        )
+        self.assertTrue(reached)
+
+
+class NewestStableRayTest(unittest.TestCase):
+    """newest_stable_ray picks the max final release (the newest minor's newest patch)."""
+
+    def test_picks_newest_patch_of_newest_minor(self):
+        payload = {
+            "releases": {
+                "2.56.0": [{"yanked": False}],
+                "2.56.1": [{"yanked": False}],
+                "2.57.0": [{"yanked": False}],
+                "2.57.1": [{"yanked": False}],
+                "2.57.2": [{"yanked": False}],
+                "2.58.0rc1": [{"yanked": False}],  # non-final: ignored by the X.Y.Z regex
+                "2.99.0": [{"yanked": True}],       # fully yanked: ignored
+            }
+        }
+
+        class _Resp:
+            def __enter__(self_):
+                return self_
+
+            def __exit__(self_, *a):
+                return False
+
+            def read(self_):
+                return json.dumps(payload).encode()
+
+        with patch.object(pbl.urllib.request, "urlopen", return_value=_Resp()):
+            self.assertEqual(pbl.newest_stable_ray(), "2.57.2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`prepare-base-locks.py` picked the newest PyPI Ray `X.Y.Z` with no minor gate, so patch **2.56.1** (over our complete 2.56.0) opened base-locks PR #904. Templates track minor Ray releases (~monthly), not patch churn — this gates the scheduled path to minor/major bumps and no-ops patches.

## Behavior
- Scheduled/auto path prepares only when the target advances `(major, minor)` over the newest complete depset. A patch over the current minor → `rc=0`, no recompile, no PR. A new minor still adopts its newest patch (`2.57.z`, not forced `.0`).
- `--version` / `--force` bypass the gate — human override for a specific target.

## Testing
- New hermetic unit test (13 cases, stdlib `unittest`, no network/ruamel), wired into pre-commit so premerge runs it.
- Real `--dry-run`: newest 2.56.1 vs complete 2.56.0 → "nothing to do", `rc=0`, no config diff. `--version 2.56.1 --dry-run` → still plans the matrix-forward diff (bypass works).
