### PR TITLE
ci(hooks): require == pins, and refresh them on every Ray bump

### DIFF
--- a/.claude/skills/template/references/dependencies.md
+++ b/.claude/skills/template/references/dependencies.md
@@ -199,9 +199,36 @@ bundle instead of pinning the old image's freeze.
    workers/replicas keep running stale deps.
 4. Scan the lock diff for a framework package moving below its image version — the "Runtime skew" trap above.
 
+## How to pin
+
+**Every requirement is `==`, at the newest version that works on that template's image.**
+
+`>=` and bare names are not pins. They tell the resolver "anything newer is fine", so the lock
+silently re-resolves to whatever is current every time it is rebuilt — the template's behaviour
+changes with nobody editing it, and CI passes because it tests the drift. `<` is worse: an upper
+bound with no lower one freezes a template in the past. `text-embeddings` carried `torch<2.5`,
+`langchain==0.1.17` and `transformers==4.40.2` for a year that way.
+
+A loose spec needs a **trailing comment saying why** — `check-dep-delivery.py pin-style` fails
+without one. Real reasons: upstream publishes no tagged releases; a documented incompatibility;
+a range the template deliberately spans. "It worked when I wrote it" is not one.
+
+Two consequences worth spelling out:
+
+- **`==` alone doesn't mean current.** A pin set 18 months ago is exactly as stale as no pin, just
+  deterministically so. Freshness is re-checked on every Ray bump — see
+  `workflows/launch-ray-bump-wave.md`.
+- **For `torch`, "newest that works" is bounded by the image's CUDA index, not PyPI.**
+  `download.pytorch.org/whl/cu128` publishes torch from 2.7.0 and `cu129` from 2.8.0. Pin below the
+  floor and uv falls back to PyPI, the wheel loses its CUDA tag (`torch==2.7.0+cu128` becomes
+  `torch==2.7.0`), and the lock still compiles. Check the index before pinning torch.
+
+`dependencies/loose-pins-allowlist.txt` grandfathers what predates this rule. It is a backlog, not
+configuration — pin an entry properly and delete its line.
+
 ## Reviewing a template's dependency delivery
 
-Seven questions. Each has produced a real fleet-wide break, and the ones marked ✅ are now caught
+Eight questions. Each has produced a real fleet-wide break, and the ones marked ✅ are now caught
 automatically — the rest still need eyes.
 
 | # | Question | Failure it catches |
@@ -213,6 +240,7 @@ automatically — the rest still need eyes.
 | 5 | Do the shipped Job/Service configs source the lock, by absolute path? | the standalone path nobody tests |
 | 6 | Does `tests.sh` install or configure something the template doesn't? | CI green while every user following the README fails |
 | 7 | ✅ Does the depset's seed freeze match `BUILD.yaml`'s image? | lock describes an environment the template never runs in |
+| 8 | ✅ Is every requirement `==`, at a version that is still current? | the lock re-resolves on every rebuild, or freezes the template years behind |
 
 Dimension 6 is the highest-yield one to check by hand, because CI is what hides it. Read `tests.sh` and the
 README side by side and ask what the test does that a user wouldn't.
@@ -222,12 +250,16 @@ README side by side and ask what the test does that a user wouldn't.
 `scripts/hooks/check-dep-delivery.py`, via pre-commit (whole repo, ~0.2s). Run a single check by name:
 
 ```bash
-python3 scripts/hooks/check-dep-delivery.py             # all three
+python3 scripts/hooks/check-dep-delivery.py             # all four
 python3 scripts/hooks/check-dep-delivery.py tests-pip   # one
 ```
 
 `tests-pip` fails only for templates that ship a lock, since that is what makes the trap live; it lists the
 lock-less ones instead, and they join the gate as they gain locks.
+
+`pin-style` fails on any requirement that is neither `==` nor commented, except those grandfathered in
+`dependencies/loose-pins-allowlist.txt`. It prints how many remain and flags allowlist entries it no
+longer needs, so the backlog is a number that only goes down.
 
 ## Gotchas
 

