### PR TITLE
fix(templates): don't hardcode an Anyscale-internal cloud in public template configs

### DIFF
--- a/templates/creatives_diffusion_finetuning/job_config.yaml
+++ b/templates/creatives_diffusion_finetuning/job_config.yaml
@@ -2,7 +2,6 @@ name: sd-lora-finetuning
 entrypoint: python scripts/run_training.py --num-workers 2 --num-epochs 3
 image_uri: anyscale/ray:2.56.0-py311-cu128
 compute_config:
-  cloud: aws-public-us-west-2
   head_node:
     instance_type: m5.2xlarge
   worker_nodes:

--- a/templates/fintech_fraud_risk/job_config.yaml
+++ b/templates/fintech_fraud_risk/job_config.yaml
@@ -4,7 +4,6 @@ name: fintech-fraud-risk
 entrypoint: bash -c "python scripts/01_generate_data.py --scale medium && python scripts/02_train_model.py --scale medium && python scripts/03_run_scoring.py --scale medium"
 requirements: requirements.txt
 compute_config:
-  cloud: aws-public-us-west-2
   head_node:
     instance_type: m5.4xlarge
   worker_nodes:


### PR DESCRIPTION
Public templates must not hardcode an Anyscale-internal cloud — a user in another org has no `aws-public-us-west-2`. `creatives_diffusion_finetuning` and `fintech_fraud_risk` both did, in their job compute config. Remove the `cloud` field entirely so it resolves to the org's default.

## Testing
Config-only; the job compute config isn't exercised by `/test-template` (workspace path). Correctness by inspection.

https://claude.ai/code/session_01QmLc4yWtmC3PX2NwWzPbzD
