### PR TITLE
chore(templates): move 18 GPU templates to their max CUDA image

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -147,7 +147,7 @@
   owner_team: ray-serve
   dir: templates/model-multiplexing
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-slim-py312-cu128
+    image_uri: anyscale/ray:2.56.0-slim-py312-cu129
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml
@@ -175,7 +175,7 @@
   owner_team: ray-serve
   dir: templates/serve-stable-diffusion-v2
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py312-cu128
+    image_uri: anyscale/ray:2.56.0-py312-cu129
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml
@@ -220,7 +220,7 @@
   owner_team: ray-train
   dir: templates/xgboost-training-and-serving
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-slim-py312-cu128
+    image_uri: anyscale/ray:2.56.0-slim-py312-cu129
   compute_config:
     AWS: configs/basic-single-node/aws.yaml
     GCP: configs/basic-single-node/gce.yaml
@@ -234,7 +234,7 @@
   owner_team: ray-train
   dir: templates/e2e-timeseries-forecasting
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-slim-py312-cu128
+    image_uri: anyscale/ray:2.56.0-slim-py312-cu129
   compute_config:
     AWS: configs/e2e-timeseries-forecasting/aws.yaml
     GCP: configs/e2e-timeseries-forecasting/gce.yaml
@@ -320,7 +320,7 @@
   owner_team: ray-train
   dir: templates/distributing-pytorch
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-slim-py312-cu128
+    image_uri: anyscale/ray:2.56.0-slim-py312-cu129
   compute_config:
     AWS: configs/distributing-pytorch/aws.yaml
     GCP: configs/distributing-pytorch/gce.yaml
@@ -334,7 +334,7 @@
   owner_team: ray-train
   dir: templates/pytorch-fsdp
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py312-cu128
+    image_uri: anyscale/ray:2.56.0-py312-cu129
   compute_config:
     AWS: configs/pytorch-fsdp/aws.yaml
     GCP: configs/pytorch-fsdp/gce.yaml
@@ -362,7 +362,7 @@
   owner_team: ray-train
   dir: templates/pytorch-profiling
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py312-cu128
+    image_uri: anyscale/ray:2.56.0-py312-cu129
   compute_config:
     AWS: configs/pytorch-profiling/aws.yaml
     GCP: configs/pytorch-profiling/gce.yaml
@@ -390,7 +390,7 @@
   owner_team: ray-data
   dir: templates/image-search-and-classification
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-slim-py312-cu128
+    image_uri: anyscale/ray:2.56.0-slim-py312-cu129
   compute_config:
     AWS: configs/image-search-and-classification/aws.yaml
     GCP: configs/image-search-and-classification/gce.yaml
@@ -452,7 +452,7 @@
   owner_team: ray-data
   dir: templates/text-embeddings
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py311-cu124
+    image_uri: anyscale/ray:2.56.0-py311-cu128
   compute_config:
     GCP: configs/text-embeddings/gce.yaml
     AWS: configs/text-embeddings/aws.yaml
@@ -538,7 +538,7 @@
   owner_team: ray-data
   dir: templates/ray-data-batch-image-classification
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py312-cu128
+    image_uri: anyscale/ray:2.56.0-py312-cu129
   compute_config:
     GCP: configs/basic-single-node/gce.yaml
     AWS: configs/basic-single-node/aws.yaml
@@ -552,7 +552,7 @@
   owner_team: general
   dir: templates/ray-summit-core-masterclass
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py312-cu128
+    image_uri: anyscale/ray:2.56.0-py312-cu129
   compute_config:
     AWS: configs/ray-summit-core-masterclass/aws.yaml
     GCP: configs/ray-summit-core-masterclass/gce.yaml
@@ -610,7 +610,7 @@
   owner_team: ray-train
   dir: templates/tensor_parallel_dtensor
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py312-cu128
+    image_uri: anyscale/ray:2.56.0-py312-cu129
   compute_config:
     AWS: configs/tensor_parallel_dtensor/aws.yaml
     GCP: configs/tensor_parallel_dtensor/gce.yaml