--- a/.claude/skills/template/workflows/bump-ray-version.md
+++ b/.claude/skills/template/workflows/bump-ray-version.md
@@ -41,6 +41,27 @@ curl -sf "https://hub.docker.com/v2/repositories/anyscale/ray/tags/<tag>/" >/dev
 
 Then bump `BUILD.yaml` `ray_version` and grep/update any in-template version strings.
 
+### Refresh the pins
+
+The image just changed, so this is the moment to re-check what `requirements.txt` asks for. A pin
+set at some past bump is not evidence it is still right — it is only evidence nobody looked.
+
+For each requirement, move it to `==` at the **newest version that works on the new image**:
+
+- **`torch` / `torchvision` / `torchaudio`** — bounded by the image's CUDA wheel index, not PyPI.
+  `curl -sS https://download.pytorch.org/whl/<cu>/torch/ | grep -oE 'torch-[0-9.]+'` lists what is
+  actually published; `cu128` starts at 2.7.0 and `cu129` at 2.8.0. Pin below the floor and uv
+  falls back to PyPI, the wheel silently loses its CUDA tag, and the lock still compiles. Keep
+  torch and torchvision on their matching pair.
+- **Everything else** — `pip index versions <pkg>`, then pin `==` to the newest that resolves.
+- **Already `==` at the newest available** — leave it; that is the target state, not a no-op to fix.
+- **Can't be pinned** (upstream ships no tagged releases, a documented incompatibility) — leave it
+  loose *with a trailing comment saying why*, or `pin-style` fails.
+
+Drop any line you fix from `dependencies/loose-pins-allowlist.txt`. Don't bulk-bump a pin you have
+no way to test — if a package is central to what the template demonstrates and the jump is large,
+say so in the PR body and leave it, rather than shipping an untested upgrade.
+
 ### Recompile the dependency lock
 
 The image Ray version and the template's locked deps must agree. Which case applies is decided by whether `<name>` has an entry in `dependencies/template.depsets.yaml` (equivalently, ships `templates/<name>/python_depset.lock`):
@@ -48,7 +69,7 @@ The image Ray version and the template's locked deps must agree. Which case appl
 - **No lock** (base-image or BYOD templates — e.g. `parallel-experiments`, `groot-ray-serve`, `intro-ray-libraries`) — nothing to recompile; the image bump *is* the whole change. Go to step 2.
 - **Has a lock** — regenerate it against `<version>`, **incrementally**. This is a *per-template* PR, so touch only this template's slice of the config. **Step 1 is one-time per Ray version** — if a prior bump for `<version>` (an earlier template, or the version-prep PR) already added the `ray<NEW>` bundle, skip to step 2:
   1. Add a `ray<NEW>_py<PY>_cu<CU>` bundle to `build_arg_sets`, mirroring this template's existing `ray<OLD>_*` bundle (same Python/CUDA). **Add — do not replace** the old bundle; every other template still rides it.
-  2. Repoint **only this template's** entry: its `build_arg_sets` `ray<OLD>_* → ray<NEW>_*`. Its `seed-image-freeze.sh` pre_hook interpolates `${RAY_VERSION}`, so it follows automatically — but if the new image's py/CUDA differ, fix the literal parts of the freeze filename to match the image you set in step 1. **The freeze must name the image the template now runs on**; nothing checks the pairing.
+  2. Repoint **only this template's** entry: its `build_arg_sets` `ray<OLD>_* → ray<NEW>_*`. Its `seed-image-freeze.sh` pre_hook interpolates `${RAY_VERSION}`, so it follows automatically — but if the new image's py/CUDA differ, fix the literal parts of the freeze filename to match the image you set in step 1. **The freeze must name the image the template now runs on** — `check-dep-delivery.py lock-image` fails the commit if it doesn't.
   3. `./update_deps.sh --name <this-entry-name>` — regenerates this template's lock (runs natively on Linux or macOS; `../references/dependencies.md` "Running it"). Whole-repo batch upgrade: `upgrade-dependencies.md`.
   4. Commit together: the `BUILD.yaml` bump, this template's `python_depset.lock`, and the `template.depsets.yaml` edit.
 

