### PR TITLE
build(toolchain): bump anyscale CLI to 0.26.107 for k8s clouds

### DIFF
--- a/.claude/skills/template/references/run-tests-locally-with-rayapp.md
+++ b/.claude/skills/template/references/run-tests-locally-with-rayapp.md
@@ -21,7 +21,7 @@ curl -sL "https://github.com/ray-project/rayci/releases/download/${RAYAPP_VERSIO
 ```bash
 export ANYSCALE_HOST="https://console.anyscale-staging.com"  # always staging — local tests + fixes never run against prod
 export ANYSCALE_CLI_TOKEN="<staging token>"                  # from the staging console's API tokens
-pip install anyscale==0.26.87
+pip install anyscale==0.26.107  # keep in sync with the pyproject.toml pin
 ```
 
 **Always staging.** Local rayapp runs against **staging** (`https://console.anyscale-staging.com`) only — never prod, even if the CI run used prod. Use a staging `ANYSCALE_CLI_TOKEN` (ask the user if you don't have one). If staging itself fails — auth or the test — treat it as an **infra issue and ignore it**; don't chase the failure on prod. (Prod is read-only-exceptional — see `testing-template.md` Recovery.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ requires-python = "==3.12.*"
 dependencies = [
     "pre-commit==3.8.0",
     "nbconvert==7.17.1",
-    "anyscale==0.26.99",
+    # >= 0.26.107: earlier versions' `workspace_v2 run_command` only spoke
+    # legacy port-22 SSH, unreachable on Kubernetes clouds (AKS/EKS/GKE).
+    "anyscale==0.26.107",
     "pyyaml==6.0.3",
     "pydantic==2.13.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "anyscale"
-version = "0.26.99"
+version = "0.26.107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -103,9 +103,9 @@ dependencies = [
     { name = "websockets" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/31/83e2d06eea4f54dabb4adcd40f86b57cf02c25631b7e0b56e9703fa1ec71/anyscale-0.26.99.tar.gz", hash = "sha256:a66aae2926258ba0d833ef08cc2488438c02ee21a1d5d0acef78fb35fa637ddd", size = 1746852, upload-time = "2026-04-29T22:16:39.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/26/036b165b61938c47555a2ac1d94fbbdae1e03c7a4f2a1ab122e9dd285416/anyscale-0.26.107.tar.gz", hash = "sha256:12f9cba4199abbfefe2da32b3cfbce68b33762a513b74449bab22ba6e23e4ece", size = 1904394, upload-time = "2026-08-10T23:23:41.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/6e/91070b6c337ff930ae3020cebc498088a16fa7af7b7a79d35762e9066ae1/anyscale-0.26.99-py3-none-any.whl", hash = "sha256:4f98715d3f16b110bc04dfe0d5762c5ee49c032633fcf459be3da6f0d9ed980b", size = 3143068, upload-time = "2026-04-29T22:16:36.633Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8a/4bb68e987b24abc772e9707ca5fb54017d4b0fa4e4ba0061d579e4ea356a/anyscale-0.26.107-py3-none-any.whl", hash = "sha256:b6544af91f30091fd17a6fd317f29e0df62f243ceaed6b9e6d7e005283e8f978", size = 3442359, upload-time = "2026-08-10T23:23:39.744Z" },
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ ray-bump = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyscale", specifier = "==0.26.99" },
+    { name = "anyscale", specifier = "==0.26.107" },
     { name = "nbconvert", specifier = "==7.17.1" },
     { name = "pre-commit", specifier = "==3.8.0" },
     { name = "pydantic", specifier = "==2.13.3" },


### PR DESCRIPTION
## Why

Before **0.26.107**, `workspace_v2 run_command` was unconditionally legacy port-22 SSH:

```python
host_name, config_file = self.generate_ssh_config_file(id=workspace_model.id)
return subprocess.run(["ssh"] + ANYSCALE_WORKSPACES_SSH_OPTIONS
                      + ["-F", config_file, host_name, command], ...)
```

Port 22 is unreachable on Kubernetes clouds (AKS/EKS/GKE). 0.26.107 prefers the HTTPS/WebSocket tunnel (`wss://<host>/sshws`).

Observed on an Azure AKS workspace with the old pin — every `run_command` fails, the CLI exits 0 anyway, and the template's tests silently never run:

```
>>> anyscale workspace_v2 run_command --name <ws> unzip -o workspace-intro.zip
ssh: connect to host 20.3.70.145 port 22: Connection timed out
>>> anyscale workspace_v2 run_command --name <ws> timeout 900 bash -c 'bash tests.sh'
ssh: connect to host 20.3.70.145 port 22: Connection timed out
Test completed successfully          ← reported as a pass
```

With 0.26.107 the same command against the same workspace connects and runs. **VM clouds are unaffected** (legacy SSH works there), so nothing currently green goes red.

## What

- `pyproject.toml`: `anyscale==0.26.99` → `0.26.107`. `scripts/test-pipeline/render-template-pipeline.sh` reads the pin from here, so the Buildkite template-test pipeline picks it up.
- `uv.lock` regenerated with `uv lock`, per the pyproject header and because premerge runs `uv sync --frozen`.
- `.claude/skills/template/references/run-tests-locally-with-rayapp.md`: stale `0.26.87` → `0.26.107`. Not wired to anything, but it's what a contributor copy-pastes when running rayapp by hand.

## Testing

- `uv lock --check` clean — the lock matches pyproject, which is what `uv sync --frozen` enforces in premerge.
- Verified the pipeline still parses the pin past the added comment: `grep -oE 'anyscale==[0-9][0-9A-Za-z.+!-]*' pyproject.toml | head -1 | cut -d= -f3` → `0.26.107`.
- `pre-commit` green.

## Related

Necessary but not sufficient for testing templates on Kubernetes clouds — rayapp also assumes the VM layout (`run_command` starts in `$HOME` while `push` writes to the workspace working directory; `bash -c` doesn't source the `~/.bashrc` where k8s workspaces declare PATH and `ANYSCALE_*`). See ray-project/rayci#496, which fixes the related "failing command reports success" bug. The same bump for the publish pipeline's copy of this pin is anyscale/product#42483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)