@@ -652,7 +652,7 @@
   owner_team: ray-serve
   dir: templates/asynchronous_inference
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-slim-py312-cu128
+    image_uri: anyscale/ray:2.56.0-slim-py312-cu129
   compute_config:
     AWS: configs/basic-single-node/aws.yaml
     GCP: configs/basic-single-node/gce.yaml
@@ -694,7 +694,7 @@
   owner_team: ray-train
   dir: templates/creatives_diffusion_finetuning
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py311-cu121
+    image_uri: anyscale/ray:2.56.0-py311-cu128
   compute_config:
     AWS: configs/creatives_diffusion_finetuning/aws.yaml
     GCP: configs/creatives_diffusion_finetuning/gce.yaml
@@ -708,7 +708,7 @@
   owner_team: ray-data
   dir: templates/biotech_boltz_screening
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py311-cu121
+    image_uri: anyscale/ray:2.56.0-py311-cu128
   compute_config:
     AWS: configs/biotech_boltz_screening/aws.yaml
     GCP: configs/biotech_boltz_screening/gce.yaml
@@ -722,7 +722,7 @@
   owner_team: ray-data
   dir: templates/biotech_protein_embeddings
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py311-cu121
+    image_uri: anyscale/ray:2.56.0-py311-cu128
   compute_config:
     AWS: configs/biotech_protein_embeddings/aws.yaml
     GCP: configs/biotech_protein_embeddings/gce.yaml
@@ -736,7 +736,7 @@
   owner_team: ray-data
   dir: templates/ecommerce_batch_embeddings
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py311-cu121
+    image_uri: anyscale/ray:2.56.0-py311-cu128
   compute_config:
     AWS: configs/ecommerce_batch_embeddings/aws.yaml
     GCP: configs/ecommerce_batch_embeddings/gce.yaml
@@ -750,7 +750,7 @@
   owner_team: ray-serve
   dir: templates/ecommerce_multi_model_serving
   cluster_env:
-    image_uri: anyscale/ray:2.56.0-py311-cu121
+    image_uri: anyscale/ray:2.56.0-py311-cu128
   compute_config:
     AWS: configs/ecommerce_multi_model_serving/aws.yaml
     GCP: configs/ecommerce_multi_model_serving/gce.yaml

--- a/dependencies/template.depsets.yaml
+++ b/dependencies/template.depsets.yaml
@@ -30,7 +30,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu128.freeze.txt templates/serve-stable-diffusion-v2/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu129.freeze.txt templates/serve-stable-diffusion-v2/python_depset.lock
 
   - name: langchain_agent_ray_serve_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -88,7 +88,7 @@ depsets:
     build_arg_sets:
       - ray2560_py311
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu121.freeze.txt templates/biotech_protein_embeddings/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu128.freeze.txt templates/biotech_protein_embeddings/python_depset.lock
 
   - name: ecommerce_batch_embeddings_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -103,7 +103,7 @@ depsets:
     build_arg_sets:
       - ray2560_py311
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu121.freeze.txt templates/ecommerce_batch_embeddings/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu128.freeze.txt templates/ecommerce_batch_embeddings/python_depset.lock
 
   - name: audio_dataset_curation_llm_judge_depset_${RAY_VERSION}_${PYTHON_VERSION}_${CUDA_VARIANT}
     operation: compile
