### PR TITLE
fix(object-detection-video-processing): pin head unschedulable (CPU: 0)

### DIFF
--- a/configs/object-detection-video-processing/aws.yaml
+++ b/configs/object-detection-video-processing/aws.yaml
@@ -1,7 +1,7 @@
 head_node:
   instance_type: m5.2xlarge
   resources:
-    CPU: 8
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: g4dn.xlarge

--- a/configs/object-detection-video-processing/gce.yaml
+++ b/configs/object-detection-video-processing/gce.yaml
@@ -1,7 +1,7 @@
 head_node:
   instance_type: n2-standard-8
   resources:
-    CPU: 8
+    CPU: 0
 worker_nodes:
 - name: gpu-workers
   instance_type: n1-highcpu-4-nvidia-t4-16gb-1


### PR DESCRIPTION
The head had explicit `resources: {CPU: 8}` — a schedulable head, the pattern this sweep removes. Now `CPU: 0`: the head is a coordinator, Ray tasks and the Serve ingress land on the GPU workers, and the notebook driver's video re-encoding still runs on the head as a non-Ray process.

## Testing
`/test-template object-detection-video-processing` (dispatched on this PR). Local `validate-build-yaml` schema check passes.

## Caveats
Part of the head-unschedulable sweep. Only remaining config that carried explicit non-zero head resources.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD
