### PR TITLE
fix(parallel-experiments): fetch CIFAR-10 from S3 mirror, drop fake-d…

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -512,7 +512,9 @@
   test:
     tests_path: tests/parallel-experiments/
     command: bash tests.sh
-    timeout_in_sec: 900
+    # The notebook trains the real CIFAR-10 sweep (18 CPU trials); ~10 min
+    # typical, so 900s is too tight once pip install + autoscaling are counted.
+    timeout_in_sec: 1800
 
 # owner: @suman-debnath
 - name: vhol-ray-data

--- a/templates/parallel-experiments/cifar_utils.py
+++ b/templates/parallel-experiments/cifar_utils.py
@@ -11,20 +11,12 @@ import ray
 
 
 def load_data(data_dir="./data"):
-    # In CI, short-circuit to the fake-data smoke set (see `load_test_data`
-    # below). The real CIFAR-10 download from cs.toronto.edu is slow enough
-    # (~25 kB/s from the workspace network) to blow past the per-test timeout.
-    # We can't just check an env var here: this function runs inside Ray tune
-    # trials (i.e. on Ray workers) whose process env is not the driver's env,
-    # so a shell-exported `CIFAR_USE_FAKE=1` in tests.sh never reaches this
-    # code. Instead, tests.sh touches a marker file under ~/.parallel-
-    # experiments-use-fake-data — ~ (`/home/ray`) is EFS-shared across all
-    # nodes in an Anyscale workspace, so every Ray worker sees the same file.
-    if (
-        os.environ.get("CIFAR_USE_FAKE") == "1"
-        or os.path.exists(os.path.expanduser("~/.parallel-experiments-use-fake-data"))
-    ):
-        return load_test_data()
+    # The canonical cs.toronto.edu server throttles downloads to ~85 kB/s
+    # (~35 min for the 170MB tarball). Fetch the identical archive (same md5,
+    # verified by torchvision) from Ray's public example-data bucket instead.
+    torchvision.datasets.CIFAR10.url = (
+        "https://air-example-data.s3.us-west-2.amazonaws.com/cifar-10-python.tar.gz"
+    )
 
     transform = transforms.Compose([
         transforms.ToTensor(),

--- a/tests/parallel-experiments/tests.sh
+++ b/tests/parallel-experiments/tests.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 pip install "papermill==2.7.0" "torch==2.10.0" "torchvision==0.25.0" "s3fs==2024.12.0"
-# Route load_data() through the FakeData smoke helper in cifar_utils.py.
-# The real CIFAR-10 download from cs.toronto.edu is too slow from the workspace
-# network to fit inside timeout_in_sec (BUILD.yaml). Marker file is used
-# instead of an env var because load_data runs inside Ray tune trials on
-# worker processes that don't inherit the driver shell's env; ~ (`/home/ray`)
-# is EFS-shared across the workspace, so every Ray worker sees the marker.
-touch ~/.parallel-experiments-use-fake-data
-export CIFAR_USE_FAKE=1
 papermill README.ipynb output.ipynb -k python3 --log-output


### PR DESCRIPTION
…ata hack

The canonical cs.toronto.edu CIFAR-10 host throttles to ~66-85 kB/s (~40 min for the 170MB tarball), which blew the 900s probe budget: the tune trial runs on a worker node, and the fake-data marker file under ~ never reached workers under the published (probe) compute config, so trials fell through to the real download (template-probe build 124).

Point torchvision at Ray's public example-data S3 mirror instead -- verified byte-identical (md5 c58f30108f718f92721af3b95e74349a, the checksum torchvision enforces) and ~2.5s to download from us-west-2. With the download fast everywhere, the fake-data marker/env plumbing in tests.sh is unnecessary; the test now trains the real sweep, so bump timeout_in_sec to 1800 (sweep benches ~6-12 min wall on the 32-vCPU worker plus ~5 min of pip install + autoscaling overhead).