@@ -178,7 +178,7 @@ depsets:
     build_arg_sets:
       - ray2560_py311
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu121.freeze.txt templates/creatives_diffusion_finetuning/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu128.freeze.txt templates/creatives_diffusion_finetuning/python_depset.lock
 
   - name: ecommerce_multi_model_serving_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -193,7 +193,7 @@ depsets:
     build_arg_sets:
       - ray2560_py311
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu121.freeze.txt templates/ecommerce_multi_model_serving/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu128.freeze.txt templates/ecommerce_multi_model_serving/python_depset.lock
 
   - name: biotech_boltz_screening_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -208,7 +208,7 @@ depsets:
     build_arg_sets:
       - ray2560_py311
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu121.freeze.txt templates/biotech_boltz_screening/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu128.freeze.txt templates/biotech_boltz_screening/python_depset.lock
 
   - name: finetune_stable_diffusion_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -268,7 +268,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu128.freeze.txt templates/distributing-pytorch/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu129.freeze.txt templates/distributing-pytorch/python_depset.lock
 
   - name: pytorch_fsdp_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -283,7 +283,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu128.freeze.txt templates/pytorch-fsdp/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu129.freeze.txt templates/pytorch-fsdp/python_depset.lock
 
   - name: pytorch_profiling_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -299,7 +299,7 @@ depsets:
       - ray2560_py312
 #
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu128.freeze.txt templates/pytorch-profiling/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu129.freeze.txt templates/pytorch-profiling/python_depset.lock
 
   - name: image_search_and_classification_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -314,7 +314,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu128.freeze.txt templates/image-search-and-classification/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu129.freeze.txt templates/image-search-and-classification/python_depset.lock
 
   - name: tensor_parallel_dtensor_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -322,14 +322,14 @@ depsets:
       - templates/tensor_parallel_dtensor/requirements.txt
     output: templates/tensor_parallel_dtensor/python_depset.lock
     append_flags:
-      - --index https://download.pytorch.org/whl/cu128
+      - --index https://download.pytorch.org/whl/cu129
       - --python-version=${PYTHON_VERSION}
       - --python-platform=linux
       - --unsafe-package ray
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu128.freeze.txt templates/tensor_parallel_dtensor/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu129.freeze.txt templates/tensor_parallel_dtensor/python_depset.lock
 
   - name: ray_data_batch_image_classification_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -344,7 +344,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu128.freeze.txt templates/ray-data-batch-image-classification/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu129.freeze.txt templates/ray-data-batch-image-classification/python_depset.lock
 
   - name: xgboost_training_and_serving_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -358,7 +358,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu128.freeze.txt templates/xgboost-training-and-serving/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu129.freeze.txt templates/xgboost-training-and-serving/python_depset.lock
 
   - name: ray_train_workloads_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -446,7 +446,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu128.freeze.txt templates/asynchronous_inference/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu129.freeze.txt templates/asynchronous_inference/python_depset.lock
 
   - name: mcp_ray_serve_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -490,7 +490,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu128.freeze.txt templates/ray-summit-core-masterclass/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py312-cu129.freeze.txt templates/ray-summit-core-masterclass/python_depset.lock
 
   - name: text_embeddings_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -505,7 +505,7 @@ depsets:
     build_arg_sets:
       - ray2560_py311
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu124.freeze.txt templates/text-embeddings/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-py311-cu128.freeze.txt templates/text-embeddings/python_depset.lock
 
   - name: e2e_timeseries_forecasting_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile
@@ -519,7 +519,7 @@ depsets:
     build_arg_sets:
       - ray2560_py312
     pre_hooks:
-      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu128.freeze.txt templates/e2e-timeseries-forecasting/python_depset.lock
+      - dependencies/scripts/seed-image-freeze.sh dependencies/images/ray-${RAY_VERSION}-slim-py312-cu129.freeze.txt templates/e2e-timeseries-forecasting/python_depset.lock
 
   - name: ecommerce_end_to_end_depset_${RAY_VERSION}_${PYTHON_VERSION}
     operation: compile

--- a/templates/ecommerce_batch_embeddings/requirements.txt
+++ b/templates/ecommerce_batch_embeddings/requirements.txt
@@ -3,7 +3,7 @@ sentence-transformers>=2.2
 transformers>=4.35
 torch>=2.0
 pillow>=10.0
-# Pin cross-node-pickled libs to the base image (anyscale/ray:2.56.0-py311-cu121)
+# Pin cross-node-pickled libs to the base image (anyscale/ray:2.56.0-py311-cu128)
 # versions. Ray Data pickles pyarrow/numpy objects between the head and worker
 # nodes; the head gets these from the python_depset.lock install while workers
 # run the base image, so upgrading them here causes "Incompatible checksums"

--- a/templates/tensor_parallel_dtensor/python_depset.lock
+++ b/templates/tensor_parallel_dtensor/python_depset.lock
@@ -1,5 +1,5 @@
 --index-url https://pypi.org/simple
