### PR TITLE
fix(distributing-pytorch): CPU-only unschedulable head; run Step 1 on a GPU worker

### DIFF
--- a/configs/distributing-pytorch/aws.yaml
+++ b/configs/distributing-pytorch/aws.yaml
@@ -1,5 +1,7 @@
 head_node:
-  instance_type: g4dn.xlarge
+  instance_type: m5.2xlarge
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu-worker
   instance_type: g4dn.12xlarge

--- a/configs/distributing-pytorch/gce.yaml
+++ b/configs/distributing-pytorch/gce.yaml
@@ -1,5 +1,7 @@
 head_node:
-  instance_type: n1-standard-8-nvidia-tesla-t4-1
+  instance_type: n2-standard-8
+  resources:
+    CPU: 0
 worker_nodes:
 - name: gpu_worker
   instance_type: n1-standard-8-nvidia-tesla-t4-4

--- a/templates/distributing-pytorch/README.ipynb
+++ b/templates/distributing-pytorch/README.ipynb
@@ -38,7 +38,9 @@
    "source": [
     "## Step 1: Start with a basic single machine PyTorch example\n",
     "\n",
-    "In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine. Note that the code has multiple functions to highlight the changes needed to run things with Ray.\n",
+    "In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine (one GPU). Note that the code has multiple functions to highlight the changes needed to run things with Ray.\n",
+    "\n",
+    "Because the head node is a CPU-only coordinator, you run this single-machine example on a GPU worker by submitting it as a Ray task that requests one GPU. Steps 2 and 3 then distribute training across many workers with Ray Train and Ray Data.\n",
     "\n",
     "First, install and import the required Python modules."
    ]
@@ -203,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, run training."
+    "Finally, run training. The head node is a CPU-only coordinator, so submit `train_func` as a Ray task requesting one GPU (`num_gpus=1`); Ray schedules it on a GPU worker, where `torch.cuda` is available."
    ]
   },
   {
@@ -212,7 +214,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_func()"
+    "# The head node is a CPU-only coordinator with no GPU. Submit the single-machine\n",
+    "# training as a Ray task requesting one GPU so Ray runs it on a GPU worker node.\n",
+    "train_on_gpu_worker = ray.remote(num_gpus=1)(train_func)\n",
+    "ray.get(train_on_gpu_worker.remote())"
    ]
   },
   {

--- a/templates/distributing-pytorch/README.md
+++ b/templates/distributing-pytorch/README.md
@@ -22,7 +22,9 @@ git clone https://github.com/anyscale/templates && cd templates/templates/distri
 
 ## Step 1: Start with a basic single machine PyTorch example
 
-In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine. Note that the code has multiple functions to highlight the changes needed to run things with Ray.
+In this step you train a PyTorch VisionTransformer model to recognize objects using the open CIFAR-10 dataset. It's a minimal example that trains on a single machine (one GPU). Note that the code has multiple functions to highlight the changes needed to run things with Ray.
+
+Because the head node is a CPU-only coordinator, you run this single-machine example on a GPU worker by submitting it as a Ray task that requests one GPU. Steps 2 and 3 then distribute training across many workers with Ray Train and Ray Data.
 
 First, install and import the required Python modules.
 
@@ -151,11 +153,14 @@ def train_func():
         print({"epoch_num": epoch, "loss": valid_loss, "accuracy": accuracy})
 ```
 
-Finally, run training.
+Finally, run training. The head node is a CPU-only coordinator, so submit `train_func` as a Ray task requesting one GPU (`num_gpus=1`); Ray schedules it on a GPU worker, where `torch.cuda` is available.
 
 
 ```python
-train_func()
+# The head node is a CPU-only coordinator with no GPU. Submit the single-machine
+# training as a Ray task requesting one GPU so Ray runs it on a GPU worker node.
+train_on_gpu_worker = ray.remote(num_gpus=1)(train_func)
+ray.get(train_on_gpu_worker.remote())
 ```
 
 The training should take about 2 minutes and 10 seconds with an accuracy of about 0.35.  


### PR DESCRIPTION
The head node was a GPU instance (g4dn.xlarge / T4) only so the Step-1 single-machine example could use a local GPU on the driver — a schedulable "work on the head" head, which this sweep eliminates. The head is now a CPU-only coordinator (`resources: {CPU: 0}`) and Step 1 runs on a GPU worker via a Ray task (`num_gpus=1`); Steps 2-3 already train on the GPU workers via Ray Train.

## Testing
Local: `validate-build-yaml` (schema), `check-readme`, `nbconvert`, `check-image-urls` all pass. GPU CI via `/test-template distributing-pytorch` (dispatched on this PR).

## Caveats
Part of the head-unschedulable sweep — merge alongside/after the batch head-pin PRs (#908–#915).

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD
