### PR TITLE
Bump skyrl to Ray 2.56

### DIFF
--- a/BUILD.yaml
+++ b/BUILD.yaml
@@ -421,8 +421,8 @@
   dir: templates/skyrl
   cluster_env:
     byod:
-      docker_image: novaskyai/skyrl-train-ray-2.51.1-slim-py312-cu128-megatron-2.10-te
-      ray_version: 2.51.1
+      docker_image: novaskyai/skyrl-train-ray-2.56.0-py3.12-cu12.8
+      ray_version: 2.56.0
   compute_config:
     GCP: configs/skyrl/gce.yaml
     AWS: configs/skyrl/aws.yaml

--- a/templates/skyrl/README.ipynb
+++ b/templates/skyrl/README.ipynb
@@ -35,7 +35,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Setup\nSkyRL uses the [uv + Ray integration](https://www.anyscale.com/blog/uv-ray-pain-free-python-dependencies-in-clusters) for dependency management, ensuring a consistent set of dependencies get shipped to all Ray workers. This template uses the `novaskyai/skyrl-train-ray-2.51.1-slim-py312-cu128-megatron-2.10-te` docker image to ensure all necessary system depedencies are installed. The exact Dockerfile can be found at [SkyRL/docker/Dockerfile](https://github.com/NovaSky-AI/SkyRL/blob/acbc21ccf4e14d48848ab2bb094d8e00d8886072/docker/Dockerfile.megatron).\n\nFirst, clone SkyRL:\n\n```bash\ngit clone https://github.com/NovaSky-AI/SkyRL.git\ncd SkyRL/\ngit checkout acbc21c\n```"
+   "source": "## Setup\nSkyRL uses the [uv + Ray integration](https://www.anyscale.com/blog/uv-ray-pain-free-python-dependencies-in-clusters) for dependency management, ensuring a consistent set of dependencies get shipped to all Ray workers. This template uses the `novaskyai/skyrl-train-ray-2.56.0-py3.12-cu12.8` docker image to ensure all necessary system depedencies are installed. The exact Dockerfile can be found at [SkyRL/docker/Dockerfile](https://github.com/NovaSky-AI/SkyRL/blob/abd553a125bb9284f1333ccba475f5fc3e512e18/docker/Dockerfile).\n\nFirst, clone SkyRL:\n\n```bash\ngit clone https://github.com/NovaSky-AI/SkyRL.git\ncd SkyRL/\ngit checkout abd553a1\n```"
   },
   {
    "cell_type": "markdown",

--- a/templates/skyrl/README.md
+++ b/templates/skyrl/README.md
@@ -21,14 +21,14 @@ git clone https://github.com/anyscale/templates && cd templates/templates/skyrl
 ```
 
 ## Setup
-SkyRL uses the [uv + Ray integration](https://www.anyscale.com/blog/uv-ray-pain-free-python-dependencies-in-clusters) for dependency management, ensuring a consistent set of dependencies get shipped to all Ray workers. This template uses the `novaskyai/skyrl-train-ray-2.51.1-slim-py312-cu128-megatron-2.10-te` docker image to ensure all necessary system depedencies are installed. The exact Dockerfile can be found at [SkyRL/docker/Dockerfile](https://github.com/NovaSky-AI/SkyRL/blob/acbc21ccf4e14d48848ab2bb094d8e00d8886072/docker/Dockerfile.megatron).
+SkyRL uses the [uv + Ray integration](https://www.anyscale.com/blog/uv-ray-pain-free-python-dependencies-in-clusters) for dependency management, ensuring a consistent set of dependencies get shipped to all Ray workers. This template uses the `novaskyai/skyrl-train-ray-2.56.0-py3.12-cu12.8` docker image to ensure all necessary system depedencies are installed. The exact Dockerfile can be found at [SkyRL/docker/Dockerfile](https://github.com/NovaSky-AI/SkyRL/blob/abd553a125bb9284f1333ccba475f5fc3e512e18/docker/Dockerfile).
 
 First, clone SkyRL:
 
 ```bash
 git clone https://github.com/NovaSky-AI/SkyRL.git
 cd SkyRL/
-git checkout acbc21c
+git checkout abd553a1
 ```
 
 ## GRPO for solving math problems (GSM8K)

--- a/tests/skyrl/tests.sh
+++ b/tests/skyrl/tests.sh
@@ -6,13 +6,14 @@ echo "=== SkyRL Template Test ==="
 # Mirror the template README: clone + pin to the commit the BYOD image is built for.
 git clone https://github.com/NovaSky-AI/SkyRL.git
 cd SkyRL/
-git checkout acbc21c
+git checkout abd553a1
 
 # CI-only patch: switch `uv run --isolated` to `--frozen` in run_gsm8k.sh.
-# SkyRL's top-level `requires-python = ">=3.11"` makes uv's universal resolver
-# consider Python 3.14 + arm64-macOS, where ray==2.51.1 has no wheels, so
-# `--isolated` fails resolution. `--frozen` uses the shipped uv.lock and skips
-# resolution — equivalent runtime for our (linux x86_64 / py3.12) CI box.
+# `--isolated` resolves from scratch, and SkyRL's top-level
+# `requires-python = ">=3.11"` sends uv's universal resolver at Pythons and
+# platforms the GPU stack ships no wheels for. `--frozen` uses the shipped
+# uv.lock: same runtime on our linux x86_64 / py3.12 box, and it is what holds
+# Ray at the version the BYOD image is built for.
 sed -i 's/uv run --isolated/uv run --frozen/g' examples/train/gsm8k/run_gsm8k.sh
 
 # run_gsm8k.sh reads DATA_DIR to build data.train_data/data.val_data, so the


### PR DESCRIPTION
## Summary

`skyrl` was the last maintained template still on Ray 2.51.1 — 55 of 56 have a green run on 2.56, this one's last pass was 80 days ago. The 2.56 fanout was right to skip it: it rides a third-party BYOD image, and NovaSky didn't publish a 2.56 build until 2026-07-08, six days after the fanout ran.

## Changes

- Image → `novaskyai/skyrl-train-ray-2.56.0-py3.12-cu12.8`. SkyRL's installation guide says *"We recommend upgrading to the new docker image `novaskyai/skyrl-train-ray-2.56.0-py3.12-cu12.8`"*, and its own CI for the gsm8k e2e test (`ci/anyscale_gpu_e2e_test.yaml`) uses it.
- Checkout repinned `acbc21c` → [`abd553a1`](https://github.com/NovaSky-AI/SkyRL/commit/abd553a125bb9284f1333ccba475f5fc3e512e18), upstream's *"[deps] bump ray to 2.56.0, add TE wheel to pyproject.toml"* commit. Its `uv.lock` pins `ray==2.56.0` and it's the first commit referencing the 2.56 images. Image and commit have to move together — the test runs `uv run --frozen`, so the runtime Ray comes from SkyRL's lock, not the image.
- **This drops megatron and Transformer Engine from the image.** Upstream reserves `-megatron` for its megatron examples (`docs/.../examples/megatron.mdx`); this template runs gsm8k GRPO on FSDP, and TE moved into `pyproject.toml` at the same commit. There is no `slim` or `-te` variant published at 2.56 — only `py3.12-cu12.8` and `-megatron`.
- Corrected the note above the `--frozen` patch. It blamed ray 2.51.1's missing py3.14/arm64-macOS wheels; 2.56.0 publishes those (`cp310`–`cp314`, macOS arm64 included), so the reason is now that `--isolated` forces a universal resolve the CI box doesn't need.

## Tests / validation

- Verified at `abd553a1`: `uv.lock` pins `ray==2.56.0`; `examples/train/gsm8k/{run_gsm8k.sh,gsm8k_dataset.py}` still exist at the same paths; `run_gsm8k.sh` still uses `uv run --isolated`, so the sed patch still applies; every flag `tests.sh` overrides is still present.
- **CI:** [build 648](https://buildkite.com/anyscale/template-test/builds/648) — passed first try, 17.4 min. Log confirms `HEAD is now at abd553a1`, `ray-version 2.56.0`, and four real GRPO training steps (`Step 1:`–`Step 4:`), not just a clean import.
