### PR TITLE
fix(entity-recognition-with-llms): minimal deps + explicit worker delivery

### DIFF
--- a/templates/entity-recognition-with-llms/README.ipynb
+++ b/templates/entity-recognition-with-llms/README.ipynb
@@ -69,7 +69,7 @@
     "<img src=\"https://raw.githubusercontent.com/anyscale/foundational-ray-app/refs/heads/main/images/compute.png\" width=500>\n",
     "\n",
     "### Dependencies\n",
-    "Start by downloading the dependencies required for this tutorial. Notice in your [`containerfile`](https://raw.githubusercontent.com/anyscale/e2e-llm-workflows/refs/heads/main/containerfile) you have a base image [`anyscale/ray-llm:latest-py311-cu124`](https://hub.docker.com/layers/anyscale/ray-llm/latest-py311-cu124/images/sha256-5a1c55f7f416d2d2eb5f4cdd13afeda25d4f7383406cfee1f1f60da495d1b50f) followed by a list of pip packages. If you're not on [Anyscale](https://console.anyscale.com/), you can pull this Docker image yourself and install the dependencies.\n"
+    "Start by downloading the dependencies required for this tutorial. Notice in your `containerfile` you have a base image `anyscale/ray-llm:2.56.0-py312-cu130` followed by a list of pip packages. If you're not on [Anyscale](https://console.anyscale.com/), you can pull this Docker image yourself and install the dependencies.\n"
    ]
   },
   {
@@ -80,16 +80,7 @@
    "source": [
     "%%bash\n",
     "# Install dependencies\n",
-    "pip install -q \\\n",
-    "    \"pynvml==12.0.0\" \\\n",
-    "    \"hf_transfer==0.1.9\" \\\n",
-    "    \"tensorboard==2.19.0\" \\\n",
-    "    \"llamafactory@git+https://github.com/hiyouga/LlamaFactory.git\" \\\n",
-    "    \"transformers>=4.56.0,<5\" \\\n",
-    "    \"peft>=0.18\" \\\n",
-    "    \"trl>=0.18\" \\\n",
-    "    \"omegaconf\" \\\n",
-    "    \"torchdata\""
+    "pip install -q -r requirements.txt"
    ]
   },
   {
@@ -182,7 +173,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use [LLaMA-Factory](https://github.com/hiyouga/LlamaFactory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples).\n",
+    "Use [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples).\n",
     "\n",
     "**Note**: Ray also supports using other tools like [axolotl](https://axolotl-ai-cloud.github.io/axolotl/docs/ray-integration.html) or even [Ray Train + HF Accelerate + FSDP/DeepSpeed](https://docs.ray.io/en/latest/train/huggingface-accelerate.html) directly for complete control of your post-training workloads."
    ]

--- a/templates/entity-recognition-with-llms/README.md
+++ b/templates/entity-recognition-with-llms/README.md
@@ -48,23 +48,14 @@ This [Anyscale Workspace](https://docs.anyscale.com/platform/workspaces/) automa
 <img src="https://raw.githubusercontent.com/anyscale/foundational-ray-app/refs/heads/main/images/compute.png" width=500>
 
 ### Dependencies
-Start by downloading the dependencies required for this tutorial. Notice in your [`containerfile`](https://raw.githubusercontent.com/anyscale/e2e-llm-workflows/refs/heads/main/containerfile) you have a base image [`anyscale/ray-llm:latest-py311-cu124`](https://hub.docker.com/layers/anyscale/ray-llm/latest-py311-cu124/images/sha256-5a1c55f7f416d2d2eb5f4cdd13afeda25d4f7383406cfee1f1f60da495d1b50f) followed by a list of pip packages. If you're not on [Anyscale](https://console.anyscale.com/), you can pull this Docker image yourself and install the dependencies.
+Start by downloading the dependencies required for this tutorial. Notice in your `containerfile` you have a base image `anyscale/ray-llm:2.56.0-py312-cu130` followed by a list of pip packages. If you're not on [Anyscale](https://console.anyscale.com/), you can pull this Docker image yourself and install the dependencies.
 
 
 
 ```bash
 %%bash
 # Install dependencies
-pip install -q \
-    "pynvml==12.0.0" \
-    "hf_transfer==0.1.9" \
-    "tensorboard==2.19.0" \
-    "llamafactory@git+https://github.com/hiyouga/LlamaFactory.git" \
-    "transformers>=4.56.0,<5" \
-    "peft>=0.18" \
-    "trl>=0.18" \
-    "omegaconf" \
-    "torchdata"
+pip install -q -r requirements.txt
 ```
 
 ## Data ingestion
@@ -113,7 +104,7 @@ display(Code(filename="/mnt/cluster_storage/viggo/dataset_info.json", language="
 
 ## Fine-tuning
 
-Use [LLaMA-Factory](https://github.com/hiyouga/LlamaFactory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples).
+Use [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) to perform fine-tuning on a GPU worker via Ray. Find the parameters for the training workload, post-training method, dataset location, train/val details, etc. in the `lora_sft_ray.yaml` config file. See the recipes for even more post-training methods, like SFT, pretraining, PPO, DPO, KTO, etc. [on GitHub](https://github.com/hiyouga/LlamaFactory/tree/main/examples).
 
 **Note**: Ray also supports using other tools like [axolotl](https://axolotl-ai-cloud.github.io/axolotl/docs/ray-integration.html) or even [Ray Train + HF Accelerate + FSDP/DeepSpeed](https://docs.ray.io/en/latest/train/huggingface-accelerate.html) directly for complete control of your post-training workloads.
 

--- a/templates/entity-recognition-with-llms/containerfile
+++ b/templates/entity-recognition-with-llms/containerfile
@@ -1,17 +1,11 @@
 FROM anyscale/ray-llm:2.56.0-py312-cu130
 
+# LLaMA-Factory (git main) pulls peft/trl/datasets; keep transformers on the tested 4.x line.
 RUN python3 -m pip install --no-cache-dir \
-    "pynvml==12.0.0" \
-    "hf_transfer==0.1.9" \
-    "tensorboard==2.19.0" \
-    "llamafactory@git+https://github.com/hiyouga/LlamaFactory.git" \
+    "llamafactory@git+https://github.com/hiyouga/LLaMA-Factory.git" \
     "transformers>=4.56.0,<5" \
-    "peft>=0.18" \
-    "trl>=0.18" \
-    "omegaconf" \
-    "torchdata"
+    "pynvml==12.0.0" \
+    "tensorboard==2.19.0"
 
-# Fast upload/download
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
-# Bypass LLaMA-Factory strict version checks (trl, transformers bounds)
 ENV DISABLE_VERSION_CHECK=1

--- a/templates/entity-recognition-with-llms/requirements.txt
+++ b/templates/entity-recognition-with-llms/requirements.txt
@@ -1,0 +1,5 @@
+# LLaMA-Factory (git main) pulls peft/trl/datasets; keep transformers on the tested 4.x line.
+llamafactory @ git+https://github.com/hiyouga/LLaMA-Factory.git
+transformers>=4.56.0,<5
+pynvml==12.0.0
+tensorboard==2.19.0

--- a/templates/entity-recognition-with-llms/run_training.py
+++ b/templates/entity-recognition-with-llms/run_training.py
@@ -11,13 +11,29 @@ Usage:
 """
 
 import argparse
-import ray
-import subprocess
 import os
 import shutil
+import subprocess
+
+import ray
+
+_REQUIREMENTS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "requirements.txt")
 
 
-@ray.remote(num_gpus=1, num_cpus=4, accelerator_type="L4")
+def _pip_requirements() -> list:
+    with open(_REQUIREMENTS) as f:
+        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+
+@ray.remote(
+    num_gpus=1,
+    num_cpus=4,
+    accelerator_type="L4",
+    runtime_env={
+        "pip": _pip_requirements(),
+        "env_vars": {"HF_HUB_ENABLE_HF_TRANSFER": "1"},
+    },
+)
 def run_training(config_path: str) -> int:
     """Run LLaMA-Factory training on a GPU worker."""
     env = os.environ.copy()


### PR DESCRIPTION
## What

The template hand-listed `llamafactory` + `transformers/peft/trl/omegaconf/torchdata` in three places and relied on workspace auto-propagation to reach the GPU training worker.

## Fix

LLaMA-Factory **main** pulls peft/trl/datasets/torchdata itself, so:
- **requirements.txt** is just LLaMA-Factory (main — no *release* supports recent transformers; 0.9.5 caps at 5.6) + `transformers<5` held on the **validated 4.x line** + the two extras it doesn't pull (`pynvml`, `tensorboard`).
- **run_training.py** delivers that closure to the `@ray.remote` GPU task via `runtime_env` instead of head-side propagation.
- **containerfile** mirrors the minimal set; fixed the README's stale containerfile link + `py311-cu124` image reference.

## Notes

- git-main LLaMA-Factory can't be hash-locked (git dep), so this template is **system-deps** by nature — a BYOD image is the ideal future delivery.
- Kept `transformers<5` (the tested line) rather than chasing the base image's newer build — the exact image transformers version isn't reliably knowable from the repo (its base *depset lock* drifts from the deployed image), so no speculative upgrade.

https://claude.ai/code/session_01WQASugoLWZWj2Lp5AYRDka