--- a/.claude/skills/template/workflows/launch-ray-bump-wave.md
+++ b/.claude/skills/template/workflows/launch-ray-bump-wave.md
@@ -56,6 +56,11 @@ prompt is **not** in this repo — it lives on the Cursor automation dashboard, 
 source of truth; the payload is only `{template_name, ray_version}`. Each agent then runs
 `bump-ray-version.md` non-interactively.
 
+Each agent also re-pins that template's `requirements.txt` to the newest versions its new image
+supports (`bump-ray-version.md` → "Refresh the pins"). The wave is the only recurring moment the
+whole fleet's dependencies get looked at, so expect PRs to carry pin bumps alongside the image
+bump — review those as behaviour changes, not boilerplate.
+
 ## 4. Re-firing after a partial wave
 
 Safe. The delta recomputes from `BUILD.yaml`, so anything already landed at `<v>` is skipped and

--- a/dependencies/loose-pins-allowlist.txt
+++ b/dependencies/loose-pins-allowlist.txt
@@ -1,0 +1,152 @@
+# Requirements that are not `==` pinned, grandfathered in.
+#
+# This is a BACKLOG, not configuration. Every line is a template whose lock re-resolves
+# to whatever is newest when it is rebuilt, so the template's behaviour can change with
+# nobody editing it. Fix by pinning `==` at the newest version that works on that
+# template's image, then delete the line here -- the check reports entries it no longer
+# needs. If a loose spec is genuinely required, put a trailing comment on the
+# requirement saying why and drop the line here instead.
+#
+# Format: <template>/<package>
+
+
+# asynchronous_inference
+asynchronous_inference/celery                       # celery[redis]
+asynchronous_inference/pypdf2                       # PyPDF2>=3.0.0
+asynchronous_inference/requests                     # requests>=2.31.0
+
+# biotech_boltz_screening
+biotech_boltz_screening/biopython                   # biopython>=1.82
+biotech_boltz_screening/boltz                       # boltz>=0.3
+biotech_boltz_screening/pandas                      # pandas>=2.0
+biotech_boltz_screening/py3dmol                     # py3Dmol
+biotech_boltz_screening/ray                         # ray[data]>=2.9
+biotech_boltz_screening/rdkit                       # rdkit>=2023.9
+
+# biotech_protein_embeddings
+biotech_protein_embeddings/biopython                # biopython>=1.82
+biotech_protein_embeddings/pandas                   # pandas>=2.0
+biotech_protein_embeddings/ray                      # ray[data]>=2.9
+biotech_protein_embeddings/scikit-learn             # scikit-learn>=1.3
+biotech_protein_embeddings/transformers             # transformers>=4.35
+
+# creatives_diffusion_finetuning
+creatives_diffusion_finetuning/accelerate           # accelerate>=0.25
+creatives_diffusion_finetuning/diffusers            # diffusers>=0.25
+creatives_diffusion_finetuning/matplotlib           # matplotlib>=3.7
+creatives_diffusion_finetuning/peft                 # peft>=0.7
+creatives_diffusion_finetuning/pillow               # pillow>=10.0
+creatives_diffusion_finetuning/ray                  # ray[train,data]>=2.9
+creatives_diffusion_finetuning/transformers         # transformers>=4.35
+
+# deepspeed_finetune
+deepspeed_finetune/deepspeed                        # deepspeed
+
+# ecommerce_batch_embeddings
+ecommerce_batch_embeddings/faker                    # faker>=18.0
+ecommerce_batch_embeddings/pandas                   # pandas>=2.0
+ecommerce_batch_embeddings/pillow                   # pillow>=10.0
+ecommerce_batch_embeddings/ray                      # ray[data]>=2.9
+ecommerce_batch_embeddings/scikit-learn             # scikit-learn>=1.3
+ecommerce_batch_embeddings/sentence-transformers    # sentence-transformers>=2.2
+ecommerce_batch_embeddings/torch                    # torch>=2.0
+ecommerce_batch_embeddings/transformers             # transformers>=4.35
+
+# ecommerce_end_to_end
+ecommerce_end_to_end/hf_transfer                    # hf_transfer
+ecommerce_end_to_end/pillow                         # pillow
+ecommerce_end_to_end/sentence-transformers          # sentence-transformers
+
+# ecommerce_multi_model_serving
+ecommerce_multi_model_serving/faiss-cpu             # faiss-cpu>=1.7
+ecommerce_multi_model_serving/faker                 # faker>=18.0
+ecommerce_multi_model_serving/pandas                # pandas>=2.0
+ecommerce_multi_model_serving/pydantic              # pydantic>=2.0
+ecommerce_multi_model_serving/ray                   # ray[serve]>=2.9
+ecommerce_multi_model_serving/requests              # requests
+ecommerce_multi_model_serving/sentence-transformers # sentence-transformers>=2.2
+ecommerce_multi_model_serving/transformers          # transformers>=4.35
+
+# entity-recognition-with-llms
+entity-recognition-with-llms/llamafactory           # llamafactory @ git+https://github.com/hiyouga/LLaMA-Factory.git
+entity-recognition-with-llms/transformers           # transformers>=4.56.0,<5
+
+# fintech_fraud_risk
+fintech_fraud_risk/numpy                            # numpy>=1.24
+fintech_fraud_risk/pandas                           # pandas>=2.0
+fintech_fraud_risk/pyarrow                          # pyarrow>=14.0
+fintech_fraud_risk/ray                              # ray[data]>=2.9
+fintech_fraud_risk/scikit-learn                     # scikit-learn>=1.3
+fintech_fraud_risk/xgboost                          # xgboost>=2.0
+
+# fintech_quant
+fintech_quant/numpy                                 # numpy
+fintech_quant/pandas                                # pandas
+
+# pytorch-fsdp
+pytorch-fsdp/matplotlib                             # matplotlib
+
+# pytorch-profiling
+pytorch-profiling/matplotlib                        # matplotlib
+pytorch-profiling/torch_tb_profiler                 # torch_tb_profiler
+
+# ray-summit-core-masterclass
+ray-summit-core-masterclass/matplotlib              # matplotlib
+ray-summit-core-masterclass/pandas                  # pandas
+ray-summit-core-masterclass/requests                # requests
+ray-summit-core-masterclass/scikit-learn            # scikit-learn
+ray-summit-core-masterclass/tqdm                    # tqdm
+ray-summit-core-masterclass/xgboost                 # xgboost
+
+# ray-tune-train-integration
+ray-tune-train-integration/torch                    # torch>=2.5.0,<2.6.0
+ray-tune-train-integration/torchvision              # torchvision>=0.20.0,<0.21.0
+
+# ray-workshop-2026
+ray-workshop-2026/accelerate                        # accelerate>=1.5
+ray-workshop-2026/backoff                           # backoff>=2.2
+ray-workshop-2026/datasets                          # datasets>=2.0
+ray-workshop-2026/diffusers                         # diffusers>=0.32
+ray-workshop-2026/fastapi                           # fastapi>=0.100
+ray-workshop-2026/filelock                          # filelock>=3.0
+ray-workshop-2026/langdetect                        # langdetect>=1.0
+ray-workshop-2026/locust                            # locust>=2.0
+ray-workshop-2026/matplotlib                        # matplotlib>=3.7
+ray-workshop-2026/numpy                             # numpy>=1.24
+ray-workshop-2026/pandas                            # pandas>=2.0
+ray-workshop-2026/peft                              # peft>=0.5
+ray-workshop-2026/pillow                            # Pillow>=10.0
+ray-workshop-2026/psutil                            # psutil>=5.9
+ray-workshop-2026/pyarrow                           # pyarrow
+ray-workshop-2026/pydantic                          # pydantic>=2.0
+ray-workshop-2026/requests                          # requests>=2.31
+ray-workshop-2026/sentence-transformers             # sentence-transformers>=2.0
+ray-workshop-2026/starlette                         # starlette>=0.27
+ray-workshop-2026/torch                             # torch>=2.0
+ray-workshop-2026/torchvision                       # torchvision>=0.15
+ray-workshop-2026/tqdm                              # tqdm>=4.65
+ray-workshop-2026/transformers                      # transformers>=4.50
+
+# ray_train_workloads
+ray_train_workloads/gymnasium                       # gymnasium
+ray_train_workloads/pyarrow                         # pyarrow
+
+# stable-diffusion-pretraining
+stable-diffusion-pretraining/matplotlib             # matplotlib
+stable-diffusion-pretraining/pillow                 # Pillow
+stable-diffusion-pretraining/s3fs                   # s3fs
+stable-diffusion-pretraining/torch                  # torch>=2.5,<2.6
+stable-diffusion-pretraining/torchvision            # torchvision>=0.20,<0.21
+stable-diffusion-pretraining/typer                  # typer
+
+# storage-access-large-datasets
+storage-access-large-datasets/adlfs                 # adlfs
+storage-access-large-datasets/gcsfs                 # gcsfs
+
+# text-embeddings
+text-embeddings/torch                               # torch<2.5
+
+# xgboost-training-and-serving
+xgboost-training-and-serving/ipykernel              # ipykernel>=6.29.5
+xgboost-training-and-serving/ipywidgets             # ipywidgets>=8.1.6
+xgboost-training-and-serving/xgboost                # xgboost>=3.0.0