---extra-index-url https://download.pytorch.org/whl/cu128
+--extra-index-url https://download.pytorch.org/whl/cu129
 
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
@@ -568,57 +568,57 @@ numpy==1.26.4 \
     #   pandas
     #   torchvision
     #   transformers
-nvidia-cublas-cu12==12.8.4.1 ; sys_platform == 'linux' \
-    --hash=sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af \
-    --hash=sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142 \
-    --hash=sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0
+nvidia-cublas-cu12==12.9.1.4 ; sys_platform == 'linux' \
+    --hash=sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf \
+    --hash=sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2 \
+    --hash=sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6
     # via
     #   nvidia-cudnn-cu12
     #   nvidia-cusolver-cu12
     #   torch
-nvidia-cuda-cupti-cu12==12.8.90 ; sys_platform == 'linux' \
-    --hash=sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed \
-    --hash=sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e \
-    --hash=sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182
+nvidia-cuda-cupti-cu12==12.9.79 ; sys_platform == 'linux' \
+    --hash=sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f \
+    --hash=sha256:1848a9380067560d5bee10ed240eecc22991713e672c0515f9c3d9396adf93c8 \
+    --hash=sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe
     # via torch
-nvidia-cuda-nvrtc-cu12==12.8.93 ; sys_platform == 'linux' \
-    --hash=sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909 \
-    --hash=sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994 \
-    --hash=sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8
+nvidia-cuda-nvrtc-cu12==12.9.86 ; sys_platform == 'linux' \
+    --hash=sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead \
+    --hash=sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4 \
+    --hash=sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349
     # via torch
-nvidia-cuda-runtime-cu12==12.8.90 ; sys_platform == 'linux' \
-    --hash=sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d \
-    --hash=sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90 \
-    --hash=sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8
+nvidia-cuda-runtime-cu12==12.9.79 ; sys_platform == 'linux' \
+    --hash=sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3 \
+    --hash=sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4 \
+    --hash=sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891
     # via torch
 nvidia-cudnn-cu12==9.10.2.21 ; sys_platform == 'linux' \
     --hash=sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8 \
     --hash=sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e \
     --hash=sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8
     # via torch
-nvidia-cufft-cu12==11.3.3.83 ; sys_platform == 'linux' \
-    --hash=sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74 \
-    --hash=sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7 \
-    --hash=sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a
+nvidia-cufft-cu12==11.4.1.4 ; sys_platform == 'linux' \
+    --hash=sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf \
+    --hash=sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80 \
+    --hash=sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28
     # via torch
-nvidia-cufile-cu12==1.13.1.3 ; sys_platform == 'linux' \
-    --hash=sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc \
-    --hash=sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a
+nvidia-cufile-cu12==1.14.1.1 ; sys_platform == 'linux' \
+    --hash=sha256:8dea77590761e02cb6dd955a57cb6414c58aa3cb1b7adbf9919869a11509cf65 \
+    --hash=sha256:9552e2231792e94b1ff17bc99e958cc0e6bbbaa4a9d91fa2dbeed97716628fe6
     # via torch
-nvidia-curand-cu12==10.3.9.90 ; sys_platform == 'linux' \
-    --hash=sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9 \
-    --hash=sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd \
-    --hash=sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec
+nvidia-curand-cu12==10.3.10.19 ; sys_platform == 'linux' \
+    --hash=sha256:49b274db4780d421bd2ccd362e1415c13887c53c214f0d4b761752b8f9f6aa1e \
+    --hash=sha256:de663377feb1697e1d30ed587b07d5721fdd6d2015c738d7528a6002a6134d37 \
+    --hash=sha256:e8129e6ac40dc123bd948e33d3e11b4aa617d87a583fa2f21b3210e90c743cde
     # via torch
