### PR TITLE
fix(langchain-agent-ray-serve): propagate mcp/langchain deps to worke…

### DIFF
--- a/tests/langchain-agent-ray-serve/tests.sh
+++ b/tests/langchain-agent-ray-serve/tests.sh
@@ -7,7 +7,17 @@ uv pip install -r python_depset.lock --system --no-deps --no-cache-dir --index-s
 # — LLM + weather MCP + LangGraph agent — then query the agent.
 trap 'serve shutdown -y >/dev/null 2>&1 || true' EXIT
 serve run --non-blocking --name llm --route-prefix /llm llm_deploy_qwen:app
-serve run --non-blocking --name weather --route-prefix /weather weather_mcp_ray:app
+# runtime_env pip: the `uv pip install --system` above reaches the head only
+# (it bypasses Anyscale's worker propagation), and under the published (probe)
+# compute config the head is non-schedulable — replicas land on workers that
+# lack the locked deps (ModuleNotFoundError: mcp.server.fastmcp). Point the
+# weather/agent apps' runtime_env at python_depset.lock so replicas install
+# the same pinned closure wherever they land (same pattern as #783). The llm
+# app needs nothing beyond the ray-llm image.
+LOCK_RUNTIME_ENV="{\"pip\": \"$(pwd)/python_depset.lock\"}"
+serve run --non-blocking --name weather --route-prefix /weather \
+  --runtime-env-json "$LOCK_RUNTIME_ENV" \
+  weather_mcp_ray:app
 
 # Wait for the Qwen LLM to load (GPU autoscale + vLLM); /v1/models 200 means query-ready.
 for _ in $(seq 1 150); do
@@ -18,7 +28,7 @@ curl -sf http://localhost:8000/llm/v1/models >/dev/null
 
 # Agent deploys last (startup connects to the MCP); point it at the local LLM+MCP via the env vars it already reads.
 serve run --non-blocking --name agent --route-prefix / \
-  --runtime-env-json '{"env_vars":{"OPENAI_COMPAT_BASE_URL":"http://localhost:8000/llm/","WEATHER_MCP_BASE_URL":"http://localhost:8000/weather/","OPENAI_API_KEY":"local","WEATHER_MCP_TOKEN":"local"}}' \
+  --runtime-env-json "{\"env_vars\":{\"OPENAI_COMPAT_BASE_URL\":\"http://localhost:8000/llm/\",\"WEATHER_MCP_BASE_URL\":\"http://localhost:8000/weather/\",\"OPENAI_API_KEY\":\"local\",\"WEATHER_MCP_TOKEN\":\"local\"},\"pip\":\"$(pwd)/python_depset.lock\"}" \
   ray_serve_agent_deployment:app
 
 # Agent ready when its FastAPI route is mounted (GET /chat -> 405 Method Not Allowed).


### PR DESCRIPTION
…r replicas

The tests install python_depset.lock via `uv pip install --system`, which reaches the head node only (bypasses Anyscale's worker propagation). Under the published (probe) compute config the head is non-schedulable, so the weather and agent replicas land on workers missing the deps: WeatherMCP dies with ModuleNotFoundError 'mcp.server.fastmcp' (template-probe 124 and staging probe repro).

Give just those two serve apps a runtime_env pip pinned to the lock's versions. The llm app needs nothing beyond the ray-llm image, and whole-lock propagation would touch the L4 node's vLLM env (what #906 had to unwind for fastapi).