--- a/scripts/hooks/check-dep-delivery.py
+++ b/scripts/hooks/check-dep-delivery.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Static dependency-delivery checks (see .claude/skills/template/references/dependencies.md).
 
-Three failure modes that are invisible to `template-test` because CI happens to paper
+Four failure modes that are invisible to `template-test` because CI happens to paper
 over each one:
 
   lock-image  A lock seeded from image A while BUILD.yaml runs the template on image B.
@@ -12,8 +12,11 @@ over each one:
               runtime-env hook appends it, unpinned, to every actor's pip list; one
               unhashed entry trips pip's --require-hashes against a hashed lock and
               every runtime env for that template fails to build.
+  pin-style   A requirement that isn't `==`. The lock then re-resolves to whatever is
+              newest whenever it's regenerated, so a template's behaviour changes
+              without anyone editing it -- and CI passes, because it tests the drift.
 
-Usage: check-dep-delivery.py [lock-image|driver|tests-pip ...]   (default: all)
+Usage: check-dep-delivery.py [lock-image|driver|tests-pip|pin-style ...]   (default: all)
 """
 import re
 import sys
@@ -23,8 +26,12 @@ import yaml
 
 BUILD_YAML = Path("BUILD.yaml")
 DEPSETS = Path("dependencies/template.depsets.yaml")
+PIN_EXCEPTIONS = Path("dependencies/loose-pins-allowlist.txt")
 TESTS = Path("tests")
 LOCK = "python_depset.lock"
+
+# Leading package name of a requirement, before any extras, specifier or URL.
+REQ_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
 
 # `ray-2.56.0-py311-cu121.freeze.txt` -> `anyscale/ray:2.56.0-py311-cu121`
 FREEZE_RE = re.compile(r"^(ray(?:-llm)?)-(\d+\.\d+\.\d+.*)\.freeze\.txt$")
@@ -137,10 +144,74 @@ def check_tests_pip():
     return problems
 
 
+def requirement_lines(path: Path):
+    """[(lineno, package, spec, has_justification)] for real requirements only."""
+    for n, raw in enumerate(path.read_text().splitlines(), 1):
+        line, _, comment = raw.partition("#")
+        spec = line.strip()
+        if not spec or spec.startswith("-"):
+            continue
+        package = REQ_NAME_RE.match(spec)
+        yield n, (package.group(1).lower() if package else spec), spec, bool(comment.strip())
+
+
+def check_pin_style():
+    """Every requirement is `==`, or carries a trailing comment saying why it isn't.
+
+    The allowlist grandfathers what predates the rule so the check is green today; it is
+    a backlog, not a config, and every entry removed is a template that stopped drifting.
+    """
+    allowed = set()
+    if PIN_EXCEPTIONS.exists():
+        for line in PIN_EXCEPTIONS.read_text().splitlines():
+            entry = line.split("#")[0].strip()
+            if entry:
+                allowed.add(entry)
+
+    problems, grandfathered, stale = [], 0, []
+    roots = {name: root for name, root, _ in templates()}
+    for name, root in roots.items():
+        req = root / "requirements.txt"
+        if not req.exists():
+            continue
+        for n, package, spec, justified in requirement_lines(req):
+            if "==" in spec and "@" not in spec:
+                continue
+            if justified:
+                continue
+            if f"{name}/{package}" in allowed:
+                grandfathered += 1
+                continue
+            problems.append(
+                f"{name}: {req}:{n}\n      {spec}\n"
+                f"      Pin it with `==` at the newest version that works on this template's "
+                f"image, or add a trailing comment saying why it can't be."
+            )
+
+    for entry in sorted(allowed):
+        tmpl, _, package = entry.partition("/")
+        req = roots.get(tmpl, Path("/nonexistent")) / "requirements.txt"
+        if not req.exists() or not any(
+            p == package and not ("==" in s and "@" not in s) and not j
+            for _, p, s, j in requirement_lines(req)
+        ):
+            stale.append(entry)
+
+    if grandfathered:
+        print(f"note: {grandfathered} loose pin(s) still grandfathered in {PIN_EXCEPTIONS}. "
+              "Each one re-resolves to whatever is newest when its lock is rebuilt.")
+    if stale:
+        print(f"note: {len(stale)} allowlist entry/entries no longer needed — delete them:")
+        for entry in stale:
+            print(f"  - {entry}")
+    return problems
+
+
 CHECKS = {
     "lock-image": check_lock_image,
     "driver": check_driver,
     "tests-pip": check_tests_pip,
+    "pin-style": check_pin_style,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Across 40 templates, **30% of requirement lines are not `==`** — 49 inequalities and 27 bare package names. Those locks re-resolve to whatever is newest whenever they're rebuilt, so a template's behaviour changes with nobody editing it, and CI passes because it tests the drift.

`==` alone isn't enough either. `text-embeddings` has shipped `torch<2.5`, `langchain==0.1.17` and `transformers==4.40.2` since the commit that created the file (#739, June). A pin set once and never revisited is as stale as no pin, just deterministically so.

## What changed

**`pin-style`**, a fourth check in the existing pre-commit hook, fails any requirement that is neither `==` nor carries a trailing comment saying why it can't be. The 99 that predate the rule are grandfathered in `dependencies/loose-pins-allowlist.txt` — a backlog, not config. The check reports how many remain and names entries it no longer needs, so the number only goes down. Green today; stops new drift immediately.

**The Ray bump wave now re-pins.** `bump-ray-version.md` gains a "Refresh the pins" step between the image bump and the lock recompile — that's the one recurring moment the whole fleet's dependencies get looked at, and the image has just changed underneath them.

For `torch` the ceiling is the image's CUDA wheel index, not PyPI: `cu128` publishes from 2.7.0 and `cu129` from 2.8.0. Pin below the floor and uv falls back to PyPI, the wheel silently loses its CUDA tag (`torch==2.7.0+cu128` → `torch==2.7.0`), and the lock still compiles.

## Testing

`pre-commit` clean whole-repo. Verified `pin-style` exits 1 on a newly added loose pin, 0 once it carries a justifying comment, and 0 on the repo as-is. Also fixed a stale claim in `bump-ray-version.md` that nothing checks the lock/image pairing — `lock-image` has since #968.

## Caveat

This lands the rule and the backlog. Actually pinning those 99 is separate work needing a `/test-template` round per wave, since each is a potential behaviour change.