-nvidia-cusolver-cu12==11.7.3.90 ; sys_platform == 'linux' \
-    --hash=sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450 \
-    --hash=sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34 \
-    --hash=sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0
+nvidia-cusolver-cu12==11.7.5.82 ; sys_platform == 'linux' \
+    --hash=sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88 \
+    --hash=sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2 \
+    --hash=sha256:77666337237716783c6269a658dea310195cddbd80a5b2919b1ba8735cec8efd
     # via torch
-nvidia-cusparse-cu12==12.5.8.93 ; sys_platform == 'linux' \
-    --hash=sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b \
-    --hash=sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd \
-    --hash=sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc
+nvidia-cusparse-cu12==12.5.10.65 ; sys_platform == 'linux' \
+    --hash=sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83 \
+    --hash=sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78 \
+    --hash=sha256:9e487468a22a1eaf1fbd1d2035936a905feb79c4ce5c2f67626764ee4f90227c
     # via
     #   nvidia-cusolver-cu12
     #   torch
@@ -631,10 +631,10 @@ nvidia-nccl-cu12==2.27.5 ; sys_platform == 'linux' \
     --hash=sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a \
     --hash=sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457
     # via torch
-nvidia-nvjitlink-cu12==12.8.93 ; sys_platform == 'linux' \
-    --hash=sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88 \
-    --hash=sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7 \
-    --hash=sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f
+nvidia-nvjitlink-cu12==12.9.86 ; sys_platform == 'linux' \
+    --hash=sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca \
+    --hash=sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db \
+    --hash=sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9
     # via
     #   nvidia-cufft-cu12
     #   nvidia-cusolver-cu12
@@ -644,10 +644,10 @@ nvidia-nvshmem-cu12==3.3.20 ; sys_platform == 'linux' \
     --hash=sha256:0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0 \
     --hash=sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5
     # via torch
-nvidia-nvtx-cu12==12.8.90 ; sys_platform == 'linux' \
-    --hash=sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f \
-    --hash=sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e \
-    --hash=sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615
+nvidia-nvtx-cu12==12.9.79 ; sys_platform == 'linux' \
+    --hash=sha256:1f504e573b3a955e55aae6c747e2ae561b63fdcafcd591e43d18dae9875504f8 \
+    --hash=sha256:d1f258e752294acdb4f61c3d31fee87bd0f60e459f1e2f624376369b524cd15d \
+    --hash=sha256:fec150986817f2b4e7eed72ed059f2dcb9ba3856b9a96134e448eac946a6952f
     # via torch
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
@@ -1201,46 +1201,32 @@ tokenizers==0.21.4 \
     --hash=sha256:f23186c40395fc390d27f519679a58023f368a0aad234af145e0f39ad1212732 \
     --hash=sha256:fa23f85fbc9a02ec5c6978da172cdcbac23498c3ca9f3645c5c68740ac007880
     # via transformers
