### PR TITLE
docs(template skill): link the Ray docs example-publishing procedure

### DIFF
--- a/.claude/skills/template/workflows/create-template.md
+++ b/.claude/skills/template/workflows/create-template.md
@@ -65,3 +65,11 @@ Commit on a branch and open a PR against `main`. Run `/test-template`, get it gr
 ## 9. Publish + register via the product gallery
 
 Hand off to **`/register-template`** (the `console-template-plugin` in anyscale/product). For a **new** template it owns the whole publish: the `workspace-templates.yaml` gallery entry **and** the `tmpl-publish` run (dev → dev-console test → staging → prod), interleaved in that order — the dev-console test needs both the artifact and the gallery entry to exist. **Don't run `tmpl-publish` yourself** here, and do no other product-repo work.
+
+## 10. Optional — surface it as a Ray docs example
+
+Step 9 puts the template in the Anyscale console gallery. It does **not** put it on [docs.ray.io](https://docs.ray.io) — that's a separate registration in `ray-project/ray`. The Ray docs build fetches published template builds from `templates.ci.ray.io` and renders each one's `README.md` under `_collections/`, so a template must be published (step 9) before Ray can pull it. Three Ray-side edits: a `_TEMPLATE_COLLECTIONS` entry (`doc/source/template_collections.py`), a build pin (`doc/source/template_pins.json`), and an `examples.yml` entry for the owning library's gallery.
+
+Procedure: **[Publishing an example](https://docs.ray.io/en/master/ray-contribute/publishing-examples.html)** in the Ray contributor docs. (Linked on `/en/master/` because the page is newer than the current Ray release; it reaches `/en/latest/` with the next one.)
+
+Only do this for a template meant to be a Ray docs example — most templates are console-gallery only. If you're not sure, ask the Ray docs team.

--- a/.claude/skills/template/workflows/create-template.md
+++ b/.claude/skills/template/workflows/create-template.md
@@ -68,8 +68,8 @@ Hand off to **`/register-template`** (the `console-template-plugin` in anyscale/
 
 ## 10. Optional — surface it as a Ray docs example
 
+IMPORTANT ! Only do this for a template meant to be a Ray docs example — most templates are console-gallery only. If you're not sure, ASK the user to confirm they have the green light from Ray docs team.
+
 Step 9 puts the template in the Anyscale console gallery. It does **not** put it on [docs.ray.io](https://docs.ray.io) — that's a separate registration in `ray-project/ray`. The Ray docs build fetches published template builds from `templates.ci.ray.io` and renders each one's `README.md` under `_collections/`, so a template must be published (step 9) before Ray can pull it. Three Ray-side edits: a `_TEMPLATE_COLLECTIONS` entry (`doc/source/template_collections.py`), a build pin (`doc/source/template_pins.json`), and an `examples.yml` entry for the owning library's gallery.
 
 Procedure: **[Publishing an example](https://docs.ray.io/en/master/ray-contribute/publishing-examples.html)** in the Ray contributor docs. (Linked on `/en/master/` because the page is newer than the current Ray release; it reaches `/en/latest/` with the next one.)
-
-Only do this for a template meant to be a Ray docs example — most templates are console-gallery only. If you're not sure, ask the Ray docs team.


### PR DESCRIPTION
## Summary

The `/template` skill's `create-template` flow ends at step 9, product-gallery registration via `/register-template`. Nothing there indicates that surfacing a template as an example on [docs.ray.io](https://docs.ray.io) is a separate registration in `ray-project/ray`, so a contributor who wants both has no pointer to the second half.

This adds an optional step 10 linking the Ray-side procedure, which the Ray docs team published last week: **[Publishing an example](https://docs.ray.io/en/master/ray-contribute/publishing-examples.html)** ([ray-project/ray#64773](https://github.com/ray-project/ray/pull/64773)).

The step names the three Ray-side edits (`_TEMPLATE_COLLECTIONS` entry in `doc/source/template_collections.py`, a build pin in `doc/source/template_pins.json`, an `examples.yml` gallery entry) and the ordering constraint that puts it after step 9: the Ray docs build fetches *published* template builds from `templates.ci.ray.io`, so nothing can be pulled from an unpublished template. It's marked optional because most templates are console-gallery only.

## Notes for reviewers

- **This is an agent-rule change proposed from outside your team.** It edits `.claude/skills/template/`, so flagging it explicitly: push back on phrasing, placement, or whether this belongs in the create flow at all.
- The link uses `/en/master/` rather than the `/en/latest/` canonical form in `references/conventions.md`. The page is newer than the current Ray release, so `/en/latest/` 404s today. Happy to switch it to `/en/latest/` if you'd rather take the temporary 404 and have it self-heal at the next release.
- No behavior change: docs only. `pre-commit` passes on the changed file.

Tracked as DOC-1388 (this is one of three cross-surface links; the docs-team strategy docs and a Notion page are handled separately, so this PR does not close the ticket).
