### PR TITLE
fix(configs): K8S required_resources.memory must be bytes, not "8Gi"

### DIFF
--- a/configs/basic-single-node/k8s.yaml
+++ b/configs/basic-single-node/k8s.yaml
@@ -1,12 +1,16 @@
+# memory is in bytes, not a "32Gi" quantity string: the published bundle is
+# parsed straight into the backend's PhysicalResources (`memory: int`), and
+# only the SDK path converts suffixes — a string passes local `compute-config
+# create -f` and 422s on launch. 8Gi = 8589934592, 32Gi = 34359738368.
 head_node:
   required_resources:
     CPU: 4
-    memory: 8Gi
+    memory: 8589934592
   resources:
     CPU: 0
 worker_nodes:
 - name: cpu_worker
   required_resources:
     CPU: 8
-    memory: 32Gi
+    memory: 34359738368
   max_nodes: 1

--- a/configs/getting-started/k8s.yaml
+++ b/configs/getting-started/k8s.yaml
@@ -1,12 +1,16 @@
+# memory is in bytes, not a "32Gi" quantity string: the published bundle is
+# parsed straight into the backend's PhysicalResources (`memory: int`), and
+# only the SDK path converts suffixes — a string passes local `compute-config
+# create -f` and 422s on launch. 8Gi = 8589934592, 32Gi = 34359738368.
 head_node:
   required_resources:
     CPU: 4
-    memory: 8Gi
+    memory: 8589934592
   resources:
     CPU: 0
 worker_nodes:
 - name: cpu_worker
   required_resources:
     CPU: 8
-    memory: 32Gi
+    memory: 34359738368
   max_nodes: 2

--- a/configs/pytorch-fsdp/k8s.yaml
+++ b/configs/pytorch-fsdp/k8s.yaml
@@ -1,14 +1,18 @@
+# memory is in bytes, not a "16Gi" quantity string: the published bundle is
+# parsed straight into the backend's PhysicalResources (`memory: int`), and
+# only the SDK path converts suffixes — a string passes local `compute-config
+# create -f` and 422s on launch. 8Gi = 8589934592, 16Gi = 17179869184.
 head_node:
   required_resources:
     CPU: 4
-    memory: 8Gi
+    memory: 8589934592
   resources:
     CPU: 0
 worker_nodes:
 - name: gpu_worker
   required_resources:
     CPU: 4
-    memory: 16Gi
+    memory: 17179869184
     GPU: 1
   required_labels:
     ray.io/accelerator-type: T4

--- a/scripts/hooks/validate-build-yaml.py
+++ b/scripts/hooks/validate-build-yaml.py
@@ -463,6 +463,22 @@ def check_k8s_configs_declarative(entries: list[Entry]) -> list[str]:
                     f"read by the launch-time GPU validation — use "
                     f"`required_labels: {{ray.io/accelerator-type: ...}}`"
                 )
+            # memory is bytes, never a Kubernetes quantity string. `rayapp
+            # build` copies required_resources verbatim into the published
+            # bundle, and the console clone path parses that bundle into the
+            # backend's PhysicalResources, whose `memory` is an int — "8Gi"
+            # there is a 422. Only the SDK (`compute-config create -f`)
+            # converts suffixes, so a string survives local testing and fails
+            # at launch; nothing else in the pipeline catches it.
+            mem = rr.get("memory")
+            if mem is not None and (isinstance(mem, bool) or not isinstance(mem, int)):
+                errors.append(
+                    f"{path}: {loc}.required_resources.memory must be an "
+                    f"integer number of bytes, not {mem!r} — the published "
+                    f"bundle goes to the backend unconverted "
+                    f"(8Gi = 8589934592, 16Gi = 17179869184, "
+                    f"32Gi = 34359738368)"
+                )
             # Mirror the backend's check_gpu_accelerator_consistency: GPU
             # count and accelerator-type label come together (TPU labels are
             # paired with TPU fields backend-side instead).


### PR DESCRIPTION
Stacked on #940 — targets `add-azure-declarative-compute-config` so the diff is just this fix.

## Problem

The three K8S configs specify memory as Kubernetes quantity strings (`8Gi`, `16Gi`, `32Gi`). That form is accepted by `anyscale compute-config create -f`, because the SDK converts suffixes to bytes before building the API request (`PhysicalResources.to_dict(for_api=True)` → `_parse_memory_string`). That's the path #940 was validated on, so it looked fine.

**The publish path never touches the SDK.** `rayapp build` copies `required_resources` verbatim into the bundle, and the console clone path (`workspaces_service._make_template_compute_config`) parses that bundle straight into the backend's `PhysicalResources`, whose `memory` is an `Optional[int]` of bytes with no quantity parsing.

Confirmed against the live Azure staging API by replaying the built bundle through the legacy create path:

```
422 Unprocessable Content from POST /cluster_computes/
  body.config.head_node_type.required_resources.memory: value is not a valid integer
  body.config.worker_node_types.0.required_resources.memory: value is not a valid integer
```

This is latent today only because the launch path force-selects AWS on Kubernetes clouds — it would surface the moment the `K8S` key is honored, i.e. exactly when #940 becomes useful.

## Fix

Integer bytes in all three configs (`8Gi` = 8589934592, `16Gi` = 17179869184, `32Gi` = 34359738368). Accepted by both paths — the SDK takes `Union[str, int]`.

Plus a validator rule, because nothing else in the pipeline catches this: the one path that converts suffixes is the path templates are tested on, so a string passes local testing and fails only at launch.

## Testing

- `pre-commit run --all-files` green; validator reports `OK: validated 56 BUILD.yaml entries`.
- The new rule fires on a reverted value: `configs/getting-started/k8s.yaml: worker_nodes[0].required_resources.memory must be an integer number of bytes, not '32Gi'`.
- All three bundles rebuilt; each carries integer memory.
- The rebuilt **pytorch-fsdp** bundle — GPU plus `required_labels` — now creates successfully through the legacy path on Azure staging (`cpt_6ji34wrn5c2iqf43v6h68rdvw2`), so the backend's `check_gpu_accelerator_consistency` passes too.
- End to end: a workspace launched on the byte-valued config on an AKS cloud (`compute_stack: K8S`, westus2) and `workspace-intro` ran its full notebook test there — 24 cells, exit 0.

One caveat on that last line: `rayapp test` can't yet drive this itself on Kubernetes clouds. It reports success while executing nothing (ray-project/rayci#496 fixes the detection), and two further k8s gaps — `run_command` starting in `$HOME` rather than the workspace working directory, and `bash -c` not sourcing the `~/.bashrc` where k8s workspaces declare PATH and `ANYSCALE_*` — had to be worked around by hand to get the run above. None of them are caused by these configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)