-torch==2.9.1+cu128 \
-    --hash=sha256:0b80b7555dcd0a75b7b06016991f01281a0bb078cf28fa2d1dfb949fad2fbd07 \
-    --hash=sha256:0c784b600959ec70ee01cb23e8bc870a0e0475af30378ff5e39f4abed8b7c1cc \
-    --hash=sha256:1176f250311fa95cc3bca8077af323e0d73ea385ba266e096af82e7e2b91f256 \
-    --hash=sha256:2314521c74d76e513c53bb72c0ce3511ef0295ff657a432790df6c207e5d7962 \
-    --hash=sha256:24420e430e77136f7079354134b34e7ba9d87e539f5ac84c33b08e5c13412ebe \
-    --hash=sha256:2a1da940f0757621d098c9755f7504d791a72a40920ec85a4fd98b20253fca4e \
-    --hash=sha256:32c036296c557f19a1537ce981c40533650097114e1720a321a39a3b08d9df56 \
-    --hash=sha256:3a01f0b64c10a82d444d9fd06b3e8c567b1158b76b2764b8f51bfd8f535064b0 \
-    --hash=sha256:4454a4faca31af81566e3a4208f10f20b8a6d9cfe42791b0ca7ff134326468fc \
-    --hash=sha256:633005a3700e81b5be0df2a7d3c1d48aced23ed927653797a3bd2b144a3aeeb6 \
-    --hash=sha256:63381a109a569b280ed3319da89d3afe5cf9ab5c879936382a212affb5c90552 \
-    --hash=sha256:64399adaa8ea0896d02cf844cba3c5dd77e769520a1af73572599e0eaa2cf551 \
-    --hash=sha256:72f0f096475e8095a6bea3fba75bd3b46cf42c761b29588f7599314e67a32661 \
-    --hash=sha256:7788d3d03d939cf00f93ac0da5ab520846f66411e339cfbf519a806e8facf519 \
-    --hash=sha256:7bcd40cbffac475b478d6ce812f03da84e9a4894956efb89c3b7bcca5dbd4f91 \
-    --hash=sha256:7cb4018f4ce68b61fd3ef87dc1c4ca520731c7b5b200e360ad47b612d7844063 \
-    --hash=sha256:7d8769bdf3200ca16a92f14df404c3370171ac3732996528a8973d753eac562f \
-    --hash=sha256:ad9183864acdd99fc5143d7ca9d3d2e7ddfc9a9600ff43217825d4e5e9855ccc \
-    --hash=sha256:c8d670aa0be6fbecd2b0e7b7d514a104dbdefcc3786ca446cf0c3415043ea40a \
-    --hash=sha256:cf4ad82430824a80a9f398e29369524ed26c152cf00c2c12002e5400b35e260d \
-    --hash=sha256:e88c78e5b08ae9303aa15da43b68b44287ecbec16d898d9fad6998832fe626a5
+torch==2.9.1+cu129 \
+    --hash=sha256:0df90a06330f53bebb40b5740e5c24c0aad4e8b363d09b02379f1c12ab43564b \
+    --hash=sha256:4559e1254e2c8e1a337758626d1cf33ca5a5ded3509fa012070334bf886b686b \
+    --hash=sha256:5a2fd9c7b730ee44bfa0aa9731b025b4323ff512b84410a93ba88e8df5149c0b \
+    --hash=sha256:5a990644f98b4db59630a5b9cf41711294fe621131dbc41e1488f3a665c8b320 \
+    --hash=sha256:5adb25576c9cff0a25aab7e859f44121a5b150a6e319e027c27b55bf1ed57524 \
+    --hash=sha256:5b12ee638825907c9dc4a700d84de7c01dcd2c4b30ae96b2f591d0fb7795c273 \
+    --hash=sha256:794482180a4f2d92a960f470fcd47e066dbe2eeb27816880e618d3ce031805f7 \
+    --hash=sha256:9968834a95e4b09f702549285f6210eade0d268b3b7e52b35aff1c6529fb8022 \
+    --hash=sha256:a070a0c3d357b44a239810767f7509c3fce3146e051751410b50630b12486cc2 \
+    --hash=sha256:aa843d96289c3211a640d381aac50b1903b6a6f7367e7e04aacfb34732dced64 \
+    --hash=sha256:ab44cf28e6ca2df679f0845fb4b950c81834431218840ca01c0a1583892a0986 \
+    --hash=sha256:b8bf86419f37f226a925b4b55b0aa227d77ff685fec0a7703fa77533b19bdc4e \
+    --hash=sha256:c501c66fe5b0e2fc70f9d8a18e17a265f92ad1d1009dba03f5938d2f15a9066f \
+    --hash=sha256:cbe8955514ace826d3638a5d5dc1faa2f9dda1de4de74941d2e86b1a0859477c
     # via
     #   -r templates/tensor_parallel_dtensor/requirements.txt
     #   torchvision
-torchvision==0.24.1+cu128 \
-    --hash=sha256:1b44f67cbd8f36e2a58bfaa3176d35b37df55604adf5929e89006e531f849faa \
-    --hash=sha256:33ecea57afa1daeedfed443a8a0cb8e4b0b403fdf18c2a328ba6f9069d403384 \
-    --hash=sha256:3b72e32377e5e91398ddc4579c77784b269652a5795f4b20a5a1d4c80e9bd3dd \
-    --hash=sha256:45792b58c2a9761da4e1d9d12c4bf5140b6250ef9210f42f716f284cff5566ea \
-    --hash=sha256:5ae2dc0f582215b078d7fd52410fe51f79b801770c53e7cfb8ad04316283017d \
-    --hash=sha256:5f7c5e0fa08d2cbee93b6e04bbedd59b5e11462cff6cefd07949217265df2370 \
-    --hash=sha256:6d836745bd3130ef8f3569c9f0d9d70103b5e2e9fa058310bcac5f63bcf2d043 \
-    --hash=sha256:87f6e32d2d98d2779f9fa58aa93cf6af049e3f87681344a2088e2fc7d9dd3e00 \
-    --hash=sha256:b50d48f4074039e6067230f123f55404014b849d7c4fe1dac3a1924ea02bbd78 \
-    --hash=sha256:b5528b460d65c64e87301e942f6450d0ae958d919386e01fa682ba5eb77e5c9d \
-    --hash=sha256:c129e153561be8992c998f87d099ff74203ac19f8b2aadeb8edfbfd30036f81c \
-    --hash=sha256:c38b0ece839de439de81ed0e81e915c200975972c0b9419608fa9568aa74ecec \
-    --hash=sha256:ccdf1aff65d5bd1af99c5430508c4c234b81384d78681607ce20f2dcf5407c56 \
-    --hash=sha256:cf84eae1d2d12a7d261a7496eca00dd927b71792011b1e84d4162c950eb3201d
+torchvision==0.24.1+cu129 \
+    --hash=sha256:225a32af77b65062260473d0d0a1e14130a948d6cc564b260c810ea909912e88 \
+    --hash=sha256:3cfc217f344f356201f6c180899c5279504d27ed808ca969b994a45e177201cf \
+    --hash=sha256:58e651a84cb48d3d0abfc8e7e847f88142f789c3daa7f1f55a1eba2965dc2ea7 \
+    --hash=sha256:7e2e4f29d8e8b00f44917efd0710b85936fe5f2083a0e112e8e382d8c857b568 \
+    --hash=sha256:91da6852c710976b9cb7e016d893e9b8e7a2c81e4db59515f1b8946135571c42 \
+    --hash=sha256:a35e1fdad43f1037276874f1cce6c66c39172e175d0b7c0254994dd964f928d3 \
+    --hash=sha256:b91365669f0ca775e49f941fd542e89759e544bf5982b043b9e447f785179856
     # via -r templates/tensor_parallel_dtensor/requirements.txt
 tqdm==4.67.1 \
     --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \


### PR DESCRIPTION
18 GPU templates sat on an older CUDA tag than their Python version supports — 5 on cu121, 1 on cu124, 12 on cu128, against maxima of cu128 (py311) and cu129 (py312). Each template's `BUILD.yaml` image and its depset's seed-freeze path move together; the `lock-image` check keeps them in step.

## Why only one lock changes

The base images ship **no torch and no `nvidia-*`** — the CUDA tag selects the system toolkit, not Python packages. The freezes for `py312-cu128` and `py312-cu129` are identical apart from a header comment. So bumping the image alone changes nothing resolvable, and the locks stay put.

The PyTorch wheel index is a separate axis, and it moves for `tensor_parallel_dtensor` only. `download.pytorch.org/whl/cu128` publishes torch from **2.7.0** and `cu129` from **2.8.0**; the other twelve templates pin torch older than that, so pointing them at the new index makes uv fall back to PyPI and silently drop the CUDA-tagged wheel (`torch==2.7.0+cu128` → `torch==2.7.0`). Moving those requires bumping torch itself, which is a real behaviour change and deserves its own PR.

## Testing

`pre-commit` clean, including `lock-image` and the `BUILD.yaml` validator. `tensor_parallel_dtensor`'s lock is the only one that changed: torch and torchvision keep their versions and move `+cu128` → `+cu129`, with the nvidia runtime libs going 12.8.x → 12.9.x.

Templates still need a `/test-template` round — worth doing before the 2.56 republish, since this changes the image every one of them runs on.

## Follow-up

Twelve templates pin torch below their image's CUDA index. Worth deciding, separately, whether to